### PR TITLE
Grammatical disambiguation

### DIFF
--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -93,7 +93,7 @@ Don't put quotes around curly braces when embedding a JavaScript expression in a
 
 >**Warning:**
 >
->Since JSX is closer to JavaScript than HTML, React DOM uses `camelCase` property naming convention instead of HTML attribute names.
+>Since JSX is closer to JavaScript than to HTML, React DOM uses `camelCase` property naming convention instead of HTML attribute names.
 >
 >For example, `class` becomes [`className`](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) in JSX, and `tabindex` becomes [`tabIndex`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex).
 


### PR DESCRIPTION
Prevents interpretation as “JSX is closer to JavaScript than HTML is”. The latter is obviously true, but the apparent meaning is the former, which is less obvious.

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
