### PR TITLE
Unify the annotation of components in docs

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -42,7 +42,7 @@ Note that all `aria-*` HTML attributes are fully supported in JSX. Whereas most 
 ## Accessible Forms
 
 ### Labeling
-Every HTML form control, such as `<input>` and `<textarea>`, needs to be labeled accessibly. We need to provide descriptive labels that are also exposed to screen readers.
+Every HTML form control, such as `<input />` and `<textarea />`, needs to be labeled accessibly. We need to provide descriptive labels that are also exposed to screen readers.
 
 The following resources show us how to do this:
 
@@ -87,7 +87,7 @@ internal page anchors and some styling:
 
 - [WebAIM - Skip Navigation Links](http://webaim.org/techniques/skipnav/)
 
-Also use landmark elements and roles, such as `<main>` and `<aside>`, to demarcate page regions as assistive technology allow the user to quickly navigate to these sections.
+Also use landmark elements and roles, such as `<main />` and `<aside />`, to demarcate page regions as assistive technology allow the user to quickly navigate to these sections.
 
 Read more about the use of these elements to enhance accessibility here:
 
@@ -158,7 +158,7 @@ Indicate the human language of page texts as screen reader software uses this to
 
 ### Setting the document title
 
-Set the document `<title>` to correctly describe the current page content as this ensures that the user remains aware of the current page context:
+Set the document `<title />` to correctly describe the current page content as this ensures that the user remains aware of the current page context:
 
 - [WCAG - Understanding the Document Title Requirement](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
 

--- a/content/docs/addons-animation.md
+++ b/content/docs/addons-animation.md
@@ -245,7 +245,7 @@ var ReactTransitionGroup = require('react-addons-transition-group') // ES5 with 
 
 #### Rendering a Different Component
 
-`ReactTransitionGroup` renders as a `span` by default. You can change this behavior by providing a `component` prop. For example, here's how you would render a `<ul>`:
+`ReactTransitionGroup` renders as a `span` by default. You can change this behavior by providing a `component` prop. For example, here's how you would render a `<ul />`:
 
 ```javascript{1}
 <ReactTransitionGroup component="ul">
@@ -253,7 +253,7 @@ var ReactTransitionGroup = require('react-addons-transition-group') // ES5 with 
 </ReactTransitionGroup>
 ```
 
-Any additional, user-defined, properties will become properties of the rendered component. For example, here's how you would render a `<ul>` with CSS class:
+Any additional, user-defined, properties will become properties of the rendered component. For example, here's how you would render a `<ul />` with CSS class:
 
 ```javascript{1}
 <ReactTransitionGroup component="ul" className="animated-list">
@@ -267,7 +267,7 @@ Every DOM component that React can render is available for use. However, `compon
 
 People often use `ReactTransitionGroup` to animate mounting and unmounting of a single child such as a collapsible panel. Normally `ReactTransitionGroup` wraps all its children in a `span` (or a custom `component` as described above). This is because any React component has to return a single root element, and `ReactTransitionGroup` is no exception to this rule.
 
-However if you only need to render a single child inside `ReactTransitionGroup`, you can completely avoid wrapping it in a `<span>` or any other DOM component. To do this, create a custom component that renders the first child passed to it directly:
+However if you only need to render a single child inside `ReactTransitionGroup`, you can completely avoid wrapping it in a `<span />` or any other DOM component. To do this, create a custom component that renders the first child passed to it directly:
 
 ```javascript
 function FirstChild(props) {
@@ -276,7 +276,7 @@ function FirstChild(props) {
 }
 ```
 
-Now you can specify `FirstChild` as the `component` prop in `<ReactTransitionGroup>` props and avoid any wrappers in the result DOM:
+Now you can specify `FirstChild` as the `component` prop in `<ReactTransitionGroup />` props and avoid any wrappers in the result DOM:
 
 ```javascript
 <ReactTransitionGroup component={FirstChild}>
@@ -284,7 +284,7 @@ Now you can specify `FirstChild` as the `component` prop in `<ReactTransitionGro
 </ReactTransitionGroup>
 ```
 
-This only works when you are animating a single child in and out, such as a collapsible panel. This approach wouldn't work when animating multiple children or replacing the single child with another child, such as an image carousel. For an image carousel, while the current image is animating out, another image will animate in, so `<ReactTransitionGroup>` needs to give them a common DOM parent. You can't avoid the wrapper for multiple children, but you can customize the wrapper with the `component` prop as described above.
+This only works when you are animating a single child in and out, such as a collapsible panel. This approach wouldn't work when animating multiple children or replacing the single child with another child, such as an image carousel. For an image carousel, while the current image is animating out, another image will animate in, so `<ReactTransitionGroup />` needs to give them a common DOM parent. You can't avoid the wrapper for multiple children, but you can customize the wrapper with the `component` prop as described above.
 
 * * *
 

--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -110,7 +110,7 @@ mockComponent(
 )
 ```
 
-Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.
+Pass a mocked component module to this method to augment it with useful methods that allow it to be used as a dummy React component. Instead of rendering as usual, the component will become a simple `<div />` (or other tag if `mockTagName` is provided) containing any provided children.
 
 > Note:
 >
@@ -147,7 +147,7 @@ Returns `true` if `element` is a React element whose type is of a React `compone
 isDOMComponent(instance)
 ```
 
-Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).
+Returns `true` if `instance` is a DOM component (such as a `<div />` or `<span />`).
 
 * * *
 
@@ -264,4 +264,3 @@ findRenderedComponentWithType(
 Same as [`scryRenderedComponentsWithType()`](#scryrenderedcomponentswithtype) but expects there to be one result and returns that one result, or throws exception if there is any other number of matches besides one.
 
 * * *
-

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -82,8 +82,8 @@ Let's recap what happens in this example:
 
 1. We call `ReactDOM.render()` with the `<Welcome name="Sara" />` element.
 2. React calls the `Welcome` component with `{name: 'Sara'}` as the props.
-3. Our `Welcome` component returns a `<h1>Hello, Sara</h1>` element as the result.
-4. React DOM efficiently updates the DOM to match `<h1>Hello, Sara</h1>`.
+3. Our `Welcome` component returns a `<h1>Hello, Sara</h1 />` element as the result.
+4. React DOM efficiently updates the DOM to match `<h1>Hello, Sara</h1 />`.
 
 >**Caveat:**
 >

--- a/content/docs/composition-vs-inheritance.md
+++ b/content/docs/composition-vs-inheritance.md
@@ -46,7 +46,7 @@ function WelcomeDialog() {
 
 [Try it on CodePen.](https://codepen.io/gaearon/pen/ozqNOV?editors=0010)
 
-Anything inside the `<FancyBorder>` JSX tag gets passed into the `FancyBorder` component as a `children` prop. Since `FancyBorder` renders `{props.children}` inside a `<div>`, the passed elements appear in the final output.
+Anything inside the `<FancyBorder />` JSX tag gets passed into the `FancyBorder` component as a `children` prop. Since `FancyBorder` renders `{props.children}` inside a `<div />`, the passed elements appear in the final output.
 
 While this is less common, sometimes you might need multiple "holes" in a component. In such cases you may come up with your own convention instead of using `children`:
 

--- a/content/docs/cross-origin-errors.md
+++ b/content/docs/cross-origin-errors.md
@@ -16,7 +16,7 @@ You can simplify the development/debugging process by ensuring that errors are t
 
 ### CDN
 
-When loading React (or other libraries that might throw errors) from a CDN, add the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute to your `<script>` tags:
+When loading React (or other libraries that might throw errors) from a CDN, add the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute to your `<script />` tags:
 
 ```html
 <script crossorigin src="..."></script>
@@ -38,4 +38,4 @@ If you use Webpack, we recommend using the `cheap-module-source-map` setting in 
 
 If your application is split into multiple bundles, these bundles may be loaded using JSONP. This may cause errors thrown in the code of these bundles to be treated as cross-origin.
 
-To resolve this, use the [`crossOriginLoading`](https://webpack.js.org/configuration/output/#output-crossoriginloading) setting in development to add the `crossorigin` attribute to the `<script>` tags generated for the JSONP requests.
+To resolve this, use the [`crossOriginLoading`](https://webpack.js.org/configuration/output/#output-crossoriginloading) setting in development to add the `crossorigin` attribute to the `<script />` tags generated for the JSONP requests.

--- a/content/docs/design-principles.md
+++ b/content/docs/design-principles.md
@@ -69,7 +69,7 @@ This is why React provides escape hatches to work with mutable models, and tries
 
 ### Scheduling
 
-Even when your components are described as functions, when you use React you don't call them directly. Every component returns a [description of what needs to be rendered](/blog/2015/12/18/react-components-elements-and-instances.html#elements-describe-the-tree), and that description may include both user-written components like `<LikeButton>` and platform-specific components like `<div>`. It is up to React to "unroll" `<LikeButton>` at some point in the future and actually apply changes to the UI tree according to the render results of the components recursively.
+Even when your components are described as functions, when you use React you don't call them directly. Every component returns a [description of what needs to be rendered](/blog/2015/12/18/react-components-elements-and-instances.html#elements-describe-the-tree), and that description may include both user-written components like `<LikeButton />` and platform-specific components like `<div />`. It is up to React to "unroll" `<LikeButton />` at some point in the future and actually apply changes to the UI tree according to the render results of the components recursively.
 
 This is a subtle distinction but a powerful one. Since you don't call that component function but let React call it, it means React has the power to delay calling it if necessary. In its current implementation React walks the tree recursively and calls render functions of the whole updated tree during a single tick. However in the future it might start [delaying some updates to avoid dropping frames](https://github.com/facebook/react/issues/6170).
 

--- a/content/docs/faq-functions.md
+++ b/content/docs/faq-functions.md
@@ -106,7 +106,7 @@ method();
 
 Binding methods helps ensure that the second snippet works the same way as the first one.
 
-With React, typically you only need to bind the methods you *pass* to other components. For example, `<button onClick={this.handleClick}>` passes `this.handleClick` so you want to bind it. However, it is unnecessary to bind the `render` method or the lifecycle methods: we don't pass them to other components.
+With React, typically you only need to bind the methods you *pass* to other components. For example, `<button onClick={this.handleClick} />` passes `this.handleClick` so you want to bind it. However, it is unnecessary to bind the `render` method or the lifecycle methods: we don't pass them to other components.
 
 [This post by Yehuda Katz](http://yehudakatz.com/2011/08/11/understanding-javascript-function-invocation-and-this/) explains what binding is, and how functions work in JavaScript, in detail.
 

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -25,7 +25,7 @@ This form has the default HTML form behavior of browsing to a new page when the 
 
 ## Controlled Components
 
-In HTML, form elements such as `<input>`, `<textarea>`, and `<select>` typically maintain their own state and update it based on user input. In React, mutable state is typically kept in the state property of components, and only updated with [`setState()`](/docs/react-component.html#setstate).
+In HTML, form elements such as `<input />`, `<textarea />`, and `<select />` typically maintain their own state and update it based on user input. In React, mutable state is typically kept in the state property of components, and only updated with [`setState()`](/docs/react-component.html#setstate).
 
 We can combine the two by making the React state be the "single source of truth". Then the React component that renders a form also controls what happens in that form on subsequent user input. An input form element whose value is controlled by React in this way is called a "controlled component".
 
@@ -78,7 +78,7 @@ handleChange(event) {
 
 ## The textarea Tag
 
-In HTML, a `<textarea>` element defines its text by its children:
+In HTML, a `<textarea />` element defines its text by its children:
 
 ```html
 <textarea>
@@ -86,7 +86,7 @@ In HTML, a `<textarea>` element defines its text by its children:
 </textarea>
 ```
 
-In React, a `<textarea>` uses a `value` attribute instead. This way, a form using a `<textarea>` can be written very similarly to a form that uses a single-line input:
+In React, a `<textarea />` uses a `value` attribute instead. This way, a form using a `<textarea />` can be written very similarly to a form that uses a single-line input:
 
 ```javascript{4-6,12-14,26}
 class EssayForm extends React.Component {
@@ -127,7 +127,7 @@ Notice that `this.state.value` is initialized in the constructor, so that the te
 
 ## The select Tag
 
-In HTML, `<select>` creates a drop-down list. For example, this HTML creates a drop-down list of flavors:
+In HTML, `<select />` creates a drop-down list. For example, this HTML creates a drop-down list of flavors:
 
 ```html
 <select>
@@ -180,15 +180,15 @@ class FlavorForm extends React.Component {
 
 [Try it on CodePen.](https://codepen.io/gaearon/pen/JbbEzX?editors=0010)
 
-Overall, this makes it so that `<input type="text">`, `<textarea>`, and `<select>` all work very similarly - they all accept a `value` attribute that you can use to implement a controlled component.
+Overall, this makes it so that `<input type="text" />`, `<textarea />`, and `<select />` all work very similarly - they all accept a `value` attribute that you can use to implement a controlled component.
 
 > Note
 >
 > You can pass an array into the `value` attribute, allowing you to select multiple options in a `select` tag:
 >
->```js
+ />```js
 ><select multiple={true} value={['B', 'C']}>
->```
+ />```
 
 ## Handling Multiple Inputs
 

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -109,7 +109,7 @@ Then, you can run several commands:
 * `yarn linc` is like `yarn lint` but faster because it only checks files that differ in your branch.
 * `yarn test` runs the complete test suite.
 * `yarn test --watch` runs an interactive test watcher.
-* `yarn test <pattern>` runs tests with matching filenames.
+* `yarn test <pattern />` runs tests with matching filenames.
 * `yarn test-prod` runs tests in the production environment. It supports all the same options as `yarn test`.
 * `yarn flow` runs the [Flow](https://flowtype.org/) typechecks.
 * `yarn build` creates a `build` folder with all the packages.

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -129,7 +129,7 @@ There is no user-defined code associated with host elements.
 
 When the reconciler encounters a host element, it lets the renderer take care of mounting it. For example, React DOM would create a DOM node.
 
-If the host element has children, the reconciler recursively mounts them following the same algorithm as above. It doesn't matter whether children are host (like `<div><hr /></div>`), composite (like `<div><Button /></div>`), or both.
+If the host element has children, the reconciler recursively mounts them following the same algorithm as above. It doesn't matter whether children are host (like `<div><hr /></div />`), composite (like `<div><Button /></div />`), or both.
 
 The DOM nodes produced by the child components will be appended to the parent DOM node, and recursively, the complete DOM structure will be assembled.
 
@@ -375,7 +375,7 @@ class DOMComponent {
 
 The main difference after refactoring from `mountHost()` is that we now keep `this.node` and `this.renderedChildren` associated with the internal DOM component instance. We will also use them for applying non-destructive updates in the future.
 
-As a result, each internal instance, composite or host, now points to its child internal instances. To help visualize this, if a functional `<App>` component renders a `<Button>` class component, and `Button` class renders a `<div>`, the internal instance tree would look like this:
+As a result, each internal instance, composite or host, now points to its child internal instances. To help visualize this, if a functional `<App />` component renders a `<Button />` class component, and `Button` class renders a `<div />`, the internal instance tree would look like this:
 
 ```js
 [object CompositeComponent] {
@@ -393,7 +393,7 @@ As a result, each internal instance, composite or host, now points to its child 
 }
 ```
 
-In the DOM you would only see the `<div>`. However the internal instance tree contains both composite and host internal instances.
+In the DOM you would only see the `<div />`. However the internal instance tree contains both composite and host internal instances.
 
 The composite internal instances need to store:
 
@@ -610,7 +610,7 @@ For example, if it returned `<Button color="red" />` the first time, and `<Butto
     // ...
 ```
 
-However, if the next rendered element has a different `type` than the previously rendered element, we can't update the internal instance. A `<button>` can't "become" an `<input>`.
+However, if the next rendered element has a different `type` than the previously rendered element, we can't update the internal instance. A `<button />` can't "become" an `<input />`.
 
 Instead, we have to unmount the existing internal instance and mount the new one corresponding to the rendered element type. For example, this is what happens when a component that previously rendered a `<button />` renders an `<input />`:
 

--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -111,7 +111,7 @@ ReactDOM.render(
 );
 ```
 
-This code renders into a DOM element with the id of `root`, so you need `<div id="root"></div>` somewhere in your HTML file.
+This code renders into a DOM element with the id of `root`, so you need `<div id="root"></div />` somewhere in your HTML file.
 
 Similarly, you can render a React component inside a DOM element somewhere inside your existing app written with any other JavaScript UI library.
 

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -43,7 +43,7 @@ Note that we defined both `componentDidMount` and `componentWillUnmount` [lifecy
 
 ### Integrating with jQuery Chosen Plugin
 
-For a more concrete example of these concepts, let's write a minimal wrapper for the plugin [Chosen](https://harvesthq.github.io/chosen/), which augments `<select>` inputs.
+For a more concrete example of these concepts, let's write a minimal wrapper for the plugin [Chosen](https://harvesthq.github.io/chosen/), which augments `<select />` inputs.
 
 >**Note:**
 >
@@ -51,9 +51,9 @@ For a more concrete example of these concepts, let's write a minimal wrapper for
 
 First, let's look at what Chosen does to the DOM.
 
-If you call it on a `<select>` DOM node, it reads the attributes off of the original DOM node, hides it with an inline style, and then appends a separate DOM node with its own visual representation right after the `<select>`. Then it fires jQuery events to notify us about the changes.
+If you call it on a `<select />` DOM node, it reads the attributes off of the original DOM node, hides it with an inline style, and then appends a separate DOM node with its own visual representation right after the `<select />`. Then it fires jQuery events to notify us about the changes.
 
-Let's say that this is the API we're striving for with our `<Chosen>` wrapper React component:
+Let's say that this is the API we're striving for with our `<Chosen />` wrapper React component:
 
 ```js
 function Example() {
@@ -69,7 +69,7 @@ function Example() {
 
 We will implement it as an [uncontrolled component](/docs/uncontrolled-components.html) for simplicity.
 
-First, we will create an empty component with a `render()` method where we return `<select>` wrapped in a `<div>`:
+First, we will create an empty component with a `render()` method where we return `<select />` wrapped in a `<div />`:
 
 ```js{4,5}
 class Chosen extends React.Component {
@@ -85,9 +85,9 @@ class Chosen extends React.Component {
 }
 ```
 
-Notice how we wrapped `<select>` in an extra `<div>`. This is necessary because Chosen will append another DOM element right after the `<select>` node we passed to it. However, as far as React is concerned, `<div>` always only has a single child. This is how we ensure that React updates won't conflict with the extra DOM node appended by Chosen. It is important that if you modify the DOM outside of React flow, you must ensure React doesn't have a reason to touch those DOM nodes.
+Notice how we wrapped `<select />` in an extra `<div />`. This is necessary because Chosen will append another DOM element right after the `<select />` node we passed to it. However, as far as React is concerned, `<div />` always only has a single child. This is how we ensure that React updates won't conflict with the extra DOM node appended by Chosen. It is important that if you modify the DOM outside of React flow, you must ensure React doesn't have a reason to touch those DOM nodes.
 
-Next, we will implement the lifecycle hooks. We need to initialize Chosen with the ref to the `<select>` node in `componentDidMount`, and tear it down in `componentWillUnmount`:
+Next, we will implement the lifecycle hooks. We need to initialize Chosen with the ref to the `<select />` node in `componentDidMount`, and tear it down in `componentWillUnmount`:
 
 ```js{2,3,7}
 componentDidMount() {
@@ -108,7 +108,7 @@ Note that React assigns no special meaning to the `this.el` field. It only works
 <select className="Chosen-select" ref={el => this.el = el}>
 ```
 
-This is enough to get our component to render, but we also want to be notified about the value changes. To do this, we will subscribe to the jQuery `change` event on the `<select>` managed by Chosen.
+This is enough to get our component to render, but we also want to be notified about the value changes. To do this, we will subscribe to the jQuery `change` event on the `<select />` managed by Chosen.
 
 We won't pass `this.props.onChange` directly to Chosen because component's props might change over time, and that includes event handlers. Instead, we will declare a `handleChange()` method that calls `this.props.onChange`, and subscribe it to the jQuery `change` event:
 
@@ -133,9 +133,9 @@ handleChange(e) {
 
 [Try it on CodePen.](http://codepen.io/gaearon/pen/bWgbeE?editors=0010)
 
-Finally, there is one more thing left to do. In React, props can change over time. For example, the `<Chosen>` component can get different children if parent component's state changes. This means that at integration points it is important that we manually update the DOM in response to prop updates, since we no longer let React manage the DOM for us.
+Finally, there is one more thing left to do. In React, props can change over time. For example, the `<Chosen />` component can get different children if parent component's state changes. This means that at integration points it is important that we manually update the DOM in response to prop updates, since we no longer let React manage the DOM for us.
 
-Chosen's documentation suggests that we can use jQuery `trigger()` API to notify it about changes to the original DOM element. We will let React take care of updating `this.props.children` inside `<select>`, but we will also add a `componentDidUpdate()` lifecycle hook that notifies Chosen about changes in the children list:
+Chosen's documentation suggests that we can use jQuery `trigger()` API to notify it about changes to the original DOM element. We will let React take care of updating `this.props.children` inside `<select />`, but we will also add a `componentDidUpdate()` lifecycle hook that notifies Chosen about changes in the children list:
 
 ```js{2,3}
 componentDidUpdate(prevProps) {
@@ -145,7 +145,7 @@ componentDidUpdate(prevProps) {
 }
 ```
 
-This way, Chosen will know to update its DOM element when the `<select>` children managed by React change.
+This way, Chosen will know to update its DOM element when the `<select />` children managed by React change.
 
 The complete implementation of the `Chosen` component looks like this:
 
@@ -227,7 +227,7 @@ ReactDOM.render(
 );
 ```
 
-From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system](/docs/handling-events.html) and register the click handler directly on the React `<button>` element:
+From here you could start moving more logic into the component and begin adopting more common React practices. For example, in components it is best not to rely on IDs because the same component can be rendered multiple times. Instead, we will use the [React event system](/docs/handling-events.html) and register the click handler directly on the React `<button />` element:
 
 ```js{2,6,9}
 function Button(props) {
@@ -255,7 +255,7 @@ You can have as many such isolated components as you like, and use `ReactDOM.ren
 
 [Backbone](http://backbonejs.org/) views typically use HTML strings, or string-producing template functions, to create the content for their DOM elements. This process, too, can be replaced with rendering a React component.
 
-Below, we will create a Backbone view called `ParagraphView`. It will override Backbone's `render()` function to render a React `<Paragraph>` component into the DOM element provided by Backbone (`this.el`). Here, too, we are using [`ReactDOM.render()`](/docs/react-dom.html#render):
+Below, we will create a Backbone view called `ParagraphView`. It will override Backbone's `render()` function to render a React `<Paragraph />` component into the DOM element provided by Backbone (`this.el`). Here, too, we are using [`ReactDOM.render()`](/docs/react-dom.html#render):
 
 ```js{1,5,8,12}
 function Paragraph(props) {

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -71,7 +71,7 @@ function WarningButton() {
 }
 ```
 
-If you don't use a JavaScript bundler and loaded React from a `<script>` tag, it is already in scope as the `React` global.
+If you don't use a JavaScript bundler and loaded React from a `<script />` tag, it is already in scope as the `React` global.
 
 ### Using Dot Notation for JSX Type
 
@@ -93,7 +93,7 @@ function BlueDatePicker() {
 
 ### User-Defined Components Must Be Capitalized
 
-When an element type starts with a lowercase letter, it refers to a built-in component like `<div>` or `<span>` and results in a string `'div'` or `'span'` passed to `React.createElement`. Types that start with a capital letter like `<Foo />` compile to `React.createElement(Foo)` and correspond to a component defined or imported in your JavaScript file.
+When an element type starts with a lowercase letter, it refers to a built-in component like `<div />` or `<span />` and results in a string `'div'` or `'span'` passed to `React.createElement`. Types that start with a capital letter like `<Foo />` compile to `React.createElement(Foo)` and correspond to a component defined or imported in your JavaScript file.
 
 We recommend naming components with a capital letter. If you do have a component that starts with a lowercase letter, assign it to a capitalized variable before using it in JSX.
 
@@ -265,7 +265,7 @@ const App = () => {
 };
 ```
 
-In the example above, the `kind` prop is safely consumed and *is not* passed on to the `<button>` element in the DOM.
+In the example above, the `kind` prop is safely consumed and *is not* passed on to the `<button />` element in the DOM.
 All other props are passed via the `...other` object making this component really flexible. You can see that it passes an `onClick` and `children` props.
 
 Spread attributes can be useful but they also make it easy to pass unnecessary props to components that don't care about them or to pass invalid HTML attributes to the DOM. We recommend using this syntax sparingly.  

--- a/content/docs/lifting-state-up.md
+++ b/content/docs/lifting-state-up.md
@@ -24,7 +24,7 @@ function BoilingVerdict(props) {
 }
 ```
 
-Next, we will create a component called `Calculator`. It renders an `<input>` that lets you enter the temperature, and keeps its value in `this.state.temperature`.
+Next, we will create a component called `Calculator`. It renders an `<input />` that lets you enter the temperature, and keeps its value in `this.state.temperature`.
 
 Additionally, it renders the `BoilingVerdict` for the current input value.
 
@@ -188,7 +188,7 @@ First, we will replace `this.state.temperature` with `this.props.temperature` in
 
 We know that [props are read-only](/docs/components-and-props.html#props-are-read-only). When the `temperature` was in the local state, the `TemperatureInput` could just call `this.setState()` to change it. However, now that the `temperature` is coming from the parent as a prop, the `TemperatureInput` has no control over it.
 
-In React, this is usually solved by making a component "controlled". Just like the DOM `<input>` accepts both a `value` and an `onChange` prop, so can the custom `TemperatureInput` accept both `temperature` and `onTemperatureChange` props from its parent `Calculator`.
+In React, this is usually solved by making a component "controlled". Just like the DOM `<input />` accepts both a `value` and an `onChange` prop, so can the custom `TemperatureInput` accept both `temperature` and `onTemperatureChange` props from its parent `Calculator`.
 
 Now, when the `TemperatureInput` wants to update its temperature, it calls `this.props.onTemperatureChange`:
 
@@ -305,7 +305,7 @@ Now, no matter which input you edit, `this.state.temperature` and `this.state.sc
 
 Let's recap what happens when you edit an input:
 
-* React calls the function specified as `onChange` on the DOM `<input>`. In our case, this is the `handleChange` method in `TemperatureInput` component.
+* React calls the function specified as `onChange` on the DOM `<input />`. In our case, this is the `handleChange` method in `TemperatureInput` component.
 * The `handleChange` method in the `TemperatureInput` component calls `this.props.onTemperatureChange()` with the new desired value. Its props, including `onTemperatureChange`, were provided by its parent component, the `Calculator`.
 * When it previously rendered, the `Calculator` has specified that `onTemperatureChange` of the Celsius `TemperatureInput` is the `Calculator`'s `handleCelsiusChange` method, and `onTemperatureChange` of the Fahrenheit `TemperatureInput` is the `Calculator`'s `handleFahrenheitChange` method. So either of these two `Calculator` methods gets called depending on which input we edited.
 * Inside these methods, the `Calculator` component asks React to re-render itself by calling `this.setState()` with the new input value and the current scale of the input we just edited.

--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -24,7 +24,7 @@ In React, transforming arrays into lists of [elements](/docs/rendering-elements.
 
 You can build collections of elements and [include them in JSX](/docs/introducing-jsx.html#embedding-expressions-in-jsx) using curly braces `{}`.
 
-Below, we loop through the `numbers` array using the JavaScript [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function. We return an `<li>` element for each item. Finally, we assign the resulting array of elements to `listItems`:
+Below, we loop through the `numbers` array using the JavaScript [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function. We return an `<li />` element for each item. Finally, we assign the resulting array of elements to `listItems`:
 
 ```javascript{2-4}
 const numbers = [1, 2, 3, 4, 5];
@@ -33,7 +33,7 @@ const listItems = numbers.map((number) =>
 );
 ```
 
-We include the entire `listItems` array inside a `<ul>` element, and [render it to the DOM](/docs/rendering-elements.html#rendering-an-element-into-the-dom):
+We include the entire `listItems` array inside a `<ul />` element, and [render it to the DOM](/docs/rendering-elements.html#rendering-an-element-into-the-dom):
 
 ```javascript{2}
 ReactDOM.render(
@@ -136,7 +136,7 @@ We don't recommend using indexes for keys if the order of items may change. This
 
 Keys only make sense in the context of the surrounding array.
 
-For example, if you [extract](/docs/components-and-props.html#extracting-components) a `ListItem` component, you should keep the key on the `<ListItem />` elements in the array rather than on the root `<li>` element in the `ListItem` itself.
+For example, if you [extract](/docs/components-and-props.html#extracting-components) a `ListItem` component, you should keep the key on the `<ListItem />` elements in the array rather than on the root `<li />` element in the `ListItem` itself.
 
 **Example: Incorrect Key Usage**
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -25,7 +25,7 @@ When diffing two trees, React first compares the two root elements. The behavior
 
 ### Elements Of Different Types
 
-Whenever the root elements have different types, React will tear down the old tree and build the new tree from scratch. Going from `<a>` to `<img>`, or from `<Article>` to `<Comment>`, or from `<Button>` to `<div>` - any of those will lead to a full rebuild.
+Whenever the root elements have different types, React will tear down the old tree and build the new tree from scratch. Going from `<a />` to `<img />`, or from `<Article />` to `<Comment />`, or from `<Button />` to `<div />` - any of those will lead to a full rebuild.
 
 When tearing down a tree, old DOM nodes are destroyed. Component instances receive `componentWillUnmount()`. When building up a new tree, new DOM nodes are inserted into the DOM. Component instances receive `componentWillMount()` and then `componentDidMount()`. Any state associated with the old tree is lost.
 
@@ -92,7 +92,7 @@ For example, when adding an element at the end of the children, converting betwe
 </ul>
 ```
 
-React will match the two `<li>first</li>` trees, match the two `<li>second</li>` trees, and then insert the `<li>third</li>` tree.
+React will match the two `<li>first</li />` trees, match the two `<li>second</li />` trees, and then insert the `<li>third</li />` tree.
 
 If you implement it naively, inserting an element at the beginning has worse performance. For example, converting between these two trees works poorly:
 
@@ -109,7 +109,7 @@ If you implement it naively, inserting an element at the beginning has worse per
 </ul>
 ```
 
-React will mutate every child instead of realizing it can keep the `<li>Duke</li>` and `<li>Villanova</li>` subtrees intact. This inefficiency can be a problem.
+React will mutate every child instead of realizing it can keep the `<li>Duke</li />` and `<li>Villanova</li />` subtrees intact. This inefficiency can be a problem.
 
 ### Keys
 

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -24,11 +24,11 @@ There are a number of attributes that work differently between React and HTML:
 
 ### checked
 
-The `checked` attribute is supported by `<input>` components of type `checkbox` or `radio`. You can use it to set whether the component is checked. This is useful for building controlled components. `defaultChecked` is the uncontrolled equivalent, which sets whether the component is checked when it is first mounted.
+The `checked` attribute is supported by `<input />` components of type `checkbox` or `radio`. You can use it to set whether the component is checked. This is useful for building controlled components. `defaultChecked` is the uncontrolled equivalent, which sets whether the component is checked when it is first mounted.
 
 ### className
 
-To specify a CSS class, use the `className` attribute. This applies to all regular DOM and SVG elements like `<div>`, `<a>`, and others.
+To specify a CSS class, use the `className` attribute. This applies to all regular DOM and SVG elements like `<div />`, `<a />`, and others.
 
 If you use React with Web Components (which is uncommon), use the `class` attribute instead.
 
@@ -56,7 +56,7 @@ The `onChange` event behaves as you would expect it to: whenever a form field is
 
 ### selected
 
-The `selected` attribute is supported by `<option>` components. You can use it to set whether the component is selected. This is useful for building controlled components.
+The `selected` attribute is supported by `<option />` components. You can use it to set whether the component is selected. This is useful for building controlled components.
 
 ### style
 
@@ -120,7 +120,7 @@ Normally, there is a warning when an element with children is also marked as `co
 
 ### value
 
-The `value` attribute is supported by `<input>` and `<textarea>` components. You can use it to set the value of the component. This is useful for building controlled components. `defaultValue` is the uncontrolled equivalent, which sets the value of the component when it is first mounted.
+The `value` attribute is supported by `<input />` and `<textarea />` components. You can use it to set the value of the component. This is useful for building controlled components. `defaultValue` is the uncontrolled equivalent, which sets the value of the component when it is first mounted.
 
 ## All Supported HTML Attributes
 

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -6,7 +6,7 @@ category: Reference
 permalink: docs/react-dom.html
 ---
 
-If you load React from a `<script>` tag, these top-level APIs are available on the `ReactDOM` global. If you use ES6 with npm, you can write `import ReactDOM from 'react-dom'`. If you use ES5 with npm, you can write `var ReactDOM = require('react-dom')`.
+If you load React from a `<script />` tag, these top-level APIs are available on the `ReactDOM` global. If you use ES6 with npm, you can write `import ReactDOM from 'react-dom'`. If you use ES5 with npm, you can write `var ReactDOM = require('react-dom')`.
 
 ## Overview
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -13,7 +13,7 @@ redirect_from:
   - "docs/top-level-api-zh-CN.html"
 ---
 
-`React` is the entry point to the React library. If you load React from a `<script>` tag, these top-level APIs are available on the `React` global. If you use ES6 with npm, you can write `import React from 'react'`. If you use ES5 with npm, you can write `var React = require('react')`.
+`React` is the entry point to the React library. If you load React from a `<script />` tag, these top-level APIs are available on the `React` global. If you use ES6 with npm, you can write `import React from 'react'`. If you use ES5 with npm, you can write `var React = require('react')`.
 
 ## Overview
 
@@ -179,7 +179,7 @@ Verifies that `children` has only one child (a React element) and returns it. Ot
 
 > Note:
 >
->`React.Children.only()` does not accept the return value of [`React.Children.map()`](#reactchildrenmap) because it is an array rather than a React element.
+ />`React.Children.only()` does not accept the return value of [`React.Children.map()`](#reactchildrenmap) because it is an array rather than a React element.
 
 #### `React.Children.toArray`
 

--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -110,7 +110,7 @@ Create a `TestRenderer` instance with the passed React element. It doesn't use t
 testRenderer.toJSON()
 ```
 
-Return an object representing the rendered tree. This tree only contains the platform-specific nodes like `<div>` or `<View>` and their props, but doesn't contain any user-written components. This is handy for [snapshot testing](http://facebook.github.io/jest/docs/en/snapshot-testing.html#snapshot-testing-with-jest).
+Return an object representing the rendered tree. This tree only contains the platform-specific nodes like `<div />` or `<View />` and their props, but doesn't contain any user-written components. This is handy for [snapshot testing](http://facebook.github.io/jest/docs/en/snapshot-testing.html#snapshot-testing-with-jest).
 
 ### `testRenderer.toTree()`
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -175,9 +175,9 @@ class Parent extends React.Component {
 }
 ```
 
-In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input />`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input />` element in the `CustomTextInput`.
 
-Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
+Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input />` itself is important, as it tells React to attach a ref to its DOM node.
 
 This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
 
@@ -212,7 +212,7 @@ class Grandparent extends React.Component {
 }
 ```
 
-Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input />`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input />` element in the `CustomTextInput`.
 
 All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
 

--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -23,7 +23,7 @@ Unlike browser DOM elements, React elements are plain objects, and are cheap to 
 
 ## Rendering an Element into the DOM
 
-Let's say there is a `<div>` somewhere in your HTML file:
+Let's say there is a `<div />` somewhere in your HTML file:
 
 ```html
 <div id="root"></div>

--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -446,7 +446,7 @@ This is commonly called a "top-down" or "unidirectional" data flow. Any state is
 
 If you imagine a component tree as a waterfall of props, each component's state is like an additional water source that joins it at an arbitrary point but also flows down.
 
-To show that all components are truly isolated, we can create an `App` component that renders three `<Clock>`s:
+To show that all components are truly isolated, we can create an `App` component that renders three `<Clock />`s:
 
 ```js{4-6}
 function App() {

--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -63,4 +63,4 @@ render() {
 }
 ```
 
-Likewise, `<input type="checkbox">` and `<input type="radio">` support `defaultChecked`, and `<select>` and `<textarea>` supports `defaultValue`.
+Likewise, `<input type="checkbox" />` and `<input type="radio" />` support `defaultChecked`, and `<select />` and `<textarea />` supports `defaultValue`.


### PR DESCRIPTION
Hi!

I am not really sure if this is a valid PR. The reason for this PR was, that I was confused about the annotation. 
In some places I found `<div>`, in other places `<div />`. Same goes for React components. 

Since I couldn't recognise what pattern you guys followed, I just made this PR. This will change all `<*>` to `<* />` in the docs.