### PR TITLE
Improved the documentation for React.Children.only

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -176,7 +176,11 @@ Returns the total number of components in `children`, equal to the number of tim
 React.Children.only(children)
 ```
 
-Returns the only child in `children`. Throws otherwise.
+Verifies that `children` has only one child (a React element) and returns it. Otherwise this method throws.
+
+> Note:
+>
+>`React.Children.only()` does not accept the return value of [`React.Children.map()`](#reactchildrenmap) because it is an array rather than a React element.
 
 #### `React.Children.toArray`
 


### PR DESCRIPTION
Fixes #87

Changed the documentation for `React.Children.only()` to make its implementation simpler to understand. 

Since a lot of issues related with this method are connected to the fact that one cannot use a return value from `React.Children.map()`, added a note to explain why map does not return values that can be accessed used by `React.Children.only()`. This can easily be tested in a simple implementation by console logging the return value of map to `React.isValidElement()`, which is what the children.only method checks for itself. This will return false. The structure of the children should still be that of an object for the method to accept it and return it. 

I think this note is necessary but I am unsure on the grammatical structure to make it understandable. If you could please check and maybe suggest a way for it to make sense to future readers of the docs.