### PR TITLE
Update `React.PureComponent` reference.

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -71,9 +71,9 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 
 ### `React.PureComponent`
 
-`React.PureComponent` is exactly like [`React.Component`](#reactcomponent), but implements [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) with a shallow prop and state comparison.
+`React.PureComponent` is exactly like [`React.Component`](#reactcomponent), but implements [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) with a shallow prop and state comparison, which [`React.Component`](#reactcomponent) is missing completely. 
 
-If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
+If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases. 
 
 > Note
 >

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -70,8 +70,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 * * *
 
 ### `React.PureComponent`
-
-`React.PureComponent` is exactly like [`React.Component`](#reactcomponent), but implements [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) with a shallow prop and state comparison, which [`React.Component`](#reactcomponent) is missing completely. 
+`React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) doesn't implement [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate), but `React.PureComponent` implements it with a shallow prop and state comparison. 
 
 If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -70,6 +70,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 * * *
 
 ### `React.PureComponent`
+
 `React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) doesn't implement [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate), but `React.PureComponent` implements it with a shallow prop and state comparison. 
 
 If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -73,7 +73,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 
 `React.PureComponent` is exactly like [`React.Component`](#reactcomponent), but implements [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate) with a shallow prop and state comparison, which [`React.Component`](#reactcomponent) is missing completely. 
 
-If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases. 
+If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
 
 > Note
 >


### PR DESCRIPTION
Maybe I'm somehow weird, but I lived for some time with an idea that `React.Component` does implement `shouldComponentUpdate` with deep comparison. `React.PureComponent` is faster because it compares shallowly.

The changes I propose should avoid this "implicit" kind of way of thinking, since it would explicitly state that `React.Component` does not compare anything.

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
