### PR TITLE
Clarify callback parameters

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -154,15 +154,15 @@ Verifies the object is a React element. Returns `true` or `false`.
 #### `React.Children.map`
 
 ```javascript
-React.Children.map(children, function[(thisArg)])
+React.Children.map(children, function(thisArg, [index]))
 ```
 
-Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is a keyed fragment or array it will be traversed: the function will never be passed the container objects. If children is `null` or `undefined`, returns `null` or `undefined` rather than an array.
+Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. The optional `index` parameter refers to the index of the current child in the array. If `children` is a keyed fragment or array it will be traversed: the function will never be passed the container objects. If children is `null` or `undefined`, returns `null` or `undefined` rather than an array.
 
 #### `React.Children.forEach`
 
 ```javascript
-React.Children.forEach(children, function[(thisArg)])
+React.Children.forEach(children, function(thisArg, [index]))
 ```
 
 Like [`React.Children.map()`](#reactchildrenmap) but does not return an array.


### PR DESCRIPTION
Clarifies the callback parameters for React.Children.map() and React.Children.forEach() by noting that they can also contain an optional `index` parameter as a second argument.

I'm not sure if the way I formatted the parameters in the function is correct. I noticed that before, `thisArg` was wrapped in brackets. Was that to signify it was optional? Feel free to correct me on that.

Preview of the change:
![image](https://user-images.githubusercontent.com/10334948/36349010-e819fb8c-144a-11e8-9ebc-43e4bd552875.png)

