### PR TITLE
Fix - broken repo link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 1. Git
 1. Node: install version 8.4 or greater
 1. Yarn: `npm i -g yarn` to install it globally via NPM
-1. A clone of the [reactjs.org repo](https://github.com/facebook/reactjs.org) on your local machine
+1. A clone of the [reactjs.org repo](https://github.com/reactjs/reactjs.org) on your local machine
 1. A fork of the repo (for any contributions)
 
 ### Installation
@@ -47,7 +47,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 1. `git add -A && git commit -m "My message"` (replacing `My message` with a commit message, such as `Fixed header logo on Android`) to stage and commit your changes
 1. `git push my-fork-name the-name-of-my-branch`
-1. Go to the [reactjs.org repo](https://github.com/facebook/reactjs.org) and you should see recently pushed branches.
+1. Go to the [reactjs.org repo](https://github.com/reactjs/reactjs.org) and you should see recently pushed branches.
 1. Follow GitHub's instructions.
 1. If possible include screenshots of visual changes. A Netlify build will also be automatically created once you make your PR so other people can see your change.
 


### PR DESCRIPTION
The links to the repository on the README file were pointing to the wrong address.