### PR TITLE
Fix style inconsistency

### DIFF
--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -367,7 +367,7 @@ class Timer extends React.Component {
   }
 
   tick() {
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       seconds: prevState.seconds + 1
     }));
   }
@@ -432,7 +432,7 @@ class TodoApp extends React.Component {
       text: this.state.text,
       id: Date.now()
     };
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       items: prevState.items.concat(newItem),
       text: ''
     }));


### PR DESCRIPTION
I discovered this inconsistency that caused the parentheses to appear/disappear when you toggle the "JSX" button. It also seems like we don't use parentheses for arrow functions with one argument, so this PR makes this behavior consistent.