### PR TITLE
Add React.createRef doc

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -94,12 +94,13 @@ React will assign the `value` property with the DOM element when the component m
 
 When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
-```javascript{4,12}
+```javascript{4,7,12}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);
     this.textInput = React.createRef();
   }
+
   componentDidMount() {
     this.textInput.value.focusTextInput();
   }
@@ -124,7 +125,7 @@ class CustomTextInput extends React.Component {
 
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```javascript{1,8,12}
+```javascript{1,8,13}
 function MyFunctionalComponent() {
   return <input />;
 }
@@ -167,7 +168,7 @@ function CustomTextInput(props) {
         onClick={handleClick}
       />
     </div>
-  );  
+  );
 }
 ```
 
@@ -211,7 +212,7 @@ This works even though `CustomTextInput` is a functional component. Unlike the s
 
 Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
 
-```javascript{4,12,21,25}
+```javascript{4,12,20,24}
 function CustomTextInput(props) {
   return (
     <div>
@@ -227,7 +228,6 @@ function Parent(props) {
     </div>
   );
 }
-
 
 class Grandparent extends React.Component {
   constructor(props) {

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -33,22 +33,10 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 
 >**Note:**
 >
->The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
+>The examples below have updated to use the `React.createRef()` API introduced in React 16.3.
 
 
-Refs can be created using `React.createRef()` and are commonly assigned to a component class instance in the constructor or via a property initializer.
-
-```javascript{4}
-class MyComponent extends React.Component {
-  constructor(props) {
-    super(props);
-    this.myRef = React.createRef();
-  }
-}
-```
-
-Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
-
+Refs can be created using `React.createRef()` and are commonly assigned to an instance property when a component is constructed.
 
 ```javascript{4,7}
 class MyComponent extends React.Component {
@@ -62,9 +50,11 @@ class MyComponent extends React.Component {
 }
 ```
 
+Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
+
 When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
 
-```javascript{5,11,21}
+```javascript{5,12,22}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -75,6 +65,7 @@ class CustomTextInput extends React.Component {
 
   focusTextInput() {
     // Explicitly focus the text input using the raw DOM API
+    // Note: we're accessing "value" to get the DOM node
     this.textInput.value.focus();
   }
 
@@ -257,20 +248,18 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 ### Callback Refs
 
-The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. Callback refs work in much the same way as object refs.
+React also supports another way to set refs called "callback refs", which give more fine-grain control over when refs are set and unset.
 
-With callback refs, instead of creating a ref with `React.createRef()`, you pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+Instead of passing a `ref` attribute created by `createRef()`, you pass a function. The function receives the React component instance or HTML DOM element as its argument, which can be stored and accessed elsewhere. This example uses the `ref` callback to store a reference to a DOM node:
 
-```javascript{8,9,19}
+```javascript{6,17}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
-    this.focusTextInput = this.focusTextInput.bind(this);
-  }
-
-  focusTextInput() {
-    // Explicitly focus the text input using the raw DOM API
-    this.textInput.focus();
+    this.focusTextInput = () => {
+      // Explicitly focus the text input using the raw DOM API
+      this.textInput.focus();
+    };
   }
 
   render() {
@@ -294,7 +283,7 @@ class CustomTextInput extends React.Component {
 
 React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks are invoked before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
 
-Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
+Using the `ref` callback to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
 You can pass callback refs between components like you can with object refs that were created with `React.createRef()`.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -111,7 +111,7 @@ React will assign the `value` property with the DOM element when the component m
 
 If we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting, we could use a ref to get access to the custom input and call its `focusTextInput` method manually:
 
-```javascript{4,7,12}
+```javascript{4,8,13}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -31,9 +31,211 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 
 ### Adding a Ref to a DOM Element
 
+>**Note:**
+>
+>The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
+
+
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
 
-When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
+
+```javascript{8,9,19}
+class CustomTextInput extends React.Component {
+  constructor(props) {
+    super(props);
+    // create a ref to store the textInput DOM element
+    this.textInput = React.createRef();
+    this.focusTextInput = this.focusTextInput.bind(this);
+  }
+
+  focusTextInput() {
+    // Explicitly focus the text input using the raw DOM API
+    this.textInput.value.focus();
+  }
+
+  render() {
+    // tell React that we want the associate the <input> ref
+    // to the `textInput` that we created in the constructor
+    return (
+      <div>
+        <input
+          type="text"
+          ref={this.textInput} />
+        <input
+          type="button"
+          value="Focus the text input"
+          onClick={this.focusTextInput}
+        />
+      </div>
+    );
+  }
+}
+```
+
+React will assign the `value` property with the DOM element when the component mounts, and assign it back to `null` when it unmounts. `ref` updates happen before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
+
+### Adding a Ref to a Class Component
+
+When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
+
+```javascript{3,9}
+class AutoFocusTextInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textInput = React.createRef();
+  }
+  componentDidMount() {
+    this.textInput.value.focusTextInput();
+  }
+
+  render() {
+    return (
+      <CustomTextInput ref={this.textInput} />
+    );
+  }
+}
+```
+
+Note that this only works if `CustomTextInput` is declared as a class:
+
+```js{1}
+class CustomTextInput extends React.Component {
+  // ...
+}
+```
+
+### Refs and Functional Components
+
+**You may not use the `ref` attribute on functional components** because they don't have instances:
+
+```javascript{1,7}
+function MyFunctionalComponent() {
+  return <input />;
+}
+
+class Parent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textInput = React.createRef();
+  }
+  render() {
+    // This will *not* work!
+    return (
+      <MyFunctionalComponent ref={this.textInput} />
+    );
+  }
+}
+```
+
+You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
+
+You can, however, **use the `ref` attribute inside a functional component** as long as you refer to a DOM element or a class component:
+
+```javascript{2,3,6,13}
+function CustomTextInput(props) {
+  // textInput must be declared here so the ref can refer to it
+  let textInput = React.createRef();
+
+  function handleClick() {
+    textInput.value.focus();
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        ref={textInput} />
+      <input
+        type="button"
+        value="Focus the text input"
+        onClick={handleClick}
+      />
+    </div>
+  );  
+}
+```
+
+### Exposing DOM Refs to Parent Components
+
+In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
+
+While you could [add a ref to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
+
+Instead, in such cases we recommend exposing a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref to the child's DOM node through the component in the middle.
+
+This works both for classes and for functional components.
+
+```javascript{4,13}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+class Parent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputElement = React.createRef();
+  }
+  render() {
+    return (
+      <CustomTextInput inputRef={this.inputElement} />
+    );
+  }
+}
+```
+
+In the example above, `Parent` passes its class property `this.inputElement` as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same ref as a special `ref` attribute to the `<input>`. As a result, `this.inputElement.value` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+
+Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
+
+This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
+
+Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
+
+```javascript{4,12,22}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+function Parent(props) {
+  return (
+    <div>
+      My input: <CustomTextInput inputRef={props.inputRef} />
+    </div>
+  );
+}
+
+
+class Grandparent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputElement = React.createRef();
+  }
+  render() {
+    return (
+      <Parent inputRef={this.inputElement} />
+    );
+  }
+}
+```
+
+Here, the ref `this.inputElement` is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed ref as a `ref` attribute to the `<input>`. As a result, `this.inputElement.value` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+
+All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
+
+### Callback Refs
+
+The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. In much the same way object refs work, callback refs can be used in a similar approach.
+
+With callback refs, instead of creating a ref with `React.createRef()`, you instead pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
 
 ```javascript{8,9,19}
 class CustomTextInput extends React.Component {
@@ -70,90 +272,7 @@ React will call the `ref` callback with the DOM element when the component mount
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
-### Adding a Ref to a Class Component
-
-When the `ref` attribute is used on a custom component declared as a class, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
-
-```javascript{3,9}
-class AutoFocusTextInput extends React.Component {
-  componentDidMount() {
-    this.textInput.focusTextInput();
-  }
-
-  render() {
-    return (
-      <CustomTextInput
-        ref={(input) => { this.textInput = input; }} />
-    );
-  }
-}
-```
-
-Note that this only works if `CustomTextInput` is declared as a class:
-
-```js{1}
-class CustomTextInput extends React.Component {
-  // ...
-}
-```
-
-### Refs and Functional Components
-
-**You may not use the `ref` attribute on functional components** because they don't have instances:
-
-```javascript{1,7}
-function MyFunctionalComponent() {
-  return <input />;
-}
-
-class Parent extends React.Component {
-  render() {
-    // This will *not* work!
-    return (
-      <MyFunctionalComponent
-        ref={(input) => { this.textInput = input; }} />
-    );
-  }
-}
-```
-
-You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
-
-You can, however, **use the `ref` attribute inside a functional component** as long as you refer to a DOM element or a class component:
-
-```javascript{2,3,6,13}
-function CustomTextInput(props) {
-  // textInput must be declared here so the ref callback can refer to it
-  let textInput = null;
-
-  function handleClick() {
-    textInput.focus();
-  }
-
-  return (
-    <div>
-      <input
-        type="text"
-        ref={(input) => { textInput = input; }} />
-      <input
-        type="button"
-        value="Focus the text input"
-        onClick={handleClick}
-      />
-    </div>
-  );  
-}
-```
-
-### Exposing DOM Refs to Parent Components
-
-In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
-
-While you could [add a ref to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
-
-Instead, in such cases we recommend exposing a special prop on the child. The child would take a function prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref callback to the child's DOM node through the component in the middle.
-
-This works both for classes and for functional components.
+You can pass callback refs between components like you can with object refs that were created with `React.createRef()`.
 
 ```javascript{4,13}
 function CustomTextInput(props) {
@@ -177,49 +296,10 @@ class Parent extends React.Component {
 
 In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
-Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
-
-This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
-
-Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
-
-```javascript{4,12,22}
-function CustomTextInput(props) {
-  return (
-    <div>
-      <input ref={props.inputRef} />
-    </div>
-  );
-}
-
-function Parent(props) {
-  return (
-    <div>
-      My input: <CustomTextInput inputRef={props.inputRef} />
-    </div>
-  );
-}
-
-
-class Grandparent extends React.Component {
-  render() {
-    return (
-      <Parent
-        inputRef={el => this.inputElement = el}
-      />
-    );
-  }
-}
-```
-
-Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
-
-All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
-
 ### Legacy API: String Refs
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
-### Caveats
+### Caveats with callback refs
 
 If the `ref` callback is defined as an inline function, it will get called twice during updates, first with `null` and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the `ref` callback as a bound method on the class, but note that it shouldn't matter in most cases.

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -36,11 +36,35 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 >The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
 
 
-React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
+Refs can be created using `React.createRef()` and are commonly assigned to a component class instance in the constructor or via a property initializer.
+
+```javascript{4}
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+}
+```
+
+Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
+
+
+```javascript{4,7}
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+  render() {
+    return <div ref={this.myRef} />;
+  }
+}
+```
 
 When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
 
-```javascript{8,9,19}
+```javascript{5,11,21}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -56,7 +80,7 @@ class CustomTextInput extends React.Component {
 
   render() {
     // tell React that we want the associate the <input> ref
-    // to the `textInput` that we created in the constructor
+    // with the `textInput` that we created in the constructor
     return (
       <div>
         <input
@@ -79,7 +103,7 @@ React will assign the `value` property with the DOM element when the component m
 
 When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
-```javascript{3,9}
+```javascript{4,12}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -109,7 +133,7 @@ class CustomTextInput extends React.Component {
 
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```javascript{1,7}
+```javascript{1,8,12}
 function MyFunctionalComponent() {
   return <input />;
 }
@@ -166,7 +190,7 @@ Instead, in such cases we recommend exposing a special prop on the child. The ch
 
 This works both for classes and for functional components.
 
-```javascript{4,13}
+```javascript{4,12,16}
 function CustomTextInput(props) {
   return (
     <div>
@@ -196,7 +220,7 @@ This works even though `CustomTextInput` is a functional component. Unlike the s
 
 Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
 
-```javascript{4,12,22}
+```javascript{4,12,21,25}
 function CustomTextInput(props) {
   return (
     <div>
@@ -233,9 +257,9 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 ### Callback Refs
 
-The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. In much the same way object refs work, callback refs can be used in a similar approach.
+The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. Callback refs work in much the same way as object refs.
 
-With callback refs, instead of creating a ref with `React.createRef()`, you instead pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+With callback refs, instead of creating a ref with `React.createRef()`, you pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
 
 ```javascript{8,9,19}
 class CustomTextInput extends React.Component {


### PR DESCRIPTION
This PR adds the new `React.createRef()` documentation to the refs page in the documentation.