### PR TITLE
Tweak Courses page

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -8,14 +8,26 @@ permalink: community/courses.html
 
 ## Free Courses
 
-- [LearnCode.academy](https://www.youtube.com/watch?v=MhkGQAoc7bc) - This React JS Course will help you get quickly up to pace with React.js development.
+- [Codecademy: React 101](https://www.codecademy.com/learn/react-101) - Codecademy's introductory course for React.
 
-- [Codecademy](https://www.codecademy.com/learn/react-101) - Codecademy's introductory course for React.
+- [Egghead.io: Start Learning React](https://egghead.io/courses/start-learning-react) - This series will explore the basic fundamentals of React to get you started.
+
+- [React Armory: Learn React by Itself](https://reactarmory.com/guides/learn-react-by-itself) - With React Armory, you can learn React without the buzzwords.
+
+- [The Road to Learn React](https://www.robinwieruch.de/the-road-to-learn-react/) - Build a real world application in plain React without complicated tooling.
 
 ## Paid Courses
 
 - [Egghead.io](https://egghead.io/browse/frameworks/react) - Short instructional videos on React and many other topics.
 
-- [Tyler McGinnis](https://tylermcginnis.com/courses) - Tyler McGinnis provides access to his courses for a monthly fee. Courses include "React Fundamentals" and "Universal React".
-
 - [Frontend Masters](https://frontendmasters.com/courses/) - Video courses on React and other frontend frameworks.
+
+- [Fullstack React](https://www.fullstackreact.com/) - The up-to-date, in-depth, complete guide to React and friends.
+
+- [Pure React](https://daveceddia.com/pure-react/) - A step-by-step guide to mastering React.
+
+- [React for Beginners](https://reactforbeginners.com/) - Learn React in just a couple of afternoons.
+
+- [React Training: Advanced React.js](https://courses.reacttraining.com/p/advanced-react) - Take your React skills to the next level.
+
+- [Tyler McGinnis](https://tylermcginnis.com/courses) - Tyler McGinnis provides access to his courses for a monthly fee. Courses include "React Fundamentals" and "Universal React".


### PR DESCRIPTION
* Removes an outdated tutorial that starts with Babel and uses 0.14
* Adds great courses

Some of these are technically books, but I'd still call them courses because they offer complementary content, and are structured/marketed as courses. I think they belong together.