### PR TITLE
Update site's doc mockComponent()

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -112,6 +112,10 @@ mockComponent(
 
 Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.
 
+> Note:
+>
+> `mockComponent()` is a legacy method that is no longer needed. A similar method can be implemented directly.
+
 * * *
 
 ### `isElement()`

--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -114,7 +114,7 @@ Pass a mocked component module to this method to augment it with useful methods 
 
 > Note:
 >
-> `mockComponent()` is a legacy method that is no longer needed. A similar method can be implemented directly.
+> `mockComponent()` is a legacy method that is no longer needed. A similar pattern can be implemented directly.
 
 * * *
 

--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -114,7 +114,7 @@ Pass a mocked component module to this method to augment it with useful methods 
 
 > Note:
 >
-> `mockComponent()` is a legacy method that is no longer needed. A similar pattern can be implemented directly.
+> `mockComponent()` is a legacy API. We recommend using [shallow rendering](/docs/test-utils.html#shallow-rendering) or [jest.mock()](https://facebook.github.io/jest/docs/en/tutorial-react-native.html#mock-native-modules-using-jestmock) instead.
 
 * * *
 


### PR DESCRIPTION
Issue #84 Happy Thanksgiving! 🦃 

Not sure if I was supposed to include that it is preferred to use [shallow rendering](https://github.com/facebook/react/issues/2499#issuecomment-110800356) but I added that mockComponent() is now legacy, unnecessary, and a [similar pattern can be implemented directly](https://github.com/facebook/react/issues/11019#issue-261957590) if user wishes to do so.

Please review and let me know if I'm missing anything 💃

![image](https://user-images.githubusercontent.com/6846913/31362670-b4880528-ad27-11e7-9b45-0a7189266681.png)
