### PR TITLE
Clarify PureComponent render prop caveat

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -305,14 +305,8 @@ To get around this problem, you can sometimes define the prop as an instance met
 
 ```js
 class MouseTracker extends React.Component {
-  constructor(props) {
-    super(props);
-
-    // This binding ensures that `this.renderTheCat` always refers
-    // to the *same* function when we use it in render.
-    this.renderTheCat = this.renderTheCat.bind(this);
-  }
-
+  // Defined as an instance method, `this.renderTheCat` always
+  // refers to *same* function when we use it in render
   renderTheCat(mouse) {
     return <Cat mouse={mouse} />;
   }
@@ -328,4 +322,4 @@ class MouseTracker extends React.Component {
 }
 ```
 
-In cases where you cannot bind the instance method ahead of time in the constructor (e.g. because you need to close over the component's props and/or state) `<Mouse>` should extend `React.Component` instead.
+In cases where you cannot define the prop statically (e.g. because you need to close over the component's props and/or state) `<Mouse>` should extend `React.Component` instead.


### PR DESCRIPTION
The example given to illustrate the caveat with PureComponents that use render props doesn't quite make sense. The _binding_ isn't what ensures that `this.renderTheCat` refers to the same function when used in `render`, and the method will work just fine when passed to the render prop unbound because it doesn't reference `this`.

If anything, I think including a bound method in the example is dangerous, because if the method _did_ reference `this.props` or `this.state`, it would be incorrect to pass a bound version to the render prop because `Mouse` would fail to re-render when props/state change, as noted in the paragraph following the example.

This removes the binding and clarifies the reasoning.

/cc @mjackson 