### PR TITLE
fix typo in community/ui-components page heading

### DIFF
--- a/content/community/tools-ui-components.md
+++ b/content/community/tools-ui-components.md
@@ -1,6 +1,6 @@
 ---
 id: ui-components
-title: UI Componets
+title: UI Components
 layout: community
 permalink: community/ui-components.html
 ---


### PR DESCRIPTION
This PR fixes a typo in the heading on this page: https://reactjs.org/community/ui-components.html