### PR TITLE
Update Yarn installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 1. Git
 1. Node: install version 8.4 or greater
-1. Yarn: `npm i -g yarn` to install it globally via NPM
+1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
 1. A clone of the [reactjs.org repo](https://github.com/reactjs/reactjs.org) on your local machine
 1. A fork of the repo (for any contributions)
 


### PR DESCRIPTION
Point to the official Yarn instructions rather than using npm (which is not recommended). 