### PR TITLE
Remove marginbottom, fix screen size of media queries for border-radius

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -105,7 +105,7 @@ class CodeEditor extends Component {
                 overflow: 'hidden',
                 borderRadius: '10px 0 0 10px',
 
-                [media.lessThan('small')]: {
+                [media.lessThan('medium')]: {
                   borderRadius: '10px 10px 0 0',
                 },
               }}>
@@ -127,6 +127,10 @@ class CodeEditor extends Component {
                   paddingLeft: '0 !important',
                   marginRight: '0 !important',
                   paddingRight: '0 !important',
+
+                  [media.lessThan('medium')]: {
+                    marginBottom: '0 !important',
+                  },
 
                   '& pre.prism-code[contenteditable]': {
                     maxHeight: '280px !important',
@@ -186,7 +190,7 @@ class CodeEditor extends Component {
                   border: `1px solid ${colors.divider}`,
                   borderRadius: '0 10px 10px 0',
 
-                  [media.lessThan('small')]: {
+                  [media.lessThan('medium')]: {
                     borderRadius: '0 0 10px 10px',
                   },
                 }}>


### PR DESCRIPTION
This PR fixes the issue here: https://github.com/reactjs/reactjs.org/issues/54

Now it looks like this:
![image](https://user-images.githubusercontent.com/13282699/31312565-a0aaabe4-ab94-11e7-89e2-0fbc71d77113.png)

* All the border-radius are fixed
* The redundant margin is removed
￼
