### PR TITLE
Update the minimal React fiddle resource links

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -41,7 +41,7 @@ We are using [GitHub Issues](https://github.com/facebook/react/issues) for our p
 
 #### Reporting New Issues
 
-The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/84v837e9/) is a great starting point.
+The best way to get your bug fixed is to provide a reduced test case. This [JSFiddle template](https://jsfiddle.net/ogcLtawf/) is a great starting point.
 
 #### Security Bugs
 


### PR DESCRIPTION
Hey, in the "Reporting New Issues" section, there is a link for "JSFiddle template".

The resources seem are out-dated which caused the fiddle breaking.
![image](https://user-images.githubusercontent.com/10692276/37814183-dd89f8fc-2ebc-11e8-9b32-ff480327cf41.png)

Created a new working fiddle 
![image](https://user-images.githubusercontent.com/10692276/37814256-2089d73a-2ebd-11e8-8cc4-f20ca29cc5e5.png)

Or updating the exisiting one and close this PR? 

Thanks!


