### PR TITLE
fix #37 Replace babel-preset-es2015 reference and link with babel-preset-env

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -84,7 +84,7 @@ Both Yarn and npm download packages from the [npm registry](http://npmjs.com/).
 
 We recommend using React with [Babel](http://babeljs.io/) to let you use ES6 and JSX in your JavaScript code. ES6 is a set of modern JavaScript features that make development easier, and JSX is an extension to the JavaScript language that works nicely with React.
 
-The [Babel setup instructions](https://babeljs.io/docs/setup/) explain how to configure Babel in many different build environments. Make sure you install [`babel-preset-react`](http://babeljs.io/docs/plugins/preset-react/#basic-setup-with-the-cli-) and [`babel-preset-es2015`](http://babeljs.io/docs/plugins/preset-es2015/#basic-setup-with-the-cli-) and enable them in your [`.babelrc` configuration](http://babeljs.io/docs/usage/babelrc/), and you're good to go.
+The [Babel setup instructions](https://babeljs.io/docs/setup/) explain how to configure Babel in many different build environments. Make sure you install [`babel-preset-react`](http://babeljs.io/docs/plugins/preset-react/#basic-setup-with-the-cli-) and [`babel-preset-env`](http://babeljs.io/docs/plugins/preset-env/) and enable them in your [`.babelrc` configuration](http://babeljs.io/docs/usage/babelrc/), and you're good to go.
 
 ### Hello World with ES6 and JSX
 


### PR DESCRIPTION
Fixes #37 
(Preview should be visible at https://deploy-preview-38--reactjs.netlify.com/docs/installation.html#enabling-es6-and-jsx)