### PR TITLE
Note about special props in PropTypes typechecking

### DIFF
--- a/content/warnings/special-props.md
+++ b/content/warnings/special-props.md
@@ -6,6 +6,4 @@ permalink: warnings/special-props.html
 
 Most props on a JSX element are passed on to the component, however, there are two special props (`ref` and `key`) which are used by React, and are thus not forwarded to the component.
 
-For instance, attempting to access `this.props.key` from a component (eg. the render function) is not defined. If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />`). While this may seem redundant, it's important to separate app logic from reconciling hints.
-
-__Note:__ You will also see this warning if you define `key` or `ref` PropTypes (using [PropTypes typechecking](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes)).
+For instance, attempting to access `this.props.key` from a component (i.e., the render function or [propTypes](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes)) is not defined. If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />`). While this may seem redundant, it's important to separate app logic from reconciling hints.

--- a/content/warnings/special-props.md
+++ b/content/warnings/special-props.md
@@ -6,4 +6,17 @@ permalink: warnings/special-props.html
 
 Most props on a JSX element are passed on to the component, however, there are two special props (`ref` and `key`) which are used by React, and are thus not forwarded to the component.
 
-For instance, attempting to access `this.props.key` from a component (eg. the render function) is not defined.  If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />`). While this may seem redundant, it's important to separate app logic from reconciling hints.
+For instance, attempting to access `this.props.key` from a component (eg. the render function) is not defined. If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />`). While this may seem redundant, it's important to separate app logic from reconciling hints.
+
+> Note:
+>
+> There is no need to validate special props using [PropTypes typechecking](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes).
+>
+> By defining `key` or `ref` PropTypes, React will try to access them during props validation phase in the development build.
+> 
+> ```js
+> ListItemWrapper.propTypes = {
+>   id: PropTypes.string,
+>   key: PropTypes.string // WARNING
+> }
+> ```

--- a/content/warnings/special-props.md
+++ b/content/warnings/special-props.md
@@ -8,15 +8,4 @@ Most props on a JSX element are passed on to the component, however, there are t
 
 For instance, attempting to access `this.props.key` from a component (eg. the render function) is not defined. If you need to access the same value within the child component, you should pass it as a different prop (ex: `<ListItemWrapper key={result.id} id={result.id} />`). While this may seem redundant, it's important to separate app logic from reconciling hints.
 
-> Note:
->
-> There is no need to validate special props using [PropTypes typechecking](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes).
->
-> By defining `key` or `ref` PropTypes, React will try to access them during props validation phase in the development build.
-> 
-> ```js
-> ListItemWrapper.propTypes = {
->   id: PropTypes.string,
->   key: PropTypes.string // WARNING
-> }
-> ```
+__Note:__ You will also see this warning if you define `key` or `ref` PropTypes (using [PropTypes typechecking](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes)).


### PR DESCRIPTION
👋 Hey,

I wanted to add a note regarding defining special props in component's `propTypes`.

While the warning is leading the user towards a usage of `this.props.key` it might also happen during PropTypes validation in development builds, which is a bit harder to figure out using the current explanation. Maybe adding this note could spare some debugging time 😉