### PR TITLE
Link for "the key attribute" corrected

### DIFF
--- a/content/docs/addons-animation.md
+++ b/content/docs/addons-animation.md
@@ -72,7 +72,7 @@ class TodoList extends React.Component {
 
 > Note:
 >
-> You must provide [the `key` attribute](/docs/multiple-components.html#dynamic-children) for all children of `ReactCSSTransitionGroup`, even when only rendering a single item. This is how React will determine which children have entered, left, or stayed.
+> You must provide [the `key` attribute](/docs/lists-and-keys.html#keys) for all children of `ReactCSSTransitionGroup`, even when only rendering a single item. This is how React will determine which children have entered, left, or stayed.
 
 In this component, when a new item is added to `ReactCSSTransitionGroup` it will get the `example-enter` CSS class and the `example-enter-active` CSS class added in the next tick. This is a convention based on the `transitionName` prop.
 


### PR DESCRIPTION
The link redirected to the incorrect page, changed to point to 'key attribute' page.