### PR TITLE
Fixing typo

### DIFF
--- a/content/blog/2017-09-26-react-v16.0.md
+++ b/content/blog/2017-09-26-react-v16.0.md
@@ -151,7 +151,7 @@ Refer to the previous announcement for [suggestions on how to migrate](/blog/201
 React 16 includes a number of small breaking changes. These only affect uncommon use cases and we don't expect them to break most apps.
 
 * React 15 had limited, undocumented support for error boundaries using `unstable_handleError`. This method has been renamed to `componentDidCatch`. You can use a codemod to [automatically migrate to the new API](https://github.com/reactjs/react-codemod#error-boundaries).
-* `ReactDOM.render` and `ReactDOM.unstable_renderIntoContainer` now return null if called from inside a lifecycle method. To work around this, you can use [portals](https://github.com/facebook/react/issues/10309#issuecomment-318433235) or [refs](https://github.com/facebook/react/issues/10309#issuecomment-318434635).
+* `ReactDOM.render` and `ReactDOM.unstable_renderSubtreeIntoContainer` now return null if called from inside a lifecycle method. To work around this, you can use [portals](https://github.com/facebook/react/issues/10309#issuecomment-318433235) or [refs](https://github.com/facebook/react/issues/10309#issuecomment-318434635).
 * `setState`:
   * Calling `setState` with null no longer triggers an update. This allows you to decide in an updater function if you want to re-render.
   * Calling `setState` directly in render always causes an update. This was not previously the case. Regardless, you should not be calling setState from render.


### PR DESCRIPTION
`unstable_renderIntoContainer` -> `unstable_renderSubtreeIntoContainer`