### PR TITLE
Parentheses instead of parens

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -377,7 +377,7 @@ The usual pattern here is pass down a function from Board to Square that gets ca
   }
 ```
 
-We split the returned element into multiple lines for readability, and added parens around it so that JavaScript doesn't insert a semicolon after `return` and break our code.
+We split the returned element into multiple lines for readability, and added parentheses around it so that JavaScript doesn't insert a semicolon after `return` and break our code.
 
 Now we're passing down two props from Board to Square: `value` and `onClick`. The latter is a function that Square can call. Let's make the following changes to Square:
 


### PR DESCRIPTION
Just a small typo, I think. 
Unless parens is an accepted short form of parentheses? 
*(Edit: just found out that it is)*

I ended up reading it as parents and kept finding what "parents" did it add. 

**Edit:** Just came across http://www.dictionary.com/browse/parens, but would still advocate the use of the full word "parentheses". If it tripped me off, I believe it might trip others as well. 