### PR TITLE
add intro video topics and linked scenes to directly navigate to

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -145,7 +145,7 @@ However, there are still some styles that the linter cannot pick up. If you are 
 
 You may be interested in watching [this short video](https://www.youtube.com/watch?v=wUpPsEcGsg8) (26 mins) which gives an introduction on how to contribute to React.
 
-#### Available topics in this video directly linked:
+#### Video highlights:
 - Building and testing React locally [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s)
 - Creating and sending pull requests [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s)
 - Organizing code [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s)

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -146,11 +146,11 @@ However, there are still some styles that the linter cannot pick up. If you are 
 You may be interested in watching [this short video](https://www.youtube.com/watch?v=wUpPsEcGsg8) (26 mins) which gives an introduction on how to contribute to React.
 
 #### Video highlights:
-- Building and testing React locally [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s)
-- Creating and sending pull requests [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s)
-- Organizing code [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s)
-- React npm registry [14:43](https://youtu.be/wUpPsEcGsg8?t=14m43s)
-- Adding new React features [19:15](https://youtu.be/wUpPsEcGsg8?t=19m15s)
+- [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s) Building and testing React locally
+- [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s) Creating and sending pull requests
+- [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s) Organizing code
+- [14:43](https://youtu.be/wUpPsEcGsg8?t=14m43s) React npm registry
+- [19:15](https://youtu.be/wUpPsEcGsg8?t=19m15s) Adding new React features
 
 ### Meeting Notes
 

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -146,11 +146,11 @@ However, there are still some styles that the linter cannot pick up. If you are 
 You may be interested in watching [this short video](https://www.youtube.com/watch?v=wUpPsEcGsg8) (26 mins) which gives an introduction on how to contribute to React.
 
 #### Video highlights:
-- [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s) Building and testing React locally
-- [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s) Creating and sending pull requests
-- [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s) Organizing code
-- [14:43](https://youtu.be/wUpPsEcGsg8?t=14m43s) React npm registry
-- [19:15](https://youtu.be/wUpPsEcGsg8?t=19m15s) Adding new React features
+- [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s) - Building and testing React locally
+- [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s) - Creating and sending pull requests
+- [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s) - Organizing code
+- [14:43](https://youtu.be/wUpPsEcGsg8?t=14m43s) - React npm registry
+- [19:15](https://youtu.be/wUpPsEcGsg8?t=19m15s) - Adding new React features
 
 ### Meeting Notes
 

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -145,6 +145,13 @@ However, there are still some styles that the linter cannot pick up. If you are 
 
 You may be interested in watching [this short video](https://www.youtube.com/watch?v=wUpPsEcGsg8) (26 mins) which gives an introduction on how to contribute to React.
 
+#### Available topics in this video directly linked:
+- build and test React locally [>](https://youtu.be/wUpPsEcGsg8?t=4m12s)
+- how to create and send pull requests to the React repository and how those are handled on project maintainer side [>](https://youtu.be/wUpPsEcGsg8?t=6m7s)
+- structure and organiztion of code: src files, entry points and module system [>](https://youtu.be/wUpPsEcGsg8?t=8m25s)
+- inspection and explanation of build/dist code pushed to npm registry [>](https://youtu.be/wUpPsEcGsg8?t=14m43s)
+- what to consider when adding new React features [>](https://youtu.be/wUpPsEcGsg8?t=19m15s)
+
 ### Meeting Notes
 
 React team meets once a week to discuss the development of React, future plans, and priorities. You can find the meeting notes in a [dedicated repository](https://github.com/reactjs/core-notes/).

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -146,11 +146,11 @@ However, there are still some styles that the linter cannot pick up. If you are 
 You may be interested in watching [this short video](https://www.youtube.com/watch?v=wUpPsEcGsg8) (26 mins) which gives an introduction on how to contribute to React.
 
 #### Available topics in this video directly linked:
-- build and test React locally [>](https://youtu.be/wUpPsEcGsg8?t=4m12s)
-- how to create and send pull requests to the React repository and how those are handled on project maintainer side [>](https://youtu.be/wUpPsEcGsg8?t=6m7s)
-- structure and organiztion of code: src files, entry points and module system [>](https://youtu.be/wUpPsEcGsg8?t=8m25s)
-- inspection and explanation of build/dist code pushed to npm registry [>](https://youtu.be/wUpPsEcGsg8?t=14m43s)
-- what to consider when adding new React features [>](https://youtu.be/wUpPsEcGsg8?t=19m15s)
+- Building and testing React locally [4:12](https://youtu.be/wUpPsEcGsg8?t=4m12s)
+- Creating and sending pull requests [6:07](https://youtu.be/wUpPsEcGsg8?t=6m7s)
+- Organizing code [8:25](https://youtu.be/wUpPsEcGsg8?t=8m25s)
+- React npm registry [14:43](https://youtu.be/wUpPsEcGsg8?t=14m43s)
+- Adding new React features [19:15](https://youtu.be/wUpPsEcGsg8?t=19m15s)
 
 ### Meeting Notes
 


### PR DESCRIPTION
I found this video very useful to get an overview on how contribute to React. Also I liked the fact, that most of the topics were clearly scoped explained. 

So in case somebody wants to have a quick info on a specific React contributing topic without watching the whole video, theses shortlinks to the proper scenes in the video might be of help. I referenced the links using ```>``` symbol, as otherwise the hyperlink styles would be too style-dominating in the visual appearance of that docs section. In case you want this to be changed, I can adjust the pull request.