### PR TITLE
Updates CrowdIn configuration to use /docs/lang/folder/file.md

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -5,8 +5,8 @@ preserve_hierarchy: true
 
 files:
   -
-    source: '/docs/*.md'
-    translation: '/docs/i18n/%locale%/%original_file_name%'
+    source: '/content/docs/*.md'
+    translation: '/docs/%locale%/docs/%original_file_name%'
     languages_mapping: &anchor
       locale:
         'af': 'af'
@@ -44,58 +44,43 @@ files:
         'zh-CN': 'zh-Hans'
         'zh-TW': 'zh-Hant'
   -
-    source: '/tutorial/*.md'
-    translation: '/tutorial/%locale%/%original_file_name%'
+    source: '/content/blog/*.md'
+    translation: '/docs/%locale%/blog/%original_file_name%'
     languages_mapping: *anchor
   -
-    source: '/community/*.md'
-    translation: '/community/%locale%/%original_file_name%'
+    source: '/content/tutorial/*.md'
+    translation: '/docs/%locale%/tutorial/%original_file_name%'
+    languages_mapping: *anchor
+  -
+    source: '/content/community/*.md'
+    translation: '/docs/%locale%/community/%original_file_name%'
     ignore:
-      - '/community/complementary-tools.it-IT.md'
-      - '/community/complementary-tools.ko-KR.md'
-      - '/community/complementary-tools.zh-CN.md'
-      - '/community/conferences.it-IT.md'
-      - '/community/conferences.ko-KR.md'
-      - '/community/conferences.zh-CN.md'
-      - '/community/examples.it-IT.md'
-      - '/community/examples.ko-KR.md'
-      - '/community/examples.zh-CN.md'
-      - '/community/videos.it-IT.md'
-      - '/community/videos.ko-KR.md'
-      - '/community/videos.zh-CN.md'
+      - '/content/community/complementary-tools.it-IT.md'
+      - '/content/community/complementary-tools.ko-KR.md'
+      - '/content/community/complementary-tools.zh-CN.md'
+      - '/content/community/conferences.it-IT.md'
+      - '/content/community/conferences.ko-KR.md'
+      - '/content/community/conferences.zh-CN.md'
+      - '/content/community/examples.it-IT.md'
+      - '/content/community/examples.ko-KR.md'
+      - '/content/community/examples.zh-CN.md'
+      - '/content/community/videos.it-IT.md'
+      - '/content/community/videos.ko-KR.md'
+      - '/content/community/videos.zh-CN.md'
     languages_mapping: *anchor
   -
-    source: '/contributing/*.md'
-    translation: '/contributing/%locale%/%original_file_name%'
+    source: '/content/contributing/*.md'
+    translation: '/docs/%locale%/contributing/%original_file_name%'
     languages_mapping: *anchor
   -
-    source: '/_data/*.yml'
-    translation: '/_data/%locale%/%original_file_name%'
-    languages_mapping: *anchor
-    ignore:
-      - '/_data/acknowledgements.yml'
-      - '/_data/authors.md'
-  -
-    source: '/warnings/*.md'
-    translation: '/warnings/%locale%/%original_file_name%'
-    languages_mapping: *anchor
-  -
-    source: '/index.md'
-    translation: '/%locale%/index.md'
+    source: '/content/warnings/*.md'
+    translation: '/docs/%locale%/warnings/%original_file_name%'
     languages_mapping: *anchor
   -
     source: '/README.md'
-    translation: '/%locale%/README.md'
+    translation: '/docs/%locale%/README.md'
     languages_mapping: *anchor
   -
-    source: '/acknowledgements.md'
-    translation: '/%locale%/acknowledgements.md'
-    languages_mapping: *anchor
-  -
-    source: '/404.md'
-    translation: '/%locale%/404.md'
-    languages_mapping: *anchor
-  -
-    source: '/jsx-compiler.md'
-    translation: '/%locale%/jsx-compiler.md'
+    source: '/content/404.md'
+    translation: '/docs/%locale%/404.md'
     languages_mapping: *anchor


### PR DESCRIPTION
This PR changes where localized files, downloaded from CrowdIn, are output.

To verify you can run crowdin upload and download locally from reacjs.org folder:

crowdin --config crowdin.yaml upload sources --auto-update -b test-17
crowdin --config crowdin.yaml download -b test-17

The files will then be available in reactjs.org/docs/*.