### PR TITLE
Hyperlink DRY

### DIFF
--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -82,7 +82,7 @@ There are two types of "model" data in React: props and state. It's important to
 
 To make your UI interactive, you need to be able to trigger changes to your underlying data model. React makes this easy with **state**.
 
-To build your app correctly, you first need to think of the minimal set of mutable state that your app needs. The key here is DRY: *Don't Repeat Yourself*. Figure out the absolute minimal representation of the state your application needs and compute everything else you need on-demand. For example, if you're building a TODO list, just keep an array of the TODO items around; don't keep a separate state variable for the count. Instead, when you want to render the TODO count, simply take the length of the TODO items array.
+To build your app correctly, you first need to think of the minimal set of mutable state that your app needs. The key here is [DRY: *Don't Repeat Yourself*](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). Figure out the absolute minimal representation of the state your application needs and compute everything else you need on-demand. For example, if you're building a TODO list, just keep an array of the TODO items around; don't keep a separate state variable for the count. Instead, when you want to render the TODO count, simply take the length of the TODO items array.
 
 Think of all of the pieces of data in our example application. We have:
 


### PR DESCRIPTION
I saw that _Single responsibility principle_ from **SOLID** was hyperlinked, but _DRY_ was not. This _PR_ adds a hyperlink to _DRY_, to make things consistent throughout the documentation. 