### PR TITLE
add Reframe to "Starter Kits"

### DIFF
--- a/content/community/tools-starter-kits.md
+++ b/content/community/tools-starter-kits.md
@@ -35,3 +35,4 @@ Ready to grow boilerplate with react-router, redux, saga, webpack 2, jest w/ cov
  * **[EDGE Platform](https://github.com/sebastian-software/edge)** Universal React/SSR + Apollo GraphQL + JS/CSS Code Splitting + Fine-Tuned Webpack + Localization/Internationalization. Most things are external dependencies. Boilerplate available.
  * **[bae](https://github.com/siddharthkp/bae)** Zero config toolkit. SSR (with data fetching) + routing + streaming + styling (with styled-components) + HMR out of the box.
  * **[breko-hub](https://github.com/tomatau/breko-hub)** A production ready boilerplate for universal react applications. Complete with code splitting, server render (using koa), redux, sagas, debugging, hot-reloading (live updates on the server), css-modules, scss, super fast integration tests and unit tests. There's also a big focus on clean code and smaller files.
+ * **[Reframe](https://github.com/brillout/reframe)** Framework to create web apps with React.


### PR DESCRIPTION
How about creating a new section "Frameworks"? Next.js, Gatsby, and Reframe are frameworks and not really starter kits.

Also, what does it take to become "Recommended by the React Team"? :eyes:

Reframe is new but I'm committed to maintain and further develop it.