### PR TITLE
Clean up "Starter Kits"

### DIFF
--- a/content/community/tools-starter-kits.md
+++ b/content/community/tools-starter-kits.md
@@ -14,83 +14,22 @@ permalink: community/starter-kits.html
 * **[razzle](https://github.com/jaredpalmer/razzle)** - Create server-rendered universal JavaScript applications with no configuration
 * **[Neutrino](https://neutrino.js.org/)** - Create and build modern JavaScript applications with zero initial configuration
 
-## Client-side Kits
+## Other Starter Kits
 
 * **[kyt](https://github.com/nytimes/kyt)** - The framework that the New York Times uses to develop and build their web properties. It's somewhat opinionated but configurable, and includes starter kits with options to build full-stack or static/client-side apps with the following tools: Express, React, static assets, latest ES, CSS/Sass Modules, Jest, code-splitting, ESLint/Prettier, StyleLint, PostCSS, and inline SVGs.
-* **[React CDK](https://github.com/kadirahq/react-cdk)** - Component Development Kit for React
-* **[React Static Boilerplate](https://github.com/koistya/react-static-boilerplate):** Static site generator based on React, Gulp/Webpack, React Hot Loader, Babel, postCSS/cssnext. Best suited for deploying React.js site to GitHub Pages or Amazon S3.
-* **[React Redux Boilerplate](https://github.com/iroy2000/react-redux-boilerplate):** React Redux Boilerplate is a workflow boilerplate that make life easier for developers by providing a virtual development environment and production ready build workflow out of the box.  ( React, Redux, Reselect, Redux Actions, ES6, ESLint, Webpack with integrated environment config support )
-* **[Create React App + Redux + React Router](https://github.com/notrab/create-react-app-redux)**: Based on Create React App, this boilerplate comes with Redux, Redux Thunk and React Router all configured ready to go.
-* **[React, TypeScript, JSPM starter-kit](https://github.com/piotrwitek/react-ts-jspm-starter-kit):** Unopinionated starter kit to build modular web apps with React & TypeScript powered by JSPM/SystemJS 0.17.X (ES2016, hot-reload, browser-sync, bundle for prod scripts)
-* **[Subschema](https://subschema.github.io/subschema)** - Subschema is a Dependency Injection Library for React, included is a project starter, with webpack, karma and babel.
+* **[React Redux Boilerplate](https://github.com/iroy2000/react-redux-boilerplate):** React Redux Boilerplate is a workflow boilerplate providing a virtual development environment and production ready build workflow out of the box. (React, Redux, Reselect, Redux Actions, ES6, ESLint, Webpack with integrated environment config support)
 * **[React + Redux + Saga Boilerplate](https://github.com/gilbarbara/react-redux-saga-boilerplate)** -
 Ready to grow boilerplate with react-router, redux, saga, webpack 2, jest w/ coverage and enzyme.
-* **[generator-enigma](https://www.npmjs.com/package/generator-enigma)** a minimalist React application scaffolding tool that sets up a ready-to-deploy web app, complete with testing via Jest and optional `react-router` boilerplate.
-* **[Component-Template](https://github.com/reactstrap/component-template)** - A create-react-app based starter kit for building, documenting, & publishing React Components. Includes React Router v4, Bootstrap 4 and Reactstrap.
+* **[Create React App + Redux + React Router](https://github.com/notrab/create-react-app-redux)**: Based on Create React App, this boilerplate comes with Redux, Redux Thunk and React Router all configured ready to go.
+* **[react-slingshot](https://github.com/coryhouse/react-slingshot):** React + Redux starter kit with Babel, hot reloading, testing, linting and a working example app.
+* **[Este](https://github.com/este/este):** Dev stack and starter kit for functional and universal (browser, server, mobile) React applications. Everything you need to start is included.
 * **[Rekit](https://github.com/supnate/rekit)** - Toolkit and boilerplates for building scalable web applications with React, Redux and React-router.
 * **[webcube](https://github.com/dexteryy/Project-WebCube)** - A JS infrastructure for modern Universal JS web app/sites and static websites. Provides built-in support and simplification for Redux sub-app, reducer bundle, router, immutable, eslint + prettier, docker, monorepo and many other tools.
-
-## Full-stack Kits
-
-* **[kyt](https://github.com/nytimes/kyt)** - The framework that the New York Times uses to develop and build their web properties. It's somewhat opinionated but configurable, and includes starter kits with options to build full-stack or static/client-side apps with the following tools: Express, React, static assets, latest ES, CSS/Sass Modules, Jest, code-splitting, ESLint/Prettier, StyleLint, PostCSS, and inline SVGs.
-* **[react-universally](https://github.com/ctrlplusb/react-universally)** A starter kit for universal react applications with React, Express, React Router (v4), ES2017, Flow, Jest, Service workers, Data-fetching and code-splitting.
- * **[web-service-template](https://github.com/nandai/web-service-template)** Membership single-page application with React and TypeScript.
  * **[starter-react-flux](https://github.com/SokichiFujita/starter-react-flux)** A generator for React and Flux project with Flux-Utils, Jest, Immutable.js, React Addons, Webpack, ESLint, Babel and ES2015.
- * **[react-slingshot](https://github.com/coryhouse/react-slingshot):** React + Redux starter kit with Babel, hot reloading, testing, linting and a working example app.
  * **[react-async-starter](https://github.com/didierfranc/react-async-starter):** React + Redux + Fetch + ES7 Async with Webpack, Babel and hot reloading.
- * **[spa-starter-kit](https://github.com/vutran/spa-starter-kit):** Full stack Docker node.js container with React, webpack, babel, sass, ESLint, React Hot Loader, Redux for a single-page application.
- * **[react-flux-starter-kit](https://github.com/coryhouse/react-flux-starter-kit):** React, Flux, React Router with Browserify, Bootstrap, and ESLint, all wired up via Gulp. Includes link to associated course.
- * **[exnext-quickstart](https://github.com/nkbt/esnext-quickstart):** Compilation, testing, code validation (ESLint) and hot reloading
- * **[react-component-template](https://github.com/nkbt/react-component-template):** Base for npm-publisheable standalone React Components with tests, ES6 coverage
- * **[Base](https://github.com/adeperio/base):** An open-source, security focused, web application starter kit.
-Built with ReactJS, Flux, Express, and Postgres.
- * **[Este](https://github.com/este/este):** Dev stack and starter kit for functional and universal (browser, server, mobile) React applications. Everything you need to start is included.
- * **[essential-react](https://github.com/pheuter/essential-react):** A minimal skeleton for building testable React apps using ES6
- * **[jspm-react](https://github.com/capaj/jspm-react):** Lightweight boilerplate on JSPM/Systemjs with hot-reloading modules for the browser
- * **[react-flux-coffeescript-browserify-gulp-demo](https://github.com/dqdinh/react-flux-coffeescript-browserify-gulp-demo):** React, Flux, Coffeescript, Browserify, Watchify, Gulp
- * **[react-reflux-boilerplate-with-webpack](https://github.com/iroy2000/react-reflux-boilerplate-with-webpack):** React Reflux Workflow Boilerplate -- React, Reflux, Gulp, Webpack, Stylus and CoffeeScript.
- * **[kontraktor-intrinsic-jsx](https://github.com/RuedigerMoeller/InstrinsicReactJSX):** Native Java-implementation of JSX Transpiler + Bundler + Server (no nashorn or node/babel required)
- * **[React-Phonegap App](https://github.com/kjda/ReactJs-Phonegap):** Phonegap App built with react using Flux.
  * **[Kriasoft React Starter Kit](https://github.com/kriasoft/react-starter-kit):** Gulp, Webpack, BrowserSync + [React Starter Kit for Visual Studio](http://visualstudiogallery.msdn.microsoft.com/d65d6b29-6dd7-4100-81b1-609e5afce356)
- * **[react-express-template](https://github.com/khaled/react-express-template):** Web app starter template with React, React Router, ES6 (via Babel), CoffeeScript, Express/Node.js, Semantic-UI, Gulp, LiveReload, and more
- * **[generator-react-webpack](https://github.com/newtriks/generator-react-webpack):** [Yeoman](http://yeoman.io/) generator for React and Webpack.
- * **[generator-react-express](https://github.com/JedWatson/generator-react-express):** [Yeoman](http://yeoman.io/) generator for React and Express with browserify, react-router and bootstrap.
- * **[generator-react-component](https://github.com/JedWatson/generator-react-component):** [Yeoman](http://yeoman.io/) generator React Component projects with Gulp, Browserify, Live Reload and publishing to GitHub Pages.
- * **[Racket](https://github.com/mohebifar/racket):** [Yeoman](http://yeoman.io/) generator for creating a universal React Redux web application.
- * **[Genesis Skeleton](http://genesis-skeleton.com/):** Modern, opinionated, full-stack starter kit for rapid, streamlined application development (supports React).
- * **[react-starter-template](https://github.com/johnthethird/react-starter-template):** Starter template with Gulp, Webpack and Bootstrap.
- * **[react-brunch](https://npmjs.org/package/react-brunch):** [Brunch](http://brunch.io/) plugin.
- * **[react-browserify-template](https://github.com/petehunt/react-browserify-template):** Quick-start with Browserify.
- * **[react-router-bootstrap-seed](https://github.com/okigan/react-router-bootstrap-seed):** Starter template with react-router, react-bootstrap and react-bootstrap-router (build with Gulp).
- * **[React Phonegap Starter](https://github.com/stample/gulp-browserify-react-phonegap-starter)**:
-Gulp, NPM, Browserify, React, Phonegap, Less, Recess, Underscore, JQuery...
- * **[generator-react-gulp-browserify](https://github.com/randylien/generator-react-gulp-browserify)** [Yeoman](http://yeoman.io/) generator for React, Gulp, Browserify and Twitter Bootstrap Sass official.
- * **[generator-react-boilerplate](https://github.com/mitchbox/generator-react-boilerplate)** [Yeoman](http://yeoman.io/) generator for React, Gulp, Browserify, Bootstrap and Fluxxor.
- * **[react-starterify](https://github.com/Granze/react-starterify):** React JS application skeleton using Browserify and other awesome tools
- * **[fluxury](https://github.com/jim-y/fluxury):** A React/Flux starter kit with NPM (build tool), Browserify, ImmutableJS, JSXHint and React-Router completely written in ES6 (Babelify transform).
- * **[react-app-boilerplate](https://github.com/christianalfoni/react-app-boilerplate):** Browserify workflow with automatic JSX transformation, dependency handling for fast builds and jasmine test environment.
- * **[nuts](https://github.com/micahlmartin/nuts):** A fully-featured starter kit that uses webpack, react, flux, backbone, mongo, and kue. Includes server-side and client-side rendering.
- * **[generator-rc](https://github.com/react-component/generator-rc):** A scaffold to develop react component quickly.
- * **[MimosaReactBackbone](https://github.com/dbashford/MimosaReactBackboneTodoList):** A TodoMVC React/Backbone app w/ Mimosa for tooling.
- * **[TodoMVC - NestedReact](https://github.com/gaperton/todomvc-nestedreact):** TodoMVC React app built with [NestedTypes](https://github.com/Volicon/NestedTypes) and [NestedReact](https://github.com/Volicon/NestedReact).
- * **[react-boilerplate](https://github.com/AbeEstrada/react-boilerplate):** It is a basic React project boilerplate, it uses JSX, React Router, Browserify, Reactify (ES6) and SASS.
- * **[koa-react-full-example](https://github.com/dozoisch/koa-react-full-example)** Boilerplate of a Koa React integration. Also shows a way to integrate koa-passport, react-router and react-bootstrap and a few other common modules. Includes an authentication flow.
- * **[generator-simple-react-browserify](https://github.com/luisrudge/generator-simple-react-browserify)** Really simple React + Browserify app generator for yeoman. Start here if you're trying to actually learn something.
- * **[react-starterkit-with-reflux](https://github.com/maisnamraju/react-starterkit)** It's a fork of [react-starterkit](https://github.com/wbkd/react-starterkit) with React, Reflux, ES6 with Babel, Fontawesome, SASS, Bootstrap SASS(not react-bootstrap), and Browserify.
- * **[react-jspm](https://github.com/chenxsan/react-jspm)** Boilerplate for developing React with jspm and SystemJS module loader.
  * **[electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate)** A React + Flux Electron application boilerplate based on React, Flux, React Router, Webpack, React Hot Loader
- * **[Coils](https://github.com/zubairq/coils):** React/SQL full stack realtime framework in Clojure
- * **[isomorphic-flux-react-react-router](https://github.com/jahrlin/isomorphic-flux-react-react-router):** A clean, unbloated starter template without any unnecessary complexity for isomorphic web apps using React, Flux, react-router. Uses gulp and webpack for builds, jest for testing and SASS for CSS preprocessing.
- * **[generator-sui-react](https://github.com/SUI-Components/generator-sui-react):** A [Yeoman](http://yeoman.io/) generator for Schibsted User Interface (sui) ReactJS components. The generator provides a basic structure to start developing a component, including coding standard rules, naming conventions and a unit testing suite.
- * **[Universal-routed-flux-demo](https://github.com/pierreavizou/universal-routed-flux-demo)** Example app to get started building universal flux applications, with Reactjs, React Router and es6.
- * **[react-starter](https://github.com/aliakakis/react-starter/)** React starter project with ES2015, Browserify, Babel, mobservable.
- * **[react-flux-flow-webpack-jest-es6](https://github.com/msalia/react-flux-flow-webpack-jest-es6)** A complete React, Flux, Flow, Webpack, Jest and ES6 starter kit.
  * **[react-boilerplate](https://github.com/mxstbr/react-boilerplate)** Quick setup for performance orientated, offline-first React.js applications featuring Redux, hot-reloading, PostCSS, react-router, ServiceWorker, AppCache, FontFaceObserver and Mocha.
  * **[vortigern](https://github.com/barbar/vortigern)** A universal boilerplate for building web applications w/ TypeScript, React, Redux and more.
- * **[react-redux-starter-kit](https://github.com/davezuko/react-redux-starter-kit):** Terrific universal Redux + React Router starter kit with Babel, SASS, hot reloading, testing, linting. Unopinionated as possible.
- * **[prax](https://github.com/mitranim/prax):** Sane functional programming style architecture for realtime apps, with single immutable state, event system, reactive views, support development through pure functions.
- * **[react-redux-universal-boilerplate](https://github.com/kiki-le-singe/react-redux-universal-boilerplate):**
-An Universal ReactJS/Redux Boilerplate with Babel, Webpack 2, Webpack backend bundling, React Hot Loader 3, sass or cssnext, testing, linting...
- * **[FUJITSU K5 Playground](https://playground.cloud.global.fujitsu.com)** A SPA and BFF generator with React, Flux, Swagger, Node.js, Material-ui, Jest, Webpack, ESLint and Babel.
  * **[CRA Universal CLI](https://github.com/antonybudianto/cra-universal)** CLI to initialize universal create-react-app without ejecting. Supports Server-side rendering with Code-splitting, and Node Stream rendering.
  * **[EDGE Platform](https://github.com/sebastian-software/edge)** Universal React/SSR + Apollo GraphQL + JS/CSS Code Splitting + Fine-Tuned Webpack + Localization/Internationalization. Most things are external dependencies. Boilerplate available.


### PR DESCRIPTION
* Removed almost all starter kits that use React 15 or earlier (left one or two exceptions that have pending PRs and are overwhelmingly well-known in the community)
* Merged "client-side" with "full stack" kits because the distinction was never respected in the first place
* Called them "other" to make it clearer we're not affiliated with them
* Removed a few things that I wouldn't classify as starter kits
