### PR TITLE
Clarify Component capital letter caveat example.

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -87,9 +87,9 @@ Let's recap what happens in this example:
 
 >**Caveat:**
 >
->Always start component names with a capital letter.
+> Always start component names with a capital letter.
 >
->For example, `<div />` represents a DOM tag, but `<Welcome />` represents a component and requires the capital 'W' in `Welcome` to be in scope.
+> React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
 
 ## Composing Components
 

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -87,9 +87,9 @@ Let's recap what happens in this example:
 
 >**Caveat:**
 >
-> Always start component names with a capital letter.
+>Always start component names with a capital letter.
 >
-> React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
+>React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
 
 ## Composing Components
 

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -89,7 +89,7 @@ Let's recap what happens in this example:
 >
 >Always start component names with a capital letter.
 >
->For example, `<div />` represents a DOM tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
+>For example, `<div />` represents a DOM tag, but `<Welcome />` represents a component and requires the capital 'W' in `Welcome` to be in scope.
 
 ## Composing Components
 


### PR DESCRIPTION
Added "...the capital 'W' in..." to help reader focus their attention on the capital 'W' within `Welcome` for minor clarity improvement.

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
