### PR TITLE
Explicitly note that ref callbacks are called before componentDidMount.

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -66,7 +66,7 @@ class CustomTextInput extends React.Component {
 }
 ```
 
-React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts.
+React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks will be called before `componentDidMount`.
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -66,7 +66,7 @@ class CustomTextInput extends React.Component {
 }
 ```
 
-React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks will be called before `componentDidMount`.
+React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks are invoked before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 


### PR DESCRIPTION
The question came up this morning on our team as to if `ref` callbacks are guaranteed to be called before `componentDidMount`. The current wording in the docs _implies_ that the answer is "yes;" however, we did find [an instance on Stack Overflow](https://stackoverflow.com/questions/44074747/componentdidmount-called-before-ref-callback) where somebody was claiming that their ref callback was called _after_ `componentDidMount`. That issue appears to possibly be related to using an instance-bound arrow function for `render`. The following comment is also linked from that thread: https://github.com/facebook/react/issues/6249#issuecomment-272026401

This PR simply makes the docs explicitly state that `ref` callbacks will be called _before_ `componentDidMount`.