### PR TITLE
fix links to pure component within docs

### DIFF
--- a/content/blog/2017-04-07-react-v15.5.0.md
+++ b/content/blog/2017-04-07-react-v15.5.0.md
@@ -113,8 +113,8 @@ We're discontinuing active maintenance of React Addons packages. In truth, most 
 - **react-addons-create-fragment** – React 16 will have first-class support for fragments, at which point this package won't be necessary. We recommend using arrays of keyed elements instead.
 - **react-addons-css-transition-group** - Use [react-transition-group/CSSTransitionGroup](https://github.com/reactjs/react-transition-group) instead. Version 1.1.1 provides a drop-in replacement.
 - **react-addons-linked-state-mixin** - Explicitly set the `value` and `onChange` handler instead.
-- **react-addons-pure-render-mixin** - Use [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
-- **react-addons-shallow-compare** - Use [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
+- **react-addons-pure-render-mixin** - Use [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
+- **react-addons-shallow-compare** - Use [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 - **react-addons-transition-group** - Use [react-transition-group/TransitionGroup](https://github.com/reactjs/react-transition-group) instead. Version 1.1.1 provides a drop-in replacement.
 - **react-addons-update** - Use [immutability-helper](https://github.com/kolodny/immutability-helper) instead, a drop-in replacement.
 - **react-linked-input** - Explicitly set the `value` and `onChange` handler instead.

--- a/content/docs/addons-pure-render-mixin.md
+++ b/content/docs/addons-pure-render-mixin.md
@@ -8,7 +8,7 @@ category: Add-Ons
 
 > Note:
 >
-> `PureRenderMixin` is a legacy add-on. Use [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
+> `PureRenderMixin` is a legacy add-on. Use [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 
 **Importing**
 

--- a/content/docs/addons-shallow-compare.md
+++ b/content/docs/addons-shallow-compare.md
@@ -8,7 +8,7 @@ category: Reference
 
 > Note:
 >
-> `shallowCompare` is a legacy add-on. Use [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
+> `shallowCompare` is a legacy add-on. Use [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 
 **Importing**
 
@@ -19,7 +19,7 @@ var shallowCompare = require('react-addons-shallow-compare'); // ES5 with npm
 
 ## Overview
 
-Before [`React.PureComponent`](/docs/react-api.html#react.purecomponent) was introduced, `shallowCompare` was commonly used to achieve the same functionality as [`PureRenderMixin`](pure-render-mixin.html) while using ES6 classes with React.
+Before [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) was introduced, `shallowCompare` was commonly used to achieve the same functionality as [`PureRenderMixin`](pure-render-mixin.html) while using ES6 classes with React.
 
 If your React component's render function is "pure" (in other words, it renders the same result given the same props and state), you can use this helper function for a performance boost in some cases.
 

--- a/content/docs/addons.md
+++ b/content/docs/addons.md
@@ -21,7 +21,7 @@ The add-ons below are in the development (unminified) version of React only:
 
 The add-ons below are considered legacy and their use is discouraged. They will keep working in observable future, but there is no further development.
 
-- [`PureRenderMixin`](pure-render-mixin.html). Use [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
+- [`PureRenderMixin`](pure-render-mixin.html). Use [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 - [`shallowCompare`](shallow-compare.html), a helper function that performs a shallow comparison for props and state in a component to decide if a component should update.
 - [`update`](update.html). Use [`kolodny/immutability-helper`](https://github.com/kolodny/immutability-helper) instead.
 - [`ReactDOMFactories`](dom-factories.html), pre-configured DOM factories to make React easier to use without JSX.

--- a/content/docs/reference-pure-render-mixin.md
+++ b/content/docs/reference-pure-render-mixin.md
@@ -8,7 +8,7 @@ permalink: docs/pure-render-mixin.html
 
 > Note
 
-> The `PureRenderMixin` mixin predates `React.PureComponent`. This reference doc is provided for legacy purposes, and you should consider using [`React.PureComponent`](/docs/react-api.html#react.purecomponent) instead.
+> The `PureRenderMixin` mixin predates `React.PureComponent`. This reference doc is provided for legacy purposes, and you should consider using [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) instead.
 
 If your React component's render function renders the same result given the same props and state, you can use this mixin for a performance boost in some cases.
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -204,7 +204,7 @@ Returning `false` does not prevent child components from re-rendering when *thei
 
 Currently, if `shouldComponentUpdate()` returns `false`, then [`componentWillUpdate()`](#componentwillupdate), [`render()`](#render), and [`componentDidUpdate()`](#componentdidupdate) will not be invoked. Note that in the future React may treat `shouldComponentUpdate()` as a hint rather than a strict directive, and returning `false` may still result in a re-rendering of the component.
 
-If you determine a specific component is slow after profiling, you may change it to inherit from [`React.PureComponent`](/docs/react-api.html#react.purecomponent) which implements `shouldComponentUpdate()` with a shallow prop and state comparison. If you are confident you want to write it by hand, you may compare `this.props` with `nextProps` and `this.state` with `nextState` and return `false` to tell React the update can be skipped.
+If you determine a specific component is slow after profiling, you may change it to inherit from [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) which implements `shouldComponentUpdate()` with a shallow prop and state comparison. If you are confident you want to write it by hand, you may compare `this.props` with `nextProps` and `this.state` with `nextState` and return `false` to tell React the update can be skipped.
 
 * * *
 


### PR DESCRIPTION
Moving [PR](https://github.com/facebook/react/pull/11127) from old repo new one. Updating links pointing to `React.purecomponent`.

Presently on the docs, all links to anchor of `React.purecomponent` are incorrect. Changing anchor links from `#react.purecomponent` to `#reactpurecomponent` as the link on the page(https://reactjs.org/docs/react-api.html#reactpurecomponent)