### PR TITLE
Add left padding for lists in all viewport sizes

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -324,10 +324,7 @@ const sharedStyles = {
       marginTop: 20,
       fontSize: 16,
       color: colors.text,
-
-      [media.lessThan('small')]: {
-        paddingLeft: 20,
-      },
+      paddingLeft: 20,
 
       '& p, & p:first-of-type': {
         fontSize: 16,


### PR DESCRIPTION
It looks wrong on medium sizes, and looks like a negative indent on large sizes.

Before:
<img width="417" alt="captura de pantalla 2017-10-11 a la s 18 08 37" src="https://user-images.githubusercontent.com/3452011/31466994-45e588d2-aeaf-11e7-8214-201a5892c25e.png">

After:
<img width="405" alt="captura de pantalla 2017-10-11 a la s 18 09 43" src="https://user-images.githubusercontent.com/3452011/31467132-6f52493a-aeaf-11e7-9bd7-2c39a0c7bbb5.png">

