### PR TITLE
Update constructor docs to include context

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -136,18 +136,18 @@ render() {
 ### `constructor()`
 
 ```javascript
-constructor(props, context)
+constructor(props)
 ```
 
-The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs. Optionally, if you need access to context in your component, call `super(props, context)`.
+The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs.
 
 The constructor is the right place to initialize state. If you don't initialize state and you don't bind methods, you don't need to implement a constructor for your React component.
 
 It's okay to initialize state based on props. This effectively "forks" the props and sets the state with the initial props. Here's an example of a valid `React.Component` subclass constructor:
 
 ```js
-constructor(props, context) {
-  super(props, context);
+constructor(props) {
+  super(props);
   this.state = {
     color: props.initialColor
   };
@@ -157,6 +157,15 @@ constructor(props, context) {
 Beware of this pattern, as state won't be up-to-date with any props update. Instead of syncing props to state, you often want to [lift the state up](/docs/lifting-state-up.html).
 
 If you "fork" props by using them for state, you might also want to implement [`componentWillReceiveProps(nextProps)`](#componentwillreceiveprops) to keep the state up-to-date with them. But lifting state up is often easier and less bug-prone.
+
+Some libraries, such as React Router, may depend on [context](/docs/context.html) being available. If you implement a constructor and need context, make sure to call `super(props, context)`.
+
+```js
+constructor(props, context) {
+  super(props, context);
+  // other component initialization logic
+}
+```
 
 * * *
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -158,14 +158,9 @@ Beware of this pattern, as state won't be up-to-date with any props update. Inst
 
 If you "fork" props by using them for state, you might also want to implement [`componentWillReceiveProps(nextProps)`](#componentwillreceiveprops) to keep the state up-to-date with them. But lifting state up is often easier and less bug-prone.
 
-Some libraries, such as React Router, may depend on [context](/docs/context.html) being available. If you implement a constructor and need context, make sure to call `super(props, context)`.
-
-```js
-constructor(props, context) {
-  super(props, context);
-  // other component initialization logic
-}
-```
+> Note
+>
+> Some libraries, such as React Router, may depend on [context](/docs/context.html) being available. If you implement a constructor and need context, make sure to call `super(props, context)` from the [constructor](/docs/context.html#referencing-context-in-lifecycle-methods).
 
 * * *
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -160,7 +160,7 @@ If you "fork" props by using them for state, you might also want to implement [`
 
 > Note
 >
-> Some libraries, such as React Router, may depend on [context](/docs/context.html) being available. If you implement a constructor and need context, make sure to call `super(props, context)` from the [constructor](/docs/context.html#referencing-context-in-lifecycle-methods).
+> Some libraries, such as React Router, might use [context](/docs/context.html) to facilitate communication between components. If you implement a [constructor](/docs/context.html#referencing-context-in-lifecycle-methods) and use one of these libraries, make sure to call `super(props, context)` from the constructor so that `context` is available on the component.
 
 * * *
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -136,18 +136,18 @@ render() {
 ### `constructor()`
 
 ```javascript
-constructor(props)
+constructor(props, context)
 ```
 
-The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs.
+The constructor for a React component is called before it is mounted. When implementing the constructor for a `React.Component` subclass, you should call `super(props)` before any other statement. Otherwise, `this.props` will be undefined in the constructor, which can lead to bugs. Optionally, if you need access to context in your component, call `super(props, context)`.
 
 The constructor is the right place to initialize state. If you don't initialize state and you don't bind methods, you don't need to implement a constructor for your React component.
 
 It's okay to initialize state based on props. This effectively "forks" the props and sets the state with the initial props. Here's an example of a valid `React.Component` subclass constructor:
 
 ```js
-constructor(props) {
-  super(props);
+constructor(props, context) {
+  super(props, context);
   this.state = {
     color: props.initialColor
   };
@@ -269,7 +269,7 @@ A class component becomes an error boundary if it defines this lifecycle method.
 For more details, see [*Error Handling in React 16*](/blog/2017/07/26/error-handling-in-react-16.html).
 
 > Note
-> 
+>
 > Error boundaries only catch errors in the components **below** them in the tree. An error boundary can’t catch an error within itself.
 
 * * *


### PR DESCRIPTION
The docs previously did not indicate that it was necessary to call `super(props, context)` if you are using context within components, which could [cause](https://github.com/facebook/react/issues/6598) [confusion](https://github.com/ReactTraining/react-router/issues/1059). Opening this PR to start discussion around a change to make this more obvious (I searched and could not find a previous issue)