### PR TITLE
missing bracket in Keyed Fragments example

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -145,7 +145,7 @@ function Glossary(props) {
           <dt>{item.term}</dt>
           <dd>{item.description}</dd>
         </Fragment>
-      )}
+      ))}
     </dl>
   );
 }


### PR DESCRIPTION
Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
