### PR TITLE
Add etymological background to "props".

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -30,7 +30,7 @@ function Welcome(props) {
 }
 ```
 
-This function is a valid React component because it accepts a single "props" object argument with data and returns a React element. We call such components "functional" because they are literally JavaScript functions.
+This function is a valid React component because it accepts a single "props" (which stands for properties) object argument with data and returns a React element. We call such components "functional" because they are literally JavaScript functions.
 
 You can also use an [ES6 class](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes) to define a component:
 


### PR DESCRIPTION
I have heard/seen multiple people ask what "props" stands for, and this is the most logical place to explain it in the documentation.