### PR TITLE
Update link to create-react-app repository

### DIFF
--- a/content/community/tools-starter-kits.md
+++ b/content/community/tools-starter-kits.md
@@ -7,7 +7,7 @@ permalink: community/starter-kits.html
 
 ## Recommended by the React Team
 
-* **[Create React App](https://github.com/facebookincubator/create-react-app)** - An officially supported way to start a client-side React project with no configuration
+* **[Create React App](https://github.com/facebook/create-react-app)** - An officially supported way to start a client-side React project with no configuration
 * **[Next.js](https://learnnextjs.com/)** - Framework for server-rendered or statically-exported React apps
 * **[Gatsby](https://www.gatsbyjs.org/)** - Blazing-fast static site generator for React
 * **[nwb](https://github.com/insin/nwb)** - A toolkit for React apps, libraries and other npm modules for the web


### PR DESCRIPTION
This PR just update the link to create-react-app from facebookincubator to facebook organization.

![captura de tela 2018-02-18 as 12 04 47](https://user-images.githubusercontent.com/7604033/36353379-abe37418-14a4-11e8-8b11-f4243eb9682b.png)

