### PR TITLE
Fix the blog slug html creation that leads to improper redirect

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -189,7 +189,7 @@ exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
           const day = match[3];
           const filename = match[4];
 
-          slug = `/blog/${year}/${month}/${day}/${filename}.html`;
+          slug = `blog/${year}/${month}/${day}/${filename}.html`;
 
           const date = new Date(year, month - 1, day);
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -127,7 +127,7 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
           // A leading "/" is required for redirects to work,
           // But multiple leading "/" will break redirects.
           // For more context see github.com/reactjs/reactjs.org/pull/194
-          const toPath = slug.startsWith('/') ? slug : `/${slug}`
+          const toPath = slug.startsWith('/') ? slug : `/${slug}`;
 
           redirectToSlugMap[fromPath] = slug;
           createRedirect({

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -124,6 +124,9 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
             process.exit(1);
           }
 
+          // A leading "/" is required for redirects to work,
+          // But multiple leading "/" will break redirects.
+          // For more context see github.com/reactjs/reactjs.org/pull/194
           const toPath = slug.startsWith('/') ? slug : `/${slug}`
 
           redirectToSlugMap[fromPath] = slug;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -124,11 +124,13 @@ exports.createPages = async ({graphql, boundActionCreators}) => {
             process.exit(1);
           }
 
+          const toPath = slug.startsWith('/') ? slug : `/${slug}`
+
           redirectToSlugMap[fromPath] = slug;
           createRedirect({
             fromPath: `/${fromPath}`,
             redirectInBrowser: true,
-            toPath: `/${slug}`,
+            toPath,
           });
         });
       }
@@ -189,7 +191,7 @@ exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
           const day = match[3];
           const filename = match[4];
 
-          slug = `blog/${year}/${month}/${day}/${filename}.html`;
+          slug = `/blog/${year}/${month}/${day}/${filename}.html`;
 
           const date = new Date(year, month - 1, day);
 


### PR DESCRIPTION
@gaearon I've drill down to the question of why it's not redirecting to a proper redirect, especially on `blog`, which you highlighted in #192 . It appears that the creation of slug in `gatsby-node.js` in the root folder contains a forward slash, which I would say create a file with a forward slash in the beginning. Having the forward slash in the beginning seems to have cause a redirect to with `blog` as the domain.

Based on the issue before, having this url -> `<domain>/blog/2014/10/14/introducting-react-elements.html` will redirect to having `blog` as the domain. The fix will resolve it to redirect into `<domain>/blog/2014/10/14/introducing-react-elements.html`.