### PR TITLE
Improve a11y in homepage examples with some labels

### DIFF
--- a/content/home/examples/a-component-using-external-plugins.js
+++ b/content/home/examples/a-component-using-external-plugins.js
@@ -2,7 +2,7 @@ class MarkdownEditor extends React.Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
-    this.state = { value: 'Type some *markdown* here!' };
+    this.state = { value: 'Hello, **world**!' };
   }
 
   handleChange(e) {
@@ -18,7 +18,11 @@ class MarkdownEditor extends React.Component {
     return (
       <div className="MarkdownEditor">
         <h3>Input</h3>
+        <label htmlFor="markdown-content">
+          Enter some markdown
+        </label>
         <textarea
+          id="markdown-content"
           onChange={this.handleChange}
           defaultValue={this.state.value}
         />

--- a/content/home/examples/an-application.js
+++ b/content/home/examples/an-application.js
@@ -12,7 +12,11 @@ class TodoApp extends React.Component {
         <h3>TODO</h3>
         <TodoList items={this.state.items} />
         <form onSubmit={this.handleSubmit}>
+          <label htmlFor="new-todo">
+            What needs to be done?
+          </label>
           <input
+            id="new-todo"
             onChange={this.handleChange}
             value={this.state.text}
           />

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -257,9 +257,13 @@ class CodeEditor extends Component {
                       padding: '5px 10px',
                     },
 
+                    '& label': {
+                      display: 'block',
+                      marginTop: 10,
+                    },
+
                     '& textarea': {
                       width: '100%',
-                      marginTop: 10,
                       height: 60,
                       padding: 5,
                     },


### PR DESCRIPTION
Hiya!

After some [chatter on twitter](https://twitter.com/pauljadam/status/969969247714766848) about the a11y of the react homepage examples, I took the liberty of adding some labels. 

This changeset adds labels to the Todo and markdown code examples on the homepage - the aim being that if folks have more exposure to something like a semantic <label> tag while learning react, maybe the habit will stick.

![a screenshot from the reactjs homepage code example for rendering a todo list - showing source code on the left with label tags added, and rendered output on the right](https://user-images.githubusercontent.com/287268/36951166-688b32d4-1fce-11e8-9cd4-663515756d88.png)

![a screenshot from the reactjs homepage code example for rendering markdown - showing source code on the left with label tags added, and rendered output on the right](https://user-images.githubusercontent.com/287268/36951174-7fcd42d4-1fce-11e8-9b1b-edf9410406bc.png)

I took a bit of creative license on the markdown textarea's label - and changed the default state of the component to render `Hello, **world**!` instead of `Type some *markdown* here` since the label conveys that. Happy to bikeshed this.

Thanks!