### PR TITLE
[Documentation] Re-add "Transferring with ... in JSX" to "JSX In-Depth / Spread Attributes"

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -232,20 +232,40 @@ In general, we don't recommend using this because it can be confused with the [E
 
 ### Spread Attributes
 
-If you already have `props` as an object, and you want to pass it in JSX, you can use `...` as a "spread" operator to pass the whole props object. These two components are equivalent:
+Spread attributes can be useful when you are building generic containers. However, they can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend that you use this syntax sparingly.
+
+An alternative to spreading all of your props is to specifically list out all the properties that you would like to consume, followed by `...other`.
 
 ```js{7}
-function App1() {
-  return <Greeting firstName="Ben" lastName="Hector" />;
-}
-
-function App2() {
-  const props = {firstName: 'Ben', lastName: 'Hector'};
-  return <Greeting {...props} />;
-}
+const { type, children, ...other } = props;
 ```
 
-Spread attributes can be useful when you are building generic containers. However, they can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend that you use this syntax sparingly.
+This ensures that you pass down all the props *except* the ones you're consuming yourself.
+
+```js{7}
+const handleClick = () => console.log("handleClick");
+
+const PrimaryButton = props => {
+  const { type, children, ...other } = props;
+  return (
+    <button type={type} {...other}>
+      {children}
+    </button>
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <PrimaryButton type="button" onClick={handleClick}>
+        Hello World!
+      </PrimaryButton>
+    </div>
+  );
+};
+```
+
+In the example above, the `...other` object contains `{ onClick: handleClick() }` but not the `type` or `children` props. This makes a component like the `PrimaryButton` more reusable and flexible because it can extract a set of unknown properties like `onClick` in the above example.
 
 ## Children in JSX
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -232,23 +232,36 @@ In general, we don't recommend using this because it can be confused with the [E
 
 ### Spread Attributes
 
+If you already have `props` as an object, and you want to pass it in JSX, you can use `...` as a "spread" operator to pass the whole props object. These two components are equivalent:
+
+```js{7}
+function App1() {
+  return <Greeting firstName="Ben" lastName="Hector" />;
+}
+
+function App2() {
+  const props = {firstName: 'Ben', lastName: 'Hector'};
+  return <Greeting {...props} />;
+}
+```
+
 Spread attributes can be useful when you are building generic containers. However, they can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend that you use this syntax sparingly.
 
 An alternative to spreading all of your props is to specifically list out all the properties that you would like to consume, followed by `...other`.
 
-```js{7}
-const { type, children, ...other } = props;
+```js
+const { children, ...other } = props;
 ```
 
 This ensures that you pass down all the props *except* the ones you're consuming yourself.
 
-```js{7}
+```js{6}
 const handleClick = () => console.log("handleClick");
 
 const PrimaryButton = props => {
-  const { type, children, ...other } = props;
+  const { children, ...other } = props;
   return (
-    <button type={type} {...other}>
+    <button {...other}>
       {children}
     </button>
   );
@@ -265,7 +278,7 @@ const App = () => {
 };
 ```
 
-In the example above, the `...other` object contains `{ onClick: handleClick() }` but not the `type` or `children` props. This makes a component like the `PrimaryButton` more reusable and flexible because it can extract a set of unknown properties like `onClick` in the above example.
+In the example above, the `...other` object contains `{ onClick: handleClick(), type: "button" }` but *not* the `children` prop. This makes a component like the `PrimaryButton` more reusable and flexible because it can extract a set of unknown properties like `onClick` in the above example.
 
 ## Children in JSX
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -245,8 +245,7 @@ function App2() {
 }
 ```
 
-You can also pick specific props that your component will consume while passing all other props using the spread operator. 
-This ensures that the component consumes the `kind` prop only, and passes down all other props via `...other`.
+You can also pick specific props that your component will consume while passing all other props using the spread operator.
 
 ```js{2}
 const Button = props => {
@@ -266,10 +265,10 @@ const App = () => {
 };
 ```
 
-In the example above, the `kind` prop is safely consumed and *is not* passed directly to the `<button>` element in the DOM.
+In the example above, the `kind` prop is safely consumed and *is not* passed on to the `<button>` element in the DOM.
 All other props are passed via the `...other` object making this component really flexible. You can see that it passes an `onClick` and `children` props.
 
-Spread attributes can be useful but not to pass invalid HTML attributes to the DOM. They can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend using this syntax sparingly.  
+Spread attributes can be useful but they also make it easy to pass unnecessary props to components that don't care about them or to pass invalid HTML attributes to the DOM. We recommend using this syntax sparingly.  
 
 ## Children in JSX
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -245,40 +245,31 @@ function App2() {
 }
 ```
 
-Spread attributes can be useful when you are building generic containers. However, they can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend that you use this syntax sparingly.
+You can also pick specific props that your component will consume while passing all other props using the spread operator. 
+This ensures that the component consumes the `kind` prop only, and passes down all other props via `...other`.
 
-An alternative to spreading all of your props is to specifically list out all the properties that you would like to consume, followed by `...other`.
-
-```js
-const { children, ...other } = props;
-```
-
-This ensures that you pass down all the props *except* the ones you're consuming yourself.
-
-```js{6}
-const handleClick = () => console.log("handleClick");
-
-const PrimaryButton = props => {
-  const { children, ...other } = props;
-  return (
-    <button {...other}>
-      {children}
-    </button>
-  );
+```js{2}
+const Button = props => {
+  const { kind, ...other } = props;
+  const className = kind === "primary" ? "PrimaryButton" : "SecondaryButton";
+  return <button className={className} {...other} />;
 };
 
 const App = () => {
   return (
     <div>
-      <PrimaryButton type="button" onClick={handleClick}>
+      <Button kind="primary" onClick={() => console.log("clicked!")}>
         Hello World!
-      </PrimaryButton>
+      </Button>
     </div>
   );
 };
 ```
 
-In the example above, the `...other` object contains `{ onClick: handleClick(), type: "button" }` but *not* the `children` prop. This makes a component like the `PrimaryButton` more reusable and flexible because it can extract a set of unknown properties like `onClick` in the above example.
+In the example above, the `kind` prop is safely consumed and *is not* passed directly to the `<button>` element in the DOM.
+All other props are passed via the `...other` object making this component really flexible. You can see that it passes an `onClick` and `children` props.
+
+Spread attributes can be useful but not to pass invalid HTML attributes to the DOM. They can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend using this syntax sparingly.  
 
 ## Children in JSX
 


### PR DESCRIPTION
resolves https://github.com/reactjs/reactjs.org/issues/109

Re-add [Transferring with `...` in JSX](https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/06-transferring-props.md#transferring-with--in-jsx) docs previously published with React v15-ish.

The overall content has been kept the same but I slightly changed the example to better reflect why using `...other` can be useful (I also wanted to avoid an example that uses a `<div>` as a checkbox).

In the example, I show a PrimaryButton component that can receive an unknown `onClick` prop function. Things like buttons handle a lot of different events -- instead of passing every possible synthetic event down as a prop, making use of `...other` helps to keep the code for `PrimaryButton` from getting bloated.

If it helps, I've also made the example live on code sandbox but didn't include it...I wasn't sure if it was totally needed, and since the docs surface codepen examples exclusively. I don't know if you all want to stay consistent with one example platform.

[![Edit React: Transferring with `...` in JSX](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/j2vzz8j0z5)