### PR TITLE
Add a warning about the synthetic event system's propagation logic

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -12,6 +12,11 @@ This reference guide documents the `SyntheticEvent` wrapper that forms part of R
 
 Your event handlers will be passed instances of `SyntheticEvent`, a cross-browser wrapper around the browser's native event. It has the same interface as the browser's native event, including `stopPropagation()` and `preventDefault()`, except the events work identically across all browsers.
 
+> Note:
+>
+> The synthetic event system implements its own event propagation, which might not be consistent with the
+> browser's native event propagation. Make sure you're not relying on the order in which synthetic events are bubbled or captured relative to native events.
+
 If you find that you need the underlying browser event for some reason, simply use the `nativeEvent` attribute to get it. Every `SyntheticEvent` object has the following attributes:
 
 ```javascript


### PR DESCRIPTION
Stemming from https://github.com/facebook/react/issues/12328 and other issues we've seen in the past, people sometimes aren't aware that the synthetic event system's propagation will sometimes be out of sync with the native event system.

Here's a quick attempt at adding a warning about it. Feedback welcome!



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
