### PR TITLE
Standardize license across source files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/CodeEditor/index.js
+++ b/src/components/CodeEditor/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/Container/index.js
+++ b/src/components/Container/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/src/components/ErrorDecoder/ErrorDecoder.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/ErrorDecoder/index.js
+++ b/src/components/ErrorDecoder/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/Flex/Flex.js
+++ b/src/components/Flex/Flex.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/Flex/index.js
+++ b/src/components/Flex/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutFooter/ExternalFooterLink.js
+++ b/src/components/LayoutFooter/ExternalFooterLink.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutFooter/FooterLink.js
+++ b/src/components/LayoutFooter/FooterLink.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutFooter/FooterNav.js
+++ b/src/components/LayoutFooter/FooterNav.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutFooter/index.js
+++ b/src/components/LayoutFooter/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutHeader/HeaderLink.js
+++ b/src/components/LayoutHeader/HeaderLink.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutHeader/SearchSvg.js
+++ b/src/components/LayoutHeader/SearchSvg.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/LayoutHeader/index.js
+++ b/src/components/LayoutHeader/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/MarkdownHeader/MarkdownHeader.js
+++ b/src/components/MarkdownHeader/MarkdownHeader.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/MarkdownHeader/index.js
+++ b/src/components/MarkdownHeader/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/MarkdownPage/index.js
+++ b/src/components/MarkdownPage/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/StickyResponsiveSidebar/index.js
+++ b/src/components/StickyResponsiveSidebar/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/components/TitleAndMetaTags/index.js
+++ b/src/components/TitleAndMetaTags/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/pages/acknowledgements.html.js
+++ b/src/pages/acknowledgements.html.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/pages/docs/error-decoder.html.js
+++ b/src/pages/docs/error-decoder.html.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/community.js
+++ b/src/templates/community.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/ButtonLink/ButtonLink.js
+++ b/src/templates/components/ButtonLink/ButtonLink.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/ButtonLink/index.js
+++ b/src/templates/components/ButtonLink/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/ChevronSvg/index.js
+++ b/src/templates/components/ChevronSvg/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/ExternalLinkSvg/index.js
+++ b/src/templates/components/ExternalLinkSvg/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/MetaTitle/index.js
+++ b/src/templates/components/MetaTitle/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/NavigationFooter/index.js
+++ b/src/templates/components/NavigationFooter/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/components/Sidebar/index.js
+++ b/src/templates/components/Sidebar/index.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/createLink.js
+++ b/src/utils/createLink.js
@@ -1,13 +1,11 @@
 /**
- * Copyright 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the CC-BY-4.0 license found
+ * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/findSectionForPath.js
+++ b/src/utils/findSectionForPath.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/isItemActive.js
+++ b/src/utils/isItemActive.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/mountCodeExample.js
+++ b/src/utils/mountCodeExample.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/sectionList.js
+++ b/src/utils/sectionList.js
@@ -1,13 +1,11 @@
 /**
- * Copyright 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the CC-BY-4.0 license found
+ * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 

--- a/src/utils/toCommaSeparatedList.js
+++ b/src/utils/toCommaSeparatedList.js
@@ -5,7 +5,7 @@
  * in the LICENSE file in the root directory of this source tree.
  *
  * @emails react-core
-*/
+ */
 
 'use strict';
 


### PR DESCRIPTION
Some of the source files were still mentioning the BSD license. I changed them to CC-BY-4.0 and also made the year consistent as 2013 (some files were 2015).