### PR TITLE
Reword the note about ESLint fragment support

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -229,7 +229,7 @@ to update Flow to the latest version.
 
 ### ESLint
 
-JSX Fragments are supported by [ESLint](https://eslint.org/) via [babel-eslint](https://github.com/babel/babel-eslint)! If you are not currently using it, then install it:
+JSX Fragments are supported by [ESLint](https://eslint.org/) 3.x when it is used together with [babel-eslint](https://github.com/babel/babel-eslint):
 
 ```bash
 # for yarn users
@@ -254,6 +254,8 @@ Ensure you have the following line inside your `.babelrc`:
 ```
 
 That's it!
+
+Note that `babel-eslint` is not officially supported by ESLint. We'll be looking into adding support for fragments to ESLint 4.x itself in the coming weeks.
 
 ### Editor Support
 


### PR DESCRIPTION
This way it doesn't seem like we're telling their users to downgrade for us.