### PR TITLE
Add check for unique redirect URLs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,6 +28,9 @@ exports.modifyWebpackConfig = ({config, stage}) => {
 exports.createPages = async ({graphql, boundActionCreators}) => {
   const {createPage, createRedirect} = boundActionCreators;
 
+  // Used to detect and prevent duplicate redirects
+  const redirectToSlugMap = {};
+
   const blogTemplate = resolve('./src/templates/blog.js');
   const communityTemplate = resolve('./src/templates/community.js');
   const docsTemplate = resolve('./src/templates/docs.js');
@@ -114,13 +117,22 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
           redirect = [redirect];
         }
 
-        redirect.forEach(fromPath =>
+        redirect.forEach(fromPath => {
+          if (redirectToSlugMap[fromPath] != null) {
+            console.error(`Duplicate redirect detected from "${fromPath}" to:\n` +
+              `* ${redirectToSlugMap[fromPath]}\n` +
+              `* ${slug}\n`
+            );
+            process.exit(1);
+          }
+
+          redirectToSlugMap[fromPath] = slug;
           createRedirect({
             fromPath: `/${fromPath}`,
             redirectInBrowser: true,
             toPath: `/${slug}`,
-          }),
-        );
+          });
+        });
       }
     }
   });


### PR DESCRIPTION
Fixes #1.

It will be faster to do the checks within the redirect registration but I think doing the check in a separate function is cleaner. There aren't too many edges (currently less than 200) so I think performance is not an issue yet.

The build does not fail when errors are thrown because Gatsby catches them I think. I'm not sure how to get around this except using `process.exit()` instead of throwing an error. @bvaughn Any thoughts?

The errors are currently printed like this. Comments welcome!

```sh
⠁ The following paths are being redirected to different permalinks:
  - docs/animation-ja-JP.html → docs/create-fragment.html, docs/animation.html
  - docs/index.html → docs/accessibility.html, docs/hello-world.html
error Plugin default-site-plugin returned an error


  Error: Found the following redirect_froms to be duplicated:
    - docs/animation-ja-JP.html
    - docs/index.html
  
  - gatsby-node.js:95 Object.exports.createPages
    /Users/yangshun/Developer/reactjs.org/gatsby-node.js:95:11
  
  
  - next_tick.js:188 process._tickCallback
    internal/process/next_tick.js:188:7
 ```