### PR TITLE
Update blog post on fragment tooling support

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -225,7 +225,7 @@ to update Flow to the latest version.
 
 ### Prettier
 
-[Prettier](https://github.com/prettier/prettier) will have support for fragments in their upcoming [1.9 release](https://github.com/prettier/prettier/pull/3237).
+[Prettier](https://github.com/prettier/prettier) added support for fragments in their [1.9 release](https://prettier.io/blog/2017/12/05/1.9.0.html#jsx-fragment-syntax-3237-https-githubcom-prettier-prettier-pull-3237-by-duailibe-https-githubcom-duailibe).
 
 ### ESLint
 


### PR DESCRIPTION
Clarifies that Prettier has released 1.9 and now supports the short Fragment JSX syntax.

Also changes the link to the section in the 1.9 release notes that describes the feature.