### PR TITLE
adds returning multiple elements example to jsx-in-depth guide

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -308,7 +308,19 @@ You can mix together different types of children, so you can use string literals
 </div>
 ```
 
-A React component can't return multiple React elements, but a single JSX expression can have multiple children, so if you want a component to render multiple things you can wrap it in a `div` like this.
+A React component can return multiple React elements:
+
+```js
+render() {
+  // No need to wrap list items in an extra element!
+  return [
+    // Don't forget the keys :)
+    <li key="A">First item</li>,
+    <li key="B">Second item</li>,
+    <li key="C">Third item</li>,
+  ];
+}
+```
 
 ### JavaScript Expressions as Children
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -308,7 +308,7 @@ You can mix together different types of children, so you can use string literals
 </div>
 ```
 
-A React component can return multiple React elements:
+A React component can return multiple elements:
 
 ```js
 render() {

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -308,7 +308,7 @@ You can mix together different types of children, so you can use string literals
 </div>
 ```
 
-A React component can return multiple elements:
+A React component can also return an array of elements:
 
 ```js
 render() {


### PR DESCRIPTION
replaces the section about having to wrap multiple elements in a `div` with the example from the [v16 blog](https://reactjs.org/blog/2017/09/26/react-v16.0.html)

![image](https://user-images.githubusercontent.com/20052710/31412547-18fa570a-addb-11e7-91b8-ce121dddbe41.png)
