### PR TITLE
Remove "use strict" from source files

### DIFF
--- a/src/components/ButtonLink/ButtonLink.js
+++ b/src/components/ButtonLink/ButtonLink.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, media} from 'theme';

--- a/src/components/ButtonLink/index.js
+++ b/src/components/ButtonLink/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import ButtonLink from './ButtonLink';
 
 export default ButtonLink;

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import Remarkable from 'remarkable';

--- a/src/components/CodeEditor/index.js
+++ b/src/components/CodeEditor/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import CodeEditor from './CodeEditor';
 
 export default CodeEditor;

--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 
 import {media} from 'theme';

--- a/src/components/Container/index.js
+++ b/src/components/Container/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Container from './Container';
 
 export default Container;

--- a/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/src/components/ErrorDecoder/ErrorDecoder.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 
 import type {Node} from 'react';

--- a/src/components/ErrorDecoder/index.js
+++ b/src/components/ErrorDecoder/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import ErrorDecoder from './ErrorDecoder';
 
 export default ErrorDecoder;

--- a/src/components/Flex/Flex.js
+++ b/src/components/Flex/Flex.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import {createElement} from 'glamor/react';
 
 import type {Node} from 'react';

--- a/src/components/Flex/index.js
+++ b/src/components/Flex/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Flex from './Flex';
 
 export default Flex;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 import {colors, fonts} from 'theme';
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Header from './Header';
 
 export default Header;

--- a/src/components/LayoutFooter/ExternalFooterLink.js
+++ b/src/components/LayoutFooter/ExternalFooterLink.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 import {colors} from 'theme';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';

--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import ExternalFooterLink from './ExternalFooterLink';
 import FooterLink from './FooterLink';

--- a/src/components/LayoutFooter/FooterLink.js
+++ b/src/components/LayoutFooter/FooterLink.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors} from 'theme';

--- a/src/components/LayoutFooter/FooterNav.js
+++ b/src/components/LayoutFooter/FooterNav.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 import {media} from 'theme';
 

--- a/src/components/LayoutFooter/index.js
+++ b/src/components/LayoutFooter/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Footer from './Footer';
 
 export default Footer;

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import HeaderLink from './HeaderLink';
 import Link from 'gatsby-link';

--- a/src/components/LayoutHeader/HeaderLink.js
+++ b/src/components/LayoutHeader/HeaderLink.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, media} from 'theme';

