### PR TITLE
Use `qs` to parse query params in ErrorDecoder

### DIFF
--- a/flow-typed/qs.js
+++ b/flow-typed/qs.js
@@ -1,0 +1,5 @@
+declare module 'qs' {
+  declare module.exports: {
+    parse: (str: string, opts: Object) => Object;
+  };
+}

--- a/flow-typed/qs.js
+++ b/flow-typed/qs.js
@@ -1,5 +1,5 @@
 declare module 'qs' {
   declare module.exports: {
-    parse: (str: string, opts: Object) => Object;
+    parse: (str: string, opts: Object) => Object,
   };
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "glamor": "^2.20.40",
     "hex2rgba": "^0.0.1",
     "prettier": "^1.7.4",
+    "qs": "^6.5.1",
     "remarkable": "^1.7.1",
     "request-promise": "^4.2.2",
     "rimraf": "^2.6.1",

--- a/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/src/components/ErrorDecoder/ErrorDecoder.js
@@ -41,7 +41,9 @@ function urlify(str: string): Node {
 
 // `?invariant=123&args[]=foo&args[]=bar`
 // or `// ?invariant=123&args[0]=foo&args[1]=bar`
-function parseQueryString(search: string): ?{code: string, args: Array<string>} {
+function parseQueryString(
+  search: string,
+): ?{|code: string, args: Array<string>|} {
   const qsResult = qs.parse(search, {ignoreQueryPrefix: true});
   if (!qsResult.invariant) {
     return null;
@@ -52,7 +54,7 @@ function parseQueryString(search: string): ?{code: string, args: Array<string>} 
   };
 }
 
-function ErrorResult(props: {code: ?string, msg: string}) {
+function ErrorResult(props: {|code: ?string, msg: string|}) {
   const code = props.code;
   const errorMsg = props.msg;
 

--- a/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/src/components/ErrorDecoder/ErrorDecoder.js
@@ -2,14 +2,17 @@
  * Copyright (c) 2013-present, Facebook, Inc.
  *
  * @emails react-core
+ * @flow
  */
 
 'use strict';
 
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
+import qs from 'qs';
 
-function replaceArgs(msg, argList) {
+import type {Node} from 'react';
+
+function replaceArgs(msg: string, argList: Array<string>): string {
   let argIdx = 0;
   return msg.replace(/%s/g, function() {
     const arg = argList[argIdx++];
@@ -17,48 +20,39 @@ function replaceArgs(msg, argList) {
   });
 }
 
-function urlify(str) {
+// When the message contains a URL (like https://fb.me/react-refs-must-have-owner),
+// make it a clickable link.
+function urlify(str: string): Node {
   const urlRegex = /(https:\/\/fb\.me\/[a-z\-]+)/g;
 
   const segments = str.split(urlRegex);
 
-  for (let i = 0; i < segments.length; i++) {
+  return segments.map((message, i) => {
     if (i % 2 === 1) {
-      segments[i] = (
-        <a key={i} target="_blank" rel="noopener" href={segments[i]}>
-          {segments[i]}
+      return (
+        <a key={i} target="_blank" rel="noopener" href={message}>
+          {message}
         </a>
       );
     }
-  }
-
-  return segments;
+    return message;
+  });
 }
 
-// ?invariant=123&args[]=foo&args[]=bar
-function parseQueryString(location) {
-  const rawQueryString = location.search.substring(1);
-  if (!rawQueryString) {
+// `?invariant=123&args[]=foo&args[]=bar`
+// or `// ?invariant=123&args[0]=foo&args[1]=bar`
+function parseQueryString(search: string): ?{code: string, args: Array<string>} {
+  const qsResult = qs.parse(search, {ignoreQueryPrefix: true});
+  if (!qsResult.invariant) {
     return null;
   }
-
-  let code = '';
-  let args = [];
-
-  const queries = rawQueryString.split('&');
-  for (let i = 0; i < queries.length; i++) {
-    const query = decodeURIComponent(queries[i]);
-    if (query.indexOf('invariant=') === 0) {
-      code = query.slice(10);
-    } else if (query.indexOf('args[]=') === 0) {
-      args.push(query.slice(7));
-    }
-  }
-
-  return [code, args];
+  return {
+    code: qsResult.invariant,
+    args: qsResult.args || [],
+  };
 }
 
-function ErrorResult(props) {
+function ErrorResult(props: {code: ?string, msg: string}) {
   const code = props.code;
   const errorMsg = props.msg;
 
@@ -79,39 +73,21 @@ function ErrorResult(props) {
   );
 }
 
-class ErrorDecoder extends Component {
-  constructor(...args) {
-    super(...args);
+function ErrorDecoder(props: {|
+  errorCodesString: string,
+  location: {search: string},
+|}) {
+  let code = null;
+  let msg = '';
 
-    this.state = {
-      code: null,
-      errorMsg: '',
-    };
+  const errorCodes = JSON.parse(props.errorCodesString);
+  const parseResult = parseQueryString(props.location.search);
+  if (parseResult != null) {
+    code = parseResult.code;
+    msg = replaceArgs(errorCodes[code], parseResult.args);
   }
 
-  componentWillMount() {
-    const {errorCodesString} = this.props;
-    const errorCodes = JSON.parse(errorCodesString);
-    const parseResult = parseQueryString(this.props.location);
-    if (parseResult != null) {
-      const [code, args] = parseResult;
-      if (errorCodes[code]) {
-        this.setState({
-          code: code,
-          errorMsg: replaceArgs(errorCodes[code], args),
-        });
-      }
-    }
-  }
-
-  render() {
-    return <ErrorResult code={this.state.code} msg={this.state.errorMsg} />;
-  }
+  return <ErrorResult code={code} msg={msg} />;
 }
-
-ErrorDecoder.propTypes = {
-  errorCodesString: PropTypes.string.isRequired,
-  location: PropTypes.object.isRequired,
-};
 
 export default ErrorDecoder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7688,6 +7688,10 @@ qs@6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+qs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"


### PR DESCRIPTION
When a website uses PHP's `http_build_query` to rebuild a query string, it changes `?invariant=149&args[]=input` to `?invariant=149&args[0]=input` (there's an extra array index `0`). 

More context: http://php.net/manual/en/function.http-build-query.php#77377 (and internal link: https://fburl.com/n6jc0g3g, https://fburl.com/hm2rnd44)

IIRC there wasn't an easy way to add an external library to our documentation site when I was working on the original ErrorDecoder, so I hand-rolled a simple query string parser that couldn't handle this case. Now we have a separate repo so I think it makes more sense to use `qs` for parsing.

Test Plan:
- `yarn run dev`
- The following URLs should all work fine:
  - http://localhost:8000/docs/error-decoder.html?invariant=142&args[]=Foo&args[]=Bar&args[]=Yoooo (this is the one that `error-codes` builds)
  - http://localhost:8000/docs/error-decoder.html?invariant=142&args[0]=Foo&args[1]=Bar&args[2]=Yoooo
