### PR TITLE
[docs] add reference to the explanation of capitalizing components

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -85,9 +85,7 @@ Let's recap what happens in this example:
 3. Our `Welcome` component returns a `<h1>Hello, Sara</h1>` element as the result.
 4. React DOM efficiently updates the DOM to match `<h1>Hello, Sara</h1>`.
 
->**Caveat:**
->
->Always start component names with a capital letter.
+>**Note:** Always start component names with a capital letter.
 >
 >React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
 >

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -90,6 +90,8 @@ Let's recap what happens in this example:
 >Always start component names with a capital letter.
 >
 >React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
+>
+>You can read more about the reasoning behind this convention [here.](https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized)
 
 ## Composing Components
 


### PR DESCRIPTION
This would allow you to understand the reasoning behind this convention and avoid any pitfalls that may derive from accidentally not following it.