### PR TITLE
Header focus style improvements

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -47,6 +47,12 @@ const Header = ({location}) => (
             marginRight: 10,
             height: '100%',
             alignItems: 'center',
+            color: colors.brand,
+
+            ':focus': {
+              outline: 0,
+              color: colors.white,
+            },
 
             [media.greaterThan('small')]: {
               width: 'calc(100% / 6)',
@@ -59,7 +65,7 @@ const Header = ({location}) => (
           <img src={logoSvg} alt="" height="20" />
           <span
             css={{
-              color: colors.brand,
+              color: 'inherit',
               marginLeft: 10,
               fontWeight: 700,
               fontSize: 20,
@@ -94,6 +100,7 @@ const Header = ({location}) => (
             WebkitOverflowScrolling: 'touch',
             height: '100%',
             width: '60%',
+
             [media.size('xsmall')]: {
               flexGrow: '1',
               width: 'auto',
@@ -170,6 +177,12 @@ const Header = ({location}) => (
               backgroundPositionY: 'center',
               backgroundPositionX: 'left',
 
+              ':focus': {
+                outline: 0,
+                backgroundColor: colors.lighter,
+                borderRadius: '0.25rem',
+              },
+
               [media.lessThan('large')]: {
                 fontSize: 16,
               },
@@ -207,10 +220,18 @@ const Header = ({location}) => (
           <a
             css={{
               padding: '5px 10px',
-              backgroundColor: colors.lighter,
-              borderRadius: 15,
               whiteSpace: 'nowrap',
               ...fonts.small,
+
+              ':hover': {
+                color: colors.brand,
+              },
+
+              ':focus': {
+                outline: 0,
+                backgroundColor: colors.lighter,
+                borderRadius: 15,
+              },
             }}
             href="https://github.com/facebook/react/releases"
             target="_blank"
@@ -223,8 +244,15 @@ const Header = ({location}) => (
               marginLeft: 10,
               whiteSpace: 'nowrap',
               ...fonts.small,
+
               ':hover': {
                 color: colors.brand,
+              },
+
+              ':focus': {
+                outline: 0,
+                backgroundColor: colors.lighter,
+                borderRadius: 15,
               },
             }}
             href="https://github.com/facebook/react/"

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -170,12 +170,12 @@ const Header = ({location}) => (
               fontWeight: 300,
               fontFamily: 'inherit',
               position: 'relative',
-              paddingLeft: '24px',
+              padding: '5px 5px 5px 29px',
               backgroundImage: 'url(/search.svg)',
               backgroundSize: '16px 16px',
               backgroundRepeat: 'no-repeat',
               backgroundPositionY: 'center',
-              backgroundPositionX: 'left',
+              backgroundPositionX: '5px',
 
               ':focus': {
                 outline: 0,
@@ -195,7 +195,7 @@ const Header = ({location}) => (
                 paddingLeft: '16px',
 
                 ':focus': {
-                  paddingLeft: '24px',
+                  paddingLeft: '29px',
                   width: '8rem',
                   outline: 'none',
                 },

--- a/src/components/LayoutHeader/HeaderLink.js
+++ b/src/components/LayoutHeader/HeaderLink.js
@@ -27,6 +27,12 @@ const style = {
   paddingRight: 15,
   fontWeight: 300,
 
+  ':focus': {
+    outline: 0,
+    backgroundColor: colors.lighter,
+    color: colors.white,
+  },
+
   [media.size('xsmall')]: {
     paddingLeft: 8,
     paddingRight: 8,
@@ -42,7 +48,7 @@ const style = {
     paddingRight: 20,
     fontSize: 18,
 
-    ':hover': {
+    ':hover:not(:focus)': {
       color: colors.brand,
     },
   },


### PR DESCRIPTION
Relates to issue #164

People don't like default browser focus outlines a lot of the time, because they're ugly. But some sort of focus style is important for accessibility. So this PR takes a stab at replacing the default header focus style with a custom one.

I think most links and buttons (in the body) are fine with default styles, but maybe we could improve the look and feel of the header?

### Before
![header-hover-focus-before](https://user-images.githubusercontent.com/29597/31637995-2a5d8864-b286-11e7-89c2-f190697bc01c.gif)

### After
![header-hover-focus-after](https://user-images.githubusercontent.com/29597/31637967-0e89bde2-b286-11e7-9725-1a817119d783.gif)

cc @joecritch, @damaera