### PR TITLE
Made changes on prettier & prettier:diff scripts in 'package.json` for Windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "dev": "gatsby develop -H 0.0.0.0",
     "lint": "eslint .",
     "netlify": "yarn install && yarn build",
-    "prettier": "prettier --config .prettierrc --write '{flow-typed,plugins,src}/**/*.js'",
-    "prettier:diff": "prettier --config .prettierrc --list-different '{flow-typed,plugins,src}/**/*.js'",
+    "prettier": "prettier --config .prettierrc --write \"{flow-typed,plugins,src}/**/*.js\"",
+    "prettier:diff": "prettier --config .prettierrc --list-different \"{flow-typed,plugins,src}/**/*.js\"",
     "reset": "rimraf ./.cache"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, Brian (@bvaughn).

This is a change made to make `yarn check-all` work on Windows 10.
Here is the related issue in which this was discussed.
[https://github.com/reactjs/reactjs.org/issues/70#issuecomment-335050477](https://github.com/reactjs/reactjs.org/issues/70#issuecomment-335050477)

