### PR TITLE
Fixes #113 Sidebar collapse and findSectionForPath

### DIFF
--- a/src/templates/components/Sidebar/Sidebar.js
+++ b/src/templates/components/Sidebar/Sidebar.js
@@ -57,7 +57,7 @@ class Sidebar extends Component {
         {sectionList.map((section, index) => (
           <SectionComponent
             createLink={createLink}
-            isActive={activeSection === section || sectionList.length === 1}
+            isActive={activeSection === section}
             key={index}
             location={location}
             onLinkClick={closeParentMenu}

--- a/src/utils/findSectionForPath.js
+++ b/src/utils/findSectionForPath.js
@@ -16,7 +16,7 @@ import slugify from './slugify';
  * This method specifically works with the nav_*.yml format.
  */
 const findSectionForPath = (pathname, sections) => {
-  let activeSection;
+  let activeSection = sections[0];
   const slugId = pathname.split('/').slice(-1)[0];
 
   sections.forEach(section => {


### PR DESCRIPTION
* `findSectionForPath` sends the first link as active page rather than `undefined`.
* Sidebar will collapse if clicked on nav title.  
* Fixes #113 