### PR TITLE
Add Chain React 2018 to conferences.md

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -36,6 +36,11 @@ May 17-18 in Paris, France
 
 [Website](https://www.react-europe.org) - [Twitter](https://twitter.com/ReactEurope) - [Facebook](https://www.facebook.com/ReactEurope)
 
+### Chain React 2018
+July 11-13 in Portland, Oregon USA
+
+[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf)
+
 ### React Rally
 August 16-17 in Salt Lake City, Utah USA
 


### PR DESCRIPTION
Adds the [Chain React 2018](https://infinite.red/ChainReactConf) conference occurring July 11-13 in Portland to `content/community/conferences.md` to "Upcoming Conferences" in chronological order.