### PR TITLE
Add Reactathon 2018 Conf

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -21,6 +21,11 @@ January 25-28 in Dornbirn, Austria
 
 [Website](http://agent.sh/)
 
+### Reactathon 2018
+March 20-22 in San Francisco, CA
+
+[Website](https://www.reactathon.com) - [Twitter](https://twitter.com/reactathon) - [Facebook](https://www.facebook.com/events/1969072426685921/)
+
 ### React Amsterdam 2018
 April 13 in Amsterdam, The Netherlands
 


### PR DESCRIPTION
This adds Reactathon 2018 to the list of Conferences:

![image](https://user-images.githubusercontent.com/5455826/35062822-2b5ad5a4-fb7a-11e7-9802-06a39338555a.png)

