### PR TITLE
Amend config's file name

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -247,7 +247,7 @@ yarn upgrade eslint@3.x babel-eslint@7
 npm update eslint@3.x babel-eslint@7
 ```
 
-Ensure you have the following line inside your `.babelrc`:
+Ensure you have the following line inside your `.eslintrc`:
 
 ```json
 "parser": "babel-eslint"


### PR DESCRIPTION
I believe the `parser` option exists in `.eslintrc` but not in `.babelrc`.