### PR TITLE
Fixed Accessiblity Issue jsx docblocks - 594

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -179,7 +179,7 @@ class CodeEditor extends Component {
                   },
                 }}
                 className="gatsby-highlight">
-                <LiveEditor onChange={this._onChange} />
+                <LiveEditor ignoreTabKey={true} onChange={this._onChange} />
               </div>
             </div>
             {error && (


### PR DESCRIPTION
set ignoreTabKey to true so that keyboard only users can tab out of jsx docblocks fixing issue #594 
