### PR TITLE
Update docs referencing referencing /src files

### DIFF
--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -14,8 +14,6 @@ It is very technical and assumes a strong understanding of React public API as w
 
 It also assumes an understanding of the [differences between React components, their instances, and elements](/blog/2015/12/18/react-components-elements-and-instances.html).
 
-The stack reconciler is powering all the React production code today. It is located in [`src/renderers/shared/stack/reconciler`](https://github.com/facebook/react/tree/master/src/renderers/shared/stack) and is used by both React DOM and React Native.
-
 ### Video: Building React from Scratch
 
 [Paul O'Shannessy](https://twitter.com/zpao) gave a talk about [building React from scratch](https://www.youtube.com/watch?v=_MAD4Oly9yg) that largely inspired this document.

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -14,6 +14,8 @@ It is very technical and assumes a strong understanding of React public API as w
 
 It also assumes an understanding of the [differences between React components, their instances, and elements](/blog/2015/12/18/react-components-elements-and-instances.html).
 
+The stack reconciler was used in React 15 and earlier. It is located at [src/renderers/shared/stack/reconciler](https://github.com/facebook/react/tree/15-stable/src/renderers/shared/stack/reconciler).
+
 ### Video: Building React from Scratch
 
 [Paul O'Shannessy](https://twitter.com/zpao) gave a talk about [building React from scratch](https://www.youtube.com/watch?v=_MAD4Oly9yg) that largely inspired this document.


### PR DESCRIPTION
This PR removes references to `/src` files in the Implementation Notes section of the documentation. It also fixes #181 

- **Previous text:**
![previous](https://user-images.githubusercontent.com/7117565/32911721-f257ee60-cada-11e7-8cb4-577df039ad6d.png)
 
- **Result:**
![updated-changes](https://user-images.githubusercontent.com/7117565/33278228-de3d8ec6-d368-11e7-9f63-a61c9fd6f923.png)
