### PR TITLE
Fix visible background over border radius in search dropdown

### DIFF
--- a/src/css/algolia.css
+++ b/src/css/algolia.css
@@ -263,7 +263,6 @@
 
 .algolia-autocomplete .ds-dropdown-menu [class^="ds-dataset-"] {
   position: relative;
-  background: #fff;
   border-radius: 4px;
   overflow: auto;
   padding: 0;
@@ -336,6 +335,7 @@
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion--wrapper {
+  background-color: #fff;
   width: 100%;
   float: left;
   padding: 8px 0 0 0;
@@ -431,7 +431,8 @@
 
 
 .algolia-autocomplete .algolia-docsearch-footer {
-  width: 110px;
+  background-color: #fff;
+  width: 100%;
   height: 30px;
   z-index: 2000;
   float: right;
@@ -446,8 +447,9 @@
   background-size: 100%;
   overflow: hidden;
   text-indent: -9000px;
-  width: 100%;
+  width: 110px;
   height: 100%;
   display: block;
-  margin-left: -5px;
+  margin-left: auto;
+  margin-right: 5px;
 }


### PR DESCRIPTION
Currently the algolia search results have a weird and subtle but eye-twitch-inducing artifact, where you can see the white background on the top round borders of the dropdown.

It looks like this:

![before](https://user-images.githubusercontent.com/2272928/31323311-af1d40a6-ac6b-11e7-9a3c-cf7d16af97e7.png)

This PR moves the background from the top container to each individual row that must be white in order to achieve the same effect.

It would look like this:

![after](https://user-images.githubusercontent.com/2272928/31323331-f65b8c8e-ac6b-11e7-9101-d2cda277f603.png)
