### PR TITLE
Add The React Podcast to podcasts list

### DIFF
--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -10,11 +10,11 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 ## Podcasts
 
-- [JavaScript Air](https://javascriptair.com/) - All about JavaScript (currently not producing new episodes).
+- [The React Podcast](http://reactpodcast.com) - The podcast about everything React.js, hosted by [React Training](https://reacttraining.com)
 
-- [React 30](https://react30.com/) - A weekly 30-minute podcast all about React (currently not producing new episodes).
+- [JavaScript Air](https://javascriptair.com/) - All about JavaScript (currently not producing new episodes)
 
-- [React Podcast](https://itunes.apple.com/us/podcast/react-podcast/id995869265?mt=2) - A podcast covering the ReactJS ecosystem (currently not producing new episodes).
+- [React 30](https://react30.com/) - A 30-minute podcast all about React (moved to [The React Podcast](http://reactpodcast.com)).
 
 ## Episodes
 


### PR DESCRIPTION
React30 has merged with The React Podcast and is now producing new episodes again.
