### PR TITLE
Add React Native EU 2018 conference

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -41,6 +41,11 @@ August 16-17 in Salt Lake City, Utah USA
 
 [Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
 
+### React Native EU 2018
+September 5-6 in Wrocław, Poland
+
+[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+
 ### ReactNext 2018
 September 6 in Tel Aviv, Israel
 


### PR DESCRIPTION
This adds React Native EU 2018 to the list of Conferences.
