### PR TITLE
Font-smoothing for Firefox (at least on OSX)

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -7,6 +7,7 @@ html {
   font-weight: 400;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {


### PR DESCRIPTION
We use a non-standard CSS property, [`font-smooth`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth), in our font reset CSS. Currently we only apply it for Chrome, but we could also apply a similar effect for Firefox on OSX. This PR does that.

### Chrome
![screen shot 2018-01-17 at 11 32 53 am](https://user-images.githubusercontent.com/29597/35062881-55c79be2-fb7a-11e7-8635-8e20554fc1af.png)

### Before (Firefox)
![screen shot 2018-01-17 at 11 32 51 am](https://user-images.githubusercontent.com/29597/35062894-5c3b3c7c-fb7a-11e7-9d77-cdf29010c623.png)

### After (Firefox)
![screen shot 2018-01-17 at 11 32 58 am](https://user-images.githubusercontent.com/29597/35062889-58e8118a-fb7a-11e7-99ec-c29357728c91.png)
