### PR TITLE
setState callback semantics

### DIFF
--- a/content/docs/faq-state.md
+++ b/content/docs/faq-state.md
@@ -59,9 +59,9 @@ Passing an update function allows you to access the current state value inside t
 
 ```jsx
 incrementCount() {
-  this.setState((prevState) => {
-    // Important: read `prevState` instead of `this.state` when updating.
-    return {count: prevState.count + 1}
+  this.setState((currentState) => {
+    // Important: read `currentState` instead of `this.state` when updating.
+    return {count: currentState.count + 1}
   });
 }
 


### PR DESCRIPTION
setState callback does not pass prevState, it passes currentState

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

See PR #620 