--- a/src/components/LayoutHeader/SearchSvg.js
+++ b/src/components/LayoutHeader/SearchSvg.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React from 'react';
 
 const SearchSvg = () => (

--- a/src/components/LayoutHeader/index.js
+++ b/src/components/LayoutHeader/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Header from './Header';
 
 export default Header;

--- a/src/components/MarkdownHeader/MarkdownHeader.js
+++ b/src/components/MarkdownHeader/MarkdownHeader.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Flex from 'components/Flex';
 import React from 'react';
 import {colors, fonts, media} from 'theme';

--- a/src/components/MarkdownHeader/index.js
+++ b/src/components/MarkdownHeader/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import MarkdownHeader from './MarkdownHeader';
 
 export default MarkdownHeader;

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';

--- a/src/components/MarkdownPage/index.js
+++ b/src/components/MarkdownPage/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import MarkdownPage from './MarkdownPage';
 
 export default MarkdownPage;

--- a/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import React, {Component} from 'react';
 import Sidebar from 'templates/components/Sidebar';

--- a/src/components/StickyResponsiveSidebar/index.js
+++ b/src/components/StickyResponsiveSidebar/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import StickyResponsiveSidebar from './StickyResponsiveSidebar';
 
 export default StickyResponsiveSidebar;

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Helmet from 'react-helmet';
 import React from 'react';
 

--- a/src/components/TitleAndMetaTags/index.js
+++ b/src/components/TitleAndMetaTags/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import TitleAndMetaTags from './TitleAndMetaTags';
 
 export default TitleAndMetaTags;

--- a/src/html.js
+++ b/src/html.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React, {Component} from 'react';
 
 let stylesStr;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 // Polyfills for IE
 import 'array-from';
 import 'string.prototype.includes';

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import Header from 'components/Header';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';

--- a/src/pages/acknowledgements.html.js
+++ b/src/pages/acknowledgements.html.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import Header from 'components/Header';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';

--- a/src/pages/blog/all.html.js
+++ b/src/pages/blog/all.html.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Link from 'gatsby-link';
 import Container from 'components/Container';
 import Header from 'components/Header';

--- a/src/pages/docs/error-decoder.html.js
+++ b/src/pages/docs/error-decoder.html.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import ErrorDecoder from 'components/ErrorDecoder';
 import Flex from 'components/Flex';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import ButtonLink from 'components/ButtonLink';
 import Container from 'components/Container';
 import Flex from 'components/Flex';

--- a/src/pages/jsx-compiler.html.js
+++ b/src/pages/jsx-compiler.html.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import Header from 'components/Header';
 import React from 'react';

--- a/src/prism-styles.js
+++ b/src/prism-styles.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import {css} from 'glamor';
 import {colors} from 'theme';
 

--- a/src/site-constants.js
+++ b/src/site-constants.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 // NOTE: We can't just use `location.toString()` because when we are rendering
 // the SSR part in node.js we won't have a proper location.
 const urlRoot = 'https://reactjs.org';

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import MarkdownPage from 'components/MarkdownPage';

--- a/src/templates/codepen-example.js
+++ b/src/templates/codepen-example.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, {Component} from 'react';
 import Container from 'components/Container';
 import {colors} from 'theme';

--- a/src/templates/community.js
+++ b/src/templates/community.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import MarkdownPage from 'components/MarkdownPage';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/templates/components/ChevronSvg/index.js
+++ b/src/templates/components/ChevronSvg/index.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 
 type Props = {

--- a/src/templates/components/ExternalLinkSvg/index.js
+++ b/src/templates/components/ExternalLinkSvg/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React from 'react';
 
 const ExternalLinkSvg = ({cssProps = {}}: {cssProps: Object}) => (

--- a/src/templates/components/MetaTitle/index.js
+++ b/src/templates/components/MetaTitle/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React from 'react';
 import {colors} from 'theme';
 

--- a/src/templates/components/NavigationFooter/NavigationFooter.js
+++ b/src/templates/components/NavigationFooter/NavigationFooter.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Container from 'components/Container';
 import Flex from 'components/Flex';
 import Link from 'gatsby-link';

--- a/src/templates/components/NavigationFooter/index.js
+++ b/src/templates/components/NavigationFooter/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import NavigationFooter from './NavigationFooter';
 
 export default NavigationFooter;

--- a/src/templates/components/Sidebar/ScrollSyncSection.js
+++ b/src/templates/components/Sidebar/ScrollSyncSection.js
@@ -7,8 +7,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React, {Component} from 'react';
 import Section from './Section';
 

--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React from 'react';
 import {colors, media} from 'theme';
 import isItemActive from 'utils/isItemActive';

--- a/src/templates/components/Sidebar/Sidebar.js
+++ b/src/templates/components/Sidebar/Sidebar.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import React, {Component} from 'react';
 import Flex from 'components/Flex';
 import Section from './Section';

--- a/src/templates/components/Sidebar/index.js
+++ b/src/templates/components/Sidebar/index.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import Sidebar from './Sidebar';
 
 export default Sidebar;

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import MarkdownPage from 'components/MarkdownPage';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import MarkdownPage from 'components/MarkdownPage';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 /**
  * Theme contains variables shared by styles of multiple components.
  */

--- a/src/utils/createLink.js
+++ b/src/utils/createLink.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import Link from 'gatsby-link';
 import React from 'react';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';

--- a/src/utils/createOgUrl.js
+++ b/src/utils/createOgUrl.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import {urlRoot} from 'site-constants';
 
 export default (slug: string): string | null =>

--- a/src/utils/findSectionForPath.js
+++ b/src/utils/findSectionForPath.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import slugify from './slugify';
 
 /**

--- a/src/utils/isItemActive.js
+++ b/src/utils/isItemActive.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import slugify from 'utils/slugify';
 
 const toAnchor = (href: string = ''): string => {

--- a/src/utils/loadScript.js
+++ b/src/utils/loadScript.js
@@ -7,8 +7,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 export default url =>
   new Promise((resolve, reject) =>
     document.head.appendChild(

--- a/src/utils/mountCodeExample.js
+++ b/src/utils/mountCodeExample.js
@@ -4,8 +4,6 @@
  * @emails react-core
  */
 
-'use strict';
-
 import CodeEditor from '../components/CodeEditor';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/utils/sectionList.js
+++ b/src/utils/sectionList.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 // $FlowExpectedError
 import navCommunity from '../../content/community/nav.yml';
 // $FlowExpectedError

--- a/src/utils/slugify.js
+++ b/src/utils/slugify.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import slugify from 'slugify';
 
 export default (string: string, directory?: string): string => {

--- a/src/utils/toCommaSeparatedList.js
+++ b/src/utils/toCommaSeparatedList.js
@@ -5,8 +5,6 @@
  * @flow
  */
 
-'use strict';
-
 import React from 'react';
 
 import type {Node} from 'react';


### PR DESCRIPTION
This pull request will remove `'use strict';` from all JavaScript files in the `src` directory. See #376 for more info.
