### PR TITLE
Add mention of custom-elements-es5-adapter

### DIFF
--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -58,3 +58,4 @@ customElements.define('x-search', XSearch);
 >Note:
 >
 >This code **will not** work if you transform classes with Babel. See [this issue](https://github.com/w3c/webcomponents/issues/587) for the discussion.
+>Include the [custom-elements-es5-adapter](https://github.com/webcomponents/webcomponentsjs#custom-elements-es5-adapterjs) before you load your web components to fix this issue.


### PR DESCRIPTION
Added a note that including the es5 adapter fixes the issue of transpiled custom elements not working in browsers like Chrome and Safari. I think the previously linked GitHub thread provides a lot of useful background information but might also be confusing for some folks and leave them wondering if custom elements will work at all in their app. Things should be all good after they include the adapter.