### PR TITLE
Fixes #44 : Update CodeEditor to display the complete content

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -131,6 +131,9 @@ class CodeEditor extends Component {
                   '& pre.prism-code[contenteditable]': {
                     maxHeight: '280px !important',
                     outline: 0,
+                    overflow : 'auto',
+                    marginRight: '0 !important',
+                    marginBottom: '0 !important',
                   },
                 }}
                 className="gatsby-highlight">


### PR DESCRIPTION
The code at the bottom of the CodeEditor in the examples was hidden, due to overflow : 'hidden' to the parent element. Made changes to show complete code. Also, hid the scroll-bar for better UI.