### PR TITLE
Missing comma in blog/2017-11-28-react-v16.2.0-fragment-support

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -57,7 +57,7 @@ render() {
  return [
   "Some text.",
   <h2 key="heading-1">A heading</h2>,
-  "More text."
+  "More text.",
   <h2 key="heading-2">Another heading</h2>,
   "Even more text."
  ];


### PR DESCRIPTION
Children in an array must be separated by commas – but a comma was missing in the middle of the example.