### PR TITLE
fix word in reconciliation doc: "controlled" -> "uncontrolled"

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -140,7 +140,7 @@ When that's not the case, you can add a new ID property to your model or hash so
 
 As a last resort, you can pass an item's index in the array as a key. This can work well if the items are never reordered, but reorders will be slow.
 
-Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like controlled inputs can get mixed up and updated in unexpected ways.
+Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like uncontrolled inputs can get mixed up and updated in unexpected ways.
 
 [Here](codepen://reconciliation/index-used-as-key) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](codepen://reconciliation/no-index-used-as-key) is a updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
 


### PR DESCRIPTION
Looking at linked CodePen examples and based on  https://medium.com/@jedwards8/uncontrolled-components-are-an-anti-pattern-abbdd86fd39e I think it's a more correct wording.