### PR TITLE
Fix redirect behavior for tutorial

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -3,7 +3,7 @@ id: tutorial
 title: "Tutorial: Intro To React"
 layout: tutorial
 sectionid: tutorial
-permalink: /tutorial/tutorial.html
+permalink: tutorial/tutorial.html
 redirect_from:
   - "docs/tutorial.html"
   - "docs/why-react.html"


### PR DESCRIPTION
Fixes #30. There should not be a trailing slash in front of the route.

https://deploy-preview-46--reactjs.netlify.com/docs/tutorial.html redirects fine, indicating that it works.

Tested on latest versions of Chrome, Firefox and Safari.