### PR TITLE
Make gatsby-source-react-error-codes plugin fail harder

### DIFF
--- a/plugins/gatsby-source-react-error-codes/gatsby-node.js
+++ b/plugins/gatsby-source-react-error-codes/gatsby-node.js
@@ -6,15 +6,23 @@ const errorCodesUrl =
 exports.sourceNodes = async ({boundActionCreators}) => {
   const {createNode} = boundActionCreators;
 
-  const jsonString = await request(errorCodesUrl);
+  try {
+    const jsonString = await request(errorCodesUrl);
 
-  createNode({
-    id: 'error-codes',
-    children: [],
-    parent: 'ERRORS',
-    internal: {
-      type: 'ErrorCodesJson',
-      contentDigest: jsonString,
-    },
-  });
+    createNode({
+      id: 'error-codes',
+      children: [],
+      parent: 'ERRORS',
+      internal: {
+        type: 'ErrorCodesJson',
+        contentDigest: jsonString,
+      },
+    });
+  } catch (error) {
+    console.error(
+      `The gatsby-source-react-error-codes plugin has failed:\n${error.message}`,
+    );
+
+    process.exit(1);
+  }
 };


### PR DESCRIPTION
Noticed that this plug-in failed quietly when running the website in airplane mode. Seems bad. So I made it actually stop the Gatsby dev process.