### PR TITLE
Change EssayForm label text to match example

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -113,7 +113,7 @@ class EssayForm extends React.Component {
     return (
       <form onSubmit={this.handleSubmit}>
         <label>
-          Name:
+          Essay:
           <textarea value={this.state.value} onChange={this.handleChange} />
         </label>
         <input type="submit" value="Submit" />


### PR DESCRIPTION
The previous example on this page for Forms includes a form for submitting names. The textarea example is for submitting an essay, so it makes sense to update the label! Small change, just something that tripped me up for a sec in reading the Quick Start guide.
