### PR TITLE
Correctly link up reference to 15.6.2 addons

### DIFF
--- a/content/blog/2017-09-25-react-v15.6.2.md
+++ b/content/blog/2017-09-25-react-v15.6.2.md
@@ -34,7 +34,7 @@ In case you don't use a bundler, we also provide pre-built bundles in the npm pa
   Minified build for production: [react/dist/react.min.js](https://unpkg.com/react@15.6.2/dist/react.min.js)<br/>
 * **React with Add-Ons**<br/>
   Dev build with warnings: [react/dist/react-with-addons.js](https://unpkg.com/react@15.6.2/dist/react-with-addons.js)<br/>
-  Minified build for production: [react/dist/react-with-addons.min.js](https://unpkg.com/react@15.5.0/dist/react-with-addons.min.js)<br/>
+  Minified build for production: [react/dist/react-with-addons.min.js](https://unpkg.com/react@15.6.2/dist/react-with-addons.min.js)<br/>
 * **React DOM** (include React in the page before React DOM)<br/>
   Dev build with warnings: [react-dom/dist/react-dom.js](https://unpkg.com/react-dom@15.6.2/dist/react-dom.js)<br/>
   Minified build for production: [react-dom/dist/react-dom.min.js](https://unpkg.com/react-dom@15.6.2/dist/react-dom.min.js)<br/>


### PR DESCRIPTION
Hey! Looks like I incorrectly linked up the add-ons version of the 15.6.2 release.  Sorry :(