### PR TITLE
Note that polyfills are required for some supported browsers too.

### DIFF
--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -20,7 +20,7 @@ The `react-dom` package provides DOM-specific methods that can be used at the to
 
 ### Browser Support
 
-React supports all popular browsers, including Internet Explorer 9 and above, although [some polyfills are required](docs/javascript-environment-requirements.html) for older browsers.
+React supports all popular browsers, including Internet Explorer 9 and above, although [some polyfills are required](/docs/javascript-environment-requirements.html) for older browsers.
 
 > Note
 >

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -20,7 +20,7 @@ The `react-dom` package provides DOM-specific methods that can be used at the to
 
 ### Browser Support
 
-React supports all popular browsers, including Internet Explorer 9 and above.
+React supports all popular browsers, including Internet Explorer 9 and above, although [some polyfills are required](docs/javascript-environment-requirements.html) for older browsers.
 
 > Note
 >


### PR DESCRIPTION
The "Browser Support" section of react-dom indicates that IE9 and above
is supported, but fails to note that the support does require additional
polyfills in some cases.  A link is added to the javascript environment
docs which already explains the polyfills required (Map, Set and rAF).

Fixes #361
