### PR TITLE
Update Yarn version in how-to-contribute.md

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -95,7 +95,7 @@ In order to accept your pull request, we need you to submit a CLA. You only need
 
 ### Contribution Prerequisites
 
-* You have [Node](https://nodejs.org) installed at v6.0.0+ and [Yarn](https://yarnpkg.com/en/) at v1.0.0+.
+* You have [Node](https://nodejs.org) installed at v6.0.0+ and [Yarn](https://yarnpkg.com/en/) at v1.2.0+.
 * You have `gcc` installed or are comfortable installing a compiler if needed. Some of our dependencies may require a compilation step. On OS X, the Xcode Command Line Tools will cover this. On Ubuntu, `apt-get install build-essential` will install the required packages. Similar commands should work on other Linux distros. Windows will require some additional steps, see the [`node-gyp` installation instructions](https://github.com/nodejs/node-gyp#installation) for details.
 * You are familiar with Git.
 


### PR DESCRIPTION
Yarn version should ideally be 1.2.0+ due to workplace fixes/updates.