### PR TITLE
Create script for checks (prettier, lint, flow) in CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,15 @@
 {
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "plugins": [
     "prettier",
     "react"
   ],
   "parser": "babel-eslint",
+  "env": {
+    "node": true,
+    "browser": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -68,11 +68,12 @@
   },
   "scripts": {
     "build": "gatsby build",
-    "check-all": "yarn prettier && yarn lint && yarn flow",
+    "check-all": "yarn prettier -- --write && yarn lint && yarn flow",
+    "check-all:verbose": "yarn prettier -- --list-different && yarn lint && yarn flow",
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "eslint .",
     "netlify": "yarn install && yarn build",
-    "prettier": "prettier --config .prettierrc --write '{flow-typed,plugins,src}/**/*.js'",
+    "prettier": "prettier --config .prettierrc '{flow-typed,plugins,src}/**/*.js'",
     "reset": "rimraf ./.cache"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "build": "gatsby build",
     "check-all": "yarn prettier && yarn lint && yarn flow",
-    "check-all:verbose": "yarn prettier:diff && yarn lint && yarn flow",
+    "ci-check": "yarn prettier:diff && yarn lint && yarn flow",
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "eslint .",
     "netlify": "yarn install && yarn build",

--- a/package.json
+++ b/package.json
@@ -68,12 +68,13 @@
   },
   "scripts": {
     "build": "gatsby build",
-    "check-all": "yarn prettier -- --write && yarn lint && yarn flow",
-    "check-all:verbose": "yarn prettier -- --list-different && yarn lint && yarn flow",
+    "check-all": "yarn prettier && yarn lint && yarn flow",
+    "check-all:verbose": "yarn prettier:diff && yarn lint && yarn flow",
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "eslint .",
     "netlify": "yarn install && yarn build",
-    "prettier": "prettier --config .prettierrc '{flow-typed,plugins,src}/**/*.js'",
+    "prettier": "prettier --config .prettierrc --write '{flow-typed,plugins,src}/**/*.js'",
+    "prettier:diff": "prettier --config .prettierrc --list-different '{flow-typed,plugins,src}/**/*.js'",
     "reset": "rimraf ./.cache"
   },
   "devDependencies": {


### PR DESCRIPTION
This intends to fix #67.

- Added a `check-all:verbose` script, which is similar to `check-all`, however lists errors out on prettier if the files are different from the prettier formatting.
- Added a `prettier:diff` script, which checks for a difference between the prettified files, and source files.

Yay or nay?