### PR TITLE
Added static redirect for HTML-to-JSX page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/html-jsx.html  http://magic.reactjs.net/htmltojsx.htm


### PR DESCRIPTION
Relates to reactjs/react-magic/pull/145 and facebook/react/issues/11080.

Verified that Gatbsy redirects still work:
* /docs/index.html -> /docs/hello-world.html

Verified that this new static redirect works:
* https://deploy-preview-6--reactjs.netlify.com/html-jsx.html -> http://magic.reactjs.net/htmltojsx.htm