### PR TITLE
Add release jsx fragment blog post

### DIFF
--- a/content/authors.yml
+++ b/content/authors.yml
@@ -10,6 +10,9 @@ benigeri:
 chenglou:
   name: Cheng Lou
   url: https://twitter.com/_chenglou
+clemmy:
+  name: Clement Hoang
+  url: https://twitter.com/c8hoang
 Daniel15:
   name: Daniel Lo Nigro
   url: http://dan.cx/

--- a/content/blog/2017-11-28-fragments-in-react-v16.2.md
+++ b/content/blog/2017-11-28-fragments-in-react-v16.2.md
@@ -145,9 +145,9 @@ If you are using Babel with [Webpack](https://webpack.js.org/), then no addition
 
 Unfortunately, support for Babel 6.x is not available, and there are currently no plans to back-port.
 
-#### Typescript
+#### TypeScript
 
-For Typescript users, please upgrade to [version 2.6.2](https://github.com/Microsoft/TypeScript/releases/tag/v2.6.2). Note that this is important even if you are already on version 2.6.1, since support was added in 2.6.2.
+For TypeScript users, please upgrade to [version 2.6.2](https://github.com/Microsoft/TypeScript/releases/tag/v2.6.2). Note that this is important even if you are already on version 2.6.1, since support was added in 2.6.2.
 
 Upgrade to the latest with the command
 
@@ -156,7 +156,8 @@ yarn upgrade typescript # for yarn users
 npm update typescript # for npm users
 ```
 
-Also, editors may complain about errors in `.tsx` and `.js/.jsx` files using the new syntax. These errors can be safely ignored, or configured for [VS Code](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions) and [Sublime Text](https://github.com/Microsoft/TypeScript-Sublime-Plugin/#note-using-different-versions-of-typescript).
+Also, editors may complain about errors in `.tsx` and `.js/.jsx` files using the new syntax. These errors can be safely ignored, but editor support for JSX fragments are already available with updates for [Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48593), [Visual Studio 2017](https://www.microsoft.com/en-us/download/details.aspx?id=55258), and [Sublime Text via Package Control](https://packagecontrol.io/packages/TypeScript).
+Visual Studio Code will be updated soon, but [can be configured to use TypeScript 2.6.2 and later](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions).
 
 #### Flow
 
@@ -177,4 +178,4 @@ For other tools, please check with the corresponding documentation to check if t
 
 This release was made possible thanks to the core team and our open source contributors. A big thanks to everyone who filed issues, contributed to syntax discussions, reviewed pull requests, added support for JSX fragments in third party libraries, and more!
 
-Also, special thanks to the [Typescript](https://www.typescriptlang.org/) and [Flow](https://flow.org/) teams, as well as the [Babel](https://babeljs.io/) maintainers, who helped make tooling support for the new syntax go seamlessly.
+Also, special thanks to the [TypeScript](https://www.typescriptlang.org/) and [Flow](https://flow.org/) teams, as well as the [Babel](https://babeljs.io/) maintainers, who helped make tooling support for the new syntax go seamlessly.

--- a/content/blog/2017-11-28-fragments-in-react-v16.2.md
+++ b/content/blog/2017-11-28-fragments-in-react-v16.2.md
@@ -3,14 +3,30 @@ title: "Fragments in React v16.2"
 author: [clemmy]
 ---
 
-Today, we're excited to bring the new `Fragment` export to React, which allows users to render **static** fragments without the unnecessary keying of each element in the fragment!
+Today, we're excited to improved support for fragments in React! We are introducing a new `Fragment` export, which allows
+which allows users to render *static* fragments using familiar JSX element syntax.
+
+```jsx
+import React, { Fragment } from 'react';
+
+render() {
+  return (
+    <Fragment>
+      <li>Look ma</li>
+      <li>a list!</li>
+    </Fragment>
+  );
+}
+```
+
+We've also included a new short syntax that is already supported by [some tools](#tooling-support):
 
 ```jsx
 render() {
   return (
     <>
       <li>Look ma</li>
-      <li>no keys!</li>
+      <li>a list!</li>
     </>
   );
 }
@@ -18,10 +34,11 @@ render() {
 
 ### Why Fragments?
 
-When React released version 16, the ability to render an array of elements from a component's `render` method was added. This allowed developers to prevent extraneous markup with `div`s that pollute the HTML. However, it was inconvenient because every element in the array had to be explicitly keyed. Previously, in order to render an array of elements, the following code would be necessary:
+React 16 added the [ability to return an array of elements from a component's `render` method](https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings). This allowed developers to prevent extraneous markup with `div`s that pollute the DOM. However, it was inconvenient for users who were writing static JSX because the syntax is completely different from how they would usually write JSX:
 
 ```jsx
 render() {
+  // keys and commas are needed when returning an array in a render
   return [
     <span key="first-span">I am</span>,
     <span key="second-span">static</span>
@@ -29,18 +46,21 @@ render() {
 }
 ```
 
-However, the keys are only necessary for React's reconciliation algorithm when child elements are re-arranged and React needs to figure out which item in one render corresponds to in a subsequent render. If the array is static, then keys aren't necessary and only add extra noise to the code. So, let's omit them:
+So, we added the `Fragment` component to React! `Fragment`s let developers return multiple elements from `render` methods using a familiar syntax that resembles normal JSX elements:
 
 ```jsx
+import React, { Fragment } from 'react';
+
 render() {
-  return [
-    <span>I am</span>,
+  // keys and commas are no longer needed
+  return <Fragment>
+    <span>I am</span>
     <span>static</span>
-  ];
+  </Fragment>;
 }
 ```
 
-But React gives a key warning with the above code! This is because React doesn't know whether the array items can ever rearrange. With fragment syntax, it is clear that the code's intent is to render a static list of children, and not a developer mistake:
+We anticipate that the above will be a common use case, so we added a shorthand syntax for it:
 
 ```jsx
 render() {
@@ -88,27 +108,29 @@ After the release of React 16, people in the React community have created soluti
 
 [For the curious, you can read more about that here.](https://github.com/facebook/react/pull/10783)
 
-Still, we are very thankful to the open source contributors who worked on solving this in the ecosystem.
+We are very thankful to [Gajus Kuizinas](https://github.com/gajus/) and other contributors who prototyped this in open source.
 
 Additionally, there is a [pragma option available in babel-plugin-transform-react-jsx](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx#pragmafrag) that allows the Babel compiler to de-sugar the `<>...</>` syntax to a custom identifier.
 
-### Example Usages
+### Usage
 
 As mentioned above, the most common way to use fragments in React is to simply use `<></>` tags. Generally, in the Javascript compiler phase of your build pipeline, the `<>...</>` will be de-sugared into a `createElement` call with `React.Fragment` as the type.
 
-Take a look at the section on [How to Use it](#how-to-use-it) to see how to update your tooling to support JSX fragments.
+Take a look at the section on [tooling support](#tooling-support) to see how to update your tooling to support JSX fragments.
 
 #### With Attributes and Keys
 
-Note that with the `<></>` syntax, attributes are not allowed to be passed. We made the decision to disallow attributes with fragments since they're semantically different from React elements. However, a fragment can be keyed by using the explicit fragment syntax:
+Note that the `<></>` syntax does not allow attributes on fragments. We made the decision to disallow attributes with fragments since they're semantically different from React elements. However, a fragment can be keyed by using the explicit fragment syntax. A common use case for this is grouping an item list into pairs:
 
 ```jsx
-import { Fragment } from 'react';
+import React, { Fragment } from 'react';
 
-<Fragment key="my-key">
-  <span>Happy</span>
-  <span>Thanksgiving!</span>
-</Fragment>
+items.map(item => (
+  <Fragment key="item.key">
+    <li>{item.title}</li>
+    <li>{item.description}</li>
+  </Fragment>
+))
 ```
 
 In the future, `Fragment` may also support more attributes, such as event handlers.
@@ -117,9 +139,9 @@ In the future, `Fragment` may also support more attributes, such as event handle
 
 You can experiment with JSX fragment syntax on this [CodePen](#) using [React v16.2.0](https://github.com/facebook/react/releases/tag/v16.2.0) and [Babel v7](https://github.com/babel/babel).
 
-### How to Use it
+### Tooling Support
 
-JSX fragments are still very new and some tools in the ecosystem may not be ready for it yet, so please be patient! However, we've tried our best to make it as simple as possible to upgrade from several popular toolchains:
+JSX fragments are still very new and many tools in the ecosystem may not be ready for it yet, so please be patient! We've tried our best to make it as simple as possible to upgrade from several popular toolchains:
 
 #### Create React App
 
@@ -143,7 +165,7 @@ npm update @babel/core @babel/preset-react # for npm users
 
 If you are using Babel with [Webpack](https://webpack.js.org/), then no additional steps need to be done because [babel-loader](https://github.com/babel/babel-loader) will be using your peer-installed version of Babel.
 
-Unfortunately, support for Babel 6.x is not available, and there are currently no plans to back-port.
+Unfortunately, support for Babel 6.x is not available, and there are currently no plans to backport.
 
 #### TypeScript
 
@@ -172,7 +194,7 @@ to update Flow to the latest version.
 
 #### Others
 
-For other tools, please check with the corresponding documentation to check if there is support available. However, it's not a problem at all if you want the functionality of `<></>` without your linters and tooling complaining! You can always start with `<Fragment></Fragment>` and do a code-mod later to replace it with `<></>` when the appropriate support is available.
+For other tools, please check with the corresponding documentation to check if there is support available. However, it's not a problem at all if you want the functionality of `<></>` without your linters and tooling complaining! You can always start with `<Fragment></Fragment>` and do a codemod later to replace it with `<></>` when the appropriate support is available.
 
 ### Acknowledgments
 

--- a/content/blog/2017-11-28-fragments-in-react-v16.2.md
+++ b/content/blog/2017-11-28-fragments-in-react-v16.2.md
@@ -1,0 +1,180 @@
+---
+title: "Fragments in React v16.2"
+author: [clemmy]
+---
+
+Today, we're excited to bring the new `Fragment` export to React, which allows users to render **static** fragments without the unnecessary keying of each element in the fragment!
+
+```jsx
+render() {
+  return (
+    <>
+      <li>Look ma</li>
+      <li>no keys!</li>
+    </>
+  );
+}
+```
+
+### Why Fragments?
+
+When React released version 16, the ability to render an array of elements from a component's `render` method was added. This allowed developers to prevent extraneous markup with `div`s that pollute the HTML. However, it was inconvenient because every element in the array had to be explicitly keyed. Previously, in order to render an array of elements, the following code would be necessary:
+
+```jsx
+render() {
+  return [
+    <span key="first-span">I am</span>,
+    <span key="second-span">static</span>
+  ];
+}
+```
+
+However, the keys are only necessary for React's reconciliation algorithm when child elements are re-arranged and React needs to figure out which item in one render corresponds to in a subsequent render. If the array is static, then keys aren't necessary and only add extra noise to the code. So, let's omit them:
+
+```jsx
+render() {
+  return [
+    <span>I am</span>,
+    <span>static</span>
+  ];
+}
+```
+
+But React gives a key warning with the above code! This is because React doesn't know whether the array items can ever rearrange. With fragment syntax, it is clear that the code's intent is to render a static list of children, and not a developer mistake:
+
+```jsx
+render() {
+  return (
+    <>
+      <span>I am</span>
+      <span>static</span>
+    </>
+  );
+}
+```
+
+#### The Syntax
+
+Inspired by some prior art such as the `XMLList() <></>` constructor in [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X/E4X_for_templating) and the existing `<></>` syntax in [Reason React](https://reasonml.github.io/reason-react/), the React team concluded on having a convenient syntax for JSX fragments that looks like `<>...</>`. This captures the idea of a fragment: It is a pair of empty tags which enforces the notion that it won't render to an actual element in the DOM.
+
+The `<></>` syntax also makes it easier to refactor since it looks just like a JSX element. For example, consider swapping the parents in the following code snippets:
+
+```jsx
+// with a parent wrapper
+<div>
+  <span>foo</span>
+  bar
+  <span>baz</span>
+</div>
+
+// with arrays (where commas are necessary and text needs to be surrounded by quotes)
+[
+  <span>foo</span>,
+  'bar',
+  <span>baz</span>
+]
+
+// with jsx fragment syntax
+<>
+  <span>foo</span>
+  bar
+  <span>baz</span>
+</>
+```
+
+#### The Export
+
+After the release of React 16, people in the React community have created solutions in order to address the problem of static lists, such as [react-aux](https://github.com/gajus/react-aux). For `Fragment`s however, the React team has decided to take ownership of the export, since there are some semantics specific to Fragments that aren't possible without core library changes. These changes have some performance wins and make reconciliation a bit more intuitive.
+
+[For the curious, you can read more about that here.](https://github.com/facebook/react/pull/10783)
+
+Still, we are very thankful to the open source contributors who worked on solving this in the ecosystem.
+
+Additionally, there is a [pragma option available in babel-plugin-transform-react-jsx](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx#pragmafrag) that allows the Babel compiler to de-sugar the `<>...</>` syntax to a custom identifier.
+
+### Example Usages
+
+As mentioned above, the most common way to use fragments in React is to simply use `<></>` tags. Generally, in the Javascript compiler phase of your build pipeline, the `<>...</>` will be de-sugared into a `createElement` call with `React.Fragment` as the type.
+
+Take a look at the section on [How to Use it](#how-to-use-it) to see how to update your tooling to support JSX fragments.
+
+#### With Attributes and Keys
+
+Note that with the `<></>` syntax, attributes are not allowed to be passed. We made the decision to disallow attributes with fragments since they're semantically different from React elements. However, a fragment can be keyed by using the explicit fragment syntax:
+
+```jsx
+import { Fragment } from 'react';
+
+<Fragment key="my-key">
+  <span>Happy</span>
+  <span>Thanksgiving!</span>
+</Fragment>
+```
+
+In the future, `Fragment` may also support more attributes, such as event handlers.
+
+### Live Demo
+
+You can experiment with JSX fragment syntax on this [CodePen](#) using [React v16.2.0](https://github.com/facebook/react/releases/tag/v16.2.0) and [Babel v7](https://github.com/babel/babel).
+
+### How to Use it
+
+JSX fragments are still very new and some tools in the ecosystem may not be ready for it yet, so please be patient! However, we've tried our best to make it as simple as possible to upgrade from several popular toolchains:
+
+#### Create React App
+
+There will be an beta release for `create-react-app` users at [v1.1-beta](https://github.com/facebookincubator/create-react-app/releases/tag/v1.1.0-beta), where adventurous users can experiment with JSX fragment syntax.
+
+#### Babel
+
+Support for JSX fragments are available in [Babel v7.0.0-beta.31](https://github.com/babel/babel/releases/tag/v7.0.0-beta.31)! If you are already on Babel 7, then simply update to the latest Babel and plugin transform with
+
+```
+yarn upgrade @babel/core @babel/plugin-transform-react-jsx # for yarn users
+npm update @babel/core @babel/plugin-transform-react-jsx # for npm users
+```
+
+or if you are using the [react preset](https://www.npmjs.com/package/@babel/preset-react):
+
+```
+yarn upgrade @babel/core @babel/preset-react # for yarn users
+npm update @babel/core @babel/preset-react # for npm users
+```
+
+If you are using Babel with [Webpack](https://webpack.js.org/), then no additional steps need to be done because [babel-loader](https://github.com/babel/babel-loader) will be using your peer-installed version of Babel.
+
+Unfortunately, support for Babel 6.x is not available, and there are currently no plans to back-port.
+
+#### Typescript
+
+For Typescript users, please upgrade to [version 2.6.2](https://github.com/Microsoft/TypeScript/releases/tag/v2.6.2). Note that this is important even if you are already on version 2.6.1, since support was added in 2.6.2.
+
+Upgrade to the latest with the command
+
+```
+yarn upgrade typescript # for yarn users
+npm update typescript # for npm users
+```
+
+Also, editors may complain about errors in `.tsx` and `.js/.jsx` files using the new syntax. These errors can be safely ignored, or configured for [VS Code](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions) and [Sublime Text](https://github.com/Microsoft/TypeScript-Sublime-Plugin/#note-using-different-versions-of-typescript).
+
+#### Flow
+
+[Flow](https://flow.org/) support for JSX fragments is available starting in [version 0.59](https://github.com/facebook/flow/releases/tag/v0.59.0). Simply run
+
+```
+yarn upgrade flow-bin # for yarn users
+npm update flow-bin # for npm users
+```
+
+to update Flow to the latest version.
+
+#### Others
+
+For other tools, please check with the corresponding documentation to check if there is support available. However, it's not a problem at all if you want the functionality of `<></>` without your linters and tooling complaining! You can always start with `<Fragment></Fragment>` and do a code-mod later to replace it with `<></>` when the appropriate support is available.
+
+### Acknowledgments
+
+This release was made possible thanks to the core team and our open source contributors. A big thanks to everyone who filed issues, contributed to syntax discussions, reviewed pull requests, added support for JSX fragments in third party libraries, and more!
+
+Also, special thanks to the [Typescript](https://www.typescriptlang.org/) and [Flow](https://flow.org/) teams, as well as the [Babel](https://babeljs.io/) maintainers, who helped make tooling support for the new syntax go seamlessly.

--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -1,5 +1,5 @@
 ---
-title: "React v16.2.0: Fragment Support"
+title: "React v16.2.0: Improved Support for Fragments"
 author: [clemmy]
 ---
 
@@ -19,15 +19,18 @@ render() {
 }
 ```
 
+This exciting new feature is made possible by new additions to both React and JSX.
+
 ## What Are Fragments?
 
-A common pattern is for a component to return a list of children. An example is rendering some text with a link inside. Take this example HTML:
+A common pattern is for a component to return a list of children. Take this example HTML:
 
 ```html
-Text with
-<a href="/foo">multiple</a>
-<a href="/bar">links</a>
-inside it.
+Some text.
+<h2>A heading</h2>
+More text.
+<h2>Another heading</h2>
+Even more text.
 ```
 
 Prior to version 16, the only way to acheive this in React was by wrapping the children in an extra element, usually a `div` or `span`:
@@ -35,14 +38,14 @@ Prior to version 16, the only way to acheive this in React was by wrapping the c
 ```js
 render() {
   return (
-    // Extraneous span element :(
-    <span>
-      Text children
-      <button>interleaved</button>
-      with
-      <button>other</button>
-      children.
-    </span>
+    // Extraneous div element :(
+    <div>
+      Some text.
+      <h2>A heading</h2>
+      More text.
+      <h2>Another heading</h2>
+      Even more text.
+    </div>
   );
 }
 ```
@@ -52,11 +55,11 @@ To address this limitation, React 16.0 added support for [returning an array of 
 ```jsx
 render() {
  return [
-    "Text children",
-    <button key="button1">interleaved</button>,
-    "with",
-    <button key="button2">other</button>,    
-    "children."
+  "Some text.",
+  <h2 key="heading-1">A heading</h2>,
+  "More text."
+  <h2 key="heading-2">Another heading</h2>,
+  "Even more text."
  ];
 }
 ```
@@ -73,11 +76,11 @@ To provide a more consistent authoring experience for fragments, React now provi
 render() {
   return (
     <Fragment>
-      Text children
-      <button>interleaved</button>
-      with
-      <button>other</button>
-      children.
+      Some text.
+      <h2>A heading</h2>
+      More text.
+      <h2>Another heading</h2>
+      Even more text.
     </Fragment>
   );
 }
@@ -112,11 +115,11 @@ Fragments are a common pattern in our codebases at Facebook. We anticipate they'
 render() {
   return (
     <>
-      Text children
-      <button>interleaved</button>
-      with
-      <button>other</button>
-      children.
+      Some text.
+      <h2>A heading</h2>
+      More text.
+      <h2>Another heading</h2>
+      Even more text.
     </>
   );
 }
@@ -152,7 +155,7 @@ function Glossary(props) {
 
 ### Live Demo
 
-You can experiment with JSX fragment syntax with this [CodePen](#).
+You can experiment with JSX fragment syntax with this [CodePen](https://codepen.io/reactjs/pen/VrEbjE?editors=1000).
 
 ## Support for Fragment Syntax
 

--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -1,5 +1,5 @@
 ---
-title: "Fragments in React v16.2"
+title: "React v16.2.0: Fragment Support"
 author: [clemmy]
 ---
 
@@ -124,7 +124,7 @@ Fragment syntax in JSX was inspired by prior art such as the `XMLList() <></>` c
 
 ### Keyed Fragments
 
-Note that the `<></>` syntax does not accept attributes, including keys. 
+Note that the `<></>` syntax does not accept attributes, including keys.
 
 If you need a keyed fragment, you can use `<React.Fragment />` directly. An use case for this is mapping a collection to an array of fragments -- for example, to create a description list:
 
@@ -287,19 +287,27 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 
 ## Changelog
 
-#### React
+### React
 
-* Add Fragment as a named export to React. ([@clemmy](https://github.com/clemmy) in [#10783](https://github.com/facebook/react/pull/10783))
+* Add `Fragment` as named export to React. ([@clemmy](https://github.com/clemmy) in [#10783](https://github.com/facebook/react/pull/10783))
+* Support experimental Call/Return types in `React.Children` utilities. ([@MatteoVH](https://github.com/MatteoVH) in [#11422](https://github.com/facebook/react/pull/11422))
 
-#### React DOM
+### React DOM
 
-* Fix regression where radio button onChange events are not fired as expected. ([@landvibe](https://github.com/landvibe) in [#11227](https://github.com/facebook/react/pull/11227))
+* Fix radio buttons not getting checked when using multiple lists of radios. ([@landvibe](https://github.com/landvibe) in [#11227](https://github.com/facebook/react/pull/11227))
+* Fix radio buttons not receiving the `onChange` event in some cases. ([@jquense](https://github.com/jquense) in [#11028](https://github.com/facebook/react/pull/11028))
 
-* Fix incorrectly checked radio buttons when using multiple lists of radio buttons. ([@darth-cheney](https://github.com/darth-cheney) in [#10739](https://github.com/facebook/react/pull/10739))
+### React Test Renderer
 
-#### React Test Renderer
+* Fix `setState()` callback firing too early when called from `componentWillMount`. ([@accordeiro](https://github.com/accordeiro) in [#11507](https://github.com/facebook/react/pull/11507))
 
-* Fix setState callback getting called before component state is updated ([@accordeiro](https://github.com/accordeiro) in [#11507](https://github.com/facebook/react/pull/11507))
+### React Reconciler
+
+* Expose `react-reconciler/reflection` with utilities useful to custom renderers. ([@rivenhk](https://github.com/rivenhk) in [#11683](https://github.com/facebook/react/pull/11683))
+
+### Internal Changes
+
+* Many tests were rewritten against the public API. Big thanks to [everyone who contributed](https://github.com/facebook/react/issues/11299)!
 
 ## Acknowledgments
 

--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -37,10 +37,11 @@ render() {
   return (
     // Extraneous span element :(
     <span>
-      Text with
-      <a href="/foo">multiple</a>
-      <a href="/bar">links</a>
-      inside it.
+      Text children
+      <button>interleaved</button>
+      with
+      <button>other</button>
+      children.
     </span>
   );
 }
@@ -51,10 +52,11 @@ To address this limitation, React 16.0 added support for [returning an array of 
 ```jsx
 render() {
  return [
-    "Text with",
-    <a key="link1" href="/foo">multiple</a>,
-    <a key="link2" href="/bar">links</a>,
-    "inside it."
+    "Text children",
+    <button key="button1">interleaved</button>,
+    "with",
+    <button key="button2">other</button>,    
+    "children."
  ];
 }
 ```
@@ -67,14 +69,15 @@ However, this has some confusing differences from normal JSX:
 
 To provide a more consistent authoring experience for fragments, React now provides a first-class `Fragment` component that can be used in place of arrays.
 
-```jsx{3,8}
+```jsx{3,9}
 render() {
   return (
     <Fragment>
-      Text with
-      <a href="/foo">multiple</a>
-      <a href="/bar">links</a>
-      inside it.
+      Text children
+      <button>interleaved</button>
+      with
+      <button>other</button>
+      children.
     </Fragment>
   );
 }
@@ -105,14 +108,15 @@ const Fragment = React.Fragment;
 
 Fragments are a common pattern in our codebases at Facebook. We anticipate they'll be widely adopted by other teams, too. To make the authoring experience as convenient as possible, we're adding syntactical support for fragments to JSX:
 
-```jsx{3,8}
+```jsx{3,9}
 render() {
   return (
     <>
-      Text with
-      <a href="/foo">multiple</a>
-      <a href="/bar">links</a>
-      inside it.
+      Text children
+      <button>interleaved</button>
+      with
+      <button>other</button>
+      children.
     </>
   );
 }

--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -19,7 +19,7 @@ render() {
 }
 ```
 
-This exciting new feature is made possible by new additions to both React and JSX.
+This exciting new feature is made possible by additions to both React and JSX.
 
 ## What Are Fragments?
 
@@ -133,7 +133,7 @@ Fragment syntax in JSX was inspired by prior art such as the `XMLList() <></>` c
 
 Note that the `<></>` syntax does not accept attributes, including keys.
 
-If you need a keyed fragment, you can use `<React.Fragment />` directly. An use case for this is mapping a collection to an array of fragments -- for example, to create a description list:
+If you need a keyed fragment, you can use `<Fragment />` directly. An use case for this is mapping a collection to an array of fragments -- for example, to create a description list:
 
 ```jsx
 function Glossary(props) {
@@ -159,7 +159,7 @@ You can experiment with JSX fragment syntax with this [CodePen](https://codepen.
 
 ## Support for Fragment Syntax
 
-These additions Support for fragment syntax in JSX will vary depending on the tools you use to build your app. Please be patient as the JSX community works to adopt the new syntax. We've been working closely with maintainers of the most popular projects:
+Support for fragment syntax in JSX will vary depending on the tools you use to build your app. Please be patient as the JSX community works to adopt the new syntax. We've been working closely with maintainers of the most popular projects:
 
 ### Create React App
 
@@ -269,18 +269,18 @@ For other tools, please check with the corresponding documentation to check if t
 
 ## Installation
 
-React v16.0.0 is available on the npm registry.
+React v16.2.0 is available on the npm registry.
 
 To install React 16 with Yarn, run:
 
 ```bash
-yarn add react@^16.0.0 react-dom@^16.0.0
+yarn add react@^16.2.0 react-dom@^16.2.0
 ```
 
 To install React 16 with npm, run:
 
 ```bash
-npm install --save react@^16.0.0 react-dom@^16.0.0
+npm install --save react@^16.2.0 react-dom@^16.2.0
 ```
 
 We also provide UMD builds of React via a CDN:

--- a/src/site-constants.js
+++ b/src/site-constants.js
@@ -10,7 +10,7 @@
 // NOTE: We can't just use `location.toString()` because when we are rendering
 // the SSR part in node.js we won't have a proper location.
 const urlRoot = 'https://reactjs.org';
-const version = '16.1.1';
+const version = '16.2.0';
 const babelURL = '//unpkg.com/babel-standalone@6.26.0/babel.min.js';
 
 export {urlRoot, version, babelURL};


### PR DESCRIPTION
First draft of the blog post for the upcoming React v16.2 release.

Todos:

- [x] Ensure CRA release link is correct
- [ ] Add a CodePen link for live demo

**Do not merge yet!**