### PR TITLE
Fixed Possible Typo and Listed Points for Legibility

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -1,3 +1,4 @@
+
 ---
 id: context
 title: Context
@@ -16,15 +17,14 @@ In some cases, you want to pass data through the component tree without having t
 You can do this directly in React with the powerful "context" API.
 
 
-## Why Not To Use Context
+## When Not To Use Context
 
 The vast majority of applications do not need to use context.
 
-If you want your application to be stable, don't use context. It is an experimental API and it is likely to break in future releases of React.
-
-If you aren't familiar with state management libraries like [Redux](https://github.com/reactjs/redux) or [MobX](https://github.com/mobxjs/mobx), don't use context. For many practical applications, these libraries and their React bindings are a good choice for managing state that is relevant to many components. It is far more likely that Redux is the right solution to your problem than that context is the right solution.
-
-If you aren't an experienced React developer, don't use context. There is usually a better way to implement functionality just using props and state.
+Do **NOT** use context if
+* you want your application to be stable. This is because context is an experimental API and it is likely to break in future releases of React.
+* you aren't an experienced React developer since there is usually a better way to implement functionality just using props and state.
+* you aren't familiar with state management libraries like [Redux](https://github.com/reactjs/redux) or [MobX](https://github.com/mobxjs/mobx). For many practical applications, these libraries and their React bindings are a good choice for managing state that is relevant to many components. It is far more likely that Redux is the right solution to your problem than context.
 
 If you insist on using context despite these warnings, try to isolate your use of context to a small area and avoid using the context API directly when possible so that it's easier to upgrade when the API changes.
 


### PR DESCRIPTION
Tweaked the wording of the Context title, and listed the reasons to **NOT** use context for better readability.
