### PR TITLE
Update signature of requestAnimationFrame in documentation

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -27,6 +27,8 @@ React also depends on `requestAnimationFrame` (even in test environments). A sim
 
 ```js
 global.requestAnimationFrame = function(callback) {
-  setTimeout(callback, 0);
+  setTimeout(function() {
+    callback(Date.now());
+  }, 0);
 };
 ```


### PR DESCRIPTION
# Scope

- Included timestamp into callback for `requestAnimationFrame` to make the function be compatible with [origin implementation](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)
