### PR TITLE
Updates "Passing Functions to Components" FAQ page with one more example

### DIFF
--- a/content/docs/faq-functions.md
+++ b/content/docs/faq-functions.md
@@ -146,8 +146,8 @@ This is equivalent to calling `.bind`:
 
 #### Example: Passing params using arrow functions
 
-```jsx
-const A = 65 // ASCII character code
+```jsx{12-14,21}
+const A = 65; // ASCII character code
 
 class Alphabet extends React.Component {
   constructor(props) {
@@ -178,12 +178,12 @@ class Alphabet extends React.Component {
 }
 ```
 
-#### Example: Passing params using data-attributes
+#### Example: Passing params to DOM elements using data-attributes
 
-Alternately, you can use DOM APIs to store data needed for event handlers. Consider this approach if you need to optimize a large number of elements or have a render tree that relies on React.PureComponent equality checks.
+Alternately, you can use DOM APIs to store data needed for event handlers on the DOM elements themselves. Consider this approach if you need to optimize a large number of elements or have a render tree that relies on `React.PureComponent` equality checks.
 
-```jsx
-const A = 65 // ASCII character code
+```jsx{13-17,25}
+const A = 65; // ASCII character code
 
 class Alphabet extends React.Component {
   constructor(props) {
@@ -214,6 +214,59 @@ class Alphabet extends React.Component {
         </ul>
       </div>
     )
+  }
+}
+```
+
+#### Example: Passing params to class-based elements using props
+
+The DOM data-attribute approach can be adapted for class-based elements if you pass the data needed for event handlers as props. This works to optimize a large number of elements and pairs well with children that extend `React.PureComponent`.
+
+```jsx{13-15,23,38}
+const A = 65; // ASCII character code
+
+class Alphabet extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.state = {
+      justClicked: null,
+      letters: Array.from({length: 26}, (_, i) => String.fromCharCode(A + i))
+    };
+  }
+
+  handleClick(letter) {
+    this.setState({ justClicked: letter });
+  }
+
+  render() {
+    return (
+      <div>
+        Just clicked: {this.state.justClicked}
+        <ul>
+          {this.state.letters.map(letter =>
+            <Letter key={letter} letter={letter} onClick={this.handleClick}/>
+          )}
+        </ul>
+      </div>
+    )
+  }
+}
+
+class Letter extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick(e) {
+    this.props.onClick(this.props.letter);
+  }
+
+  render() {
+    return <li onClick={this.onClick}>
+      {this.props.letter}
+    </li>
   }
 }
 ```

--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -142,7 +142,7 @@ The problem with this syntax is that a different callback is created each time t
 
 ## Passing Arguments to Event Handlers
 
-Inside a loop it is common to want to pass an extra parameter to an event handler. For example, if `id` is the row ID, either of the following would work:
+Inside a loop it is common to want to pass an extra parameter to an event handler. For example, if `id` were the row ID, either of the following would work:
 
 ```js
 <button onClick={(e) => this.deleteRow(id, e)}>Delete Row</button>
@@ -152,3 +152,5 @@ Inside a loop it is common to want to pass an extra parameter to an event handle
 The above two lines are equivalent, and use [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) respectively.
 
 In both cases, the `e` argument representing the React event will be passed as a second argument after the ID. With an arrow function, we have to pass it explicitly, but with `bind` any further arguments are automatically forwarded.
+
+The FAQ page for [Passing Functions to Components](/docs/faq-functions.html) shows more approaches for attaching paramenters to event handlers.


### PR DESCRIPTION
Fixes issue #673.

[Adds one more example](https://deploy-preview-676--reactjs.netlify.com/docs/faq-functions.html#example-passing-params-to-class-based-elements-using-props) for passing parameters for event handling for class-based elements (code is tested in [React Live](https://react-live.kitten.sh/)); plus highlighting to relevant lines in the three examples. 

Additionally, [I've linked from the Handling Events](https://deploy-preview-676--reactjs.netlify.com/docs/handling-events.html#passing-arguments-to-event-handlers) docs page to this FAQ page. 

First PR, hope I got everything right! :)

(Not sure if _class-based elements_ is the proper way to call these?)
