### PR TITLE
React.forwardRef accepts a render function, not Functional Component

### DIFF
--- a/examples/16-3-release-blog-post/forward-ref-example.js
+++ b/examples/16-3-release-blog-post/forward-ref-example.js
@@ -6,7 +6,11 @@ function withTheme(Component) {
         {theme => (
           // Assign the custom prop "forwardedRef" as a ref
           // highlight-next-line
-          <Component {...rest} ref={forwardedRef} theme={theme} />
+          <Component
+            {...rest}
+            ref={forwardedRef}
+            theme={theme}
+          />
         )}
       </ThemeContext.Consumer>
     );

--- a/examples/16-3-release-blog-post/forward-ref-example.js
+++ b/examples/16-3-release-blog-post/forward-ref-example.js
@@ -20,9 +20,21 @@ function withTheme(Component) {
   // We can pass it along to ThemedComponent as a regular prop, e.g. "forwardedRef"
   // And it can then be attached to the Component.
   // highlight-range{1-3}
-  return React.forwardRef((props, ref) => (
-    <ThemedComponent {...props} forwardedRef={ref} />
-  ));
+  function refForwarder(props, ref) {
+    return (
+      <ThemedComponent {...props} forwardedRef={ref} />
+    );
+  }
+
+  // These next lines are not necessary,
+  // But they do give the component a better display name in DevTools,
+  // e.g. "ForwardRef(withTheme(MyComponent))"
+  // highlight-range{1-2}
+  const name = Component.displayName || Component.name;
+  refForwarder.displayName = `withTheme(${name})`;
+
+  // highlight-next-line
+  return React.forwardRef(refForwarder);
 }
 
 // highlight-next-line

--- a/examples/16-3-release-blog-post/forward-ref-example.js
+++ b/examples/16-3-release-blog-post/forward-ref-example.js
@@ -1,27 +1,24 @@
 function withTheme(Component) {
-  // Note the second param "ref" provided by React.forwardRef.
-  // We can attach this to Component directly.
-  // highlight-range{1,5}
-  function ThemedComponent(props, ref) {
+  // highlight-next-line
+  function ThemedComponent({forwardedRef, ...rest}) {
     return (
       <ThemeContext.Consumer>
         {theme => (
-          <Component {...props} ref={ref} theme={theme} />
+          // Assign the custom prop "forwardedRef" as a ref
+          // highlight-next-line
+          <Component {...rest} ref={forwardedRef} theme={theme} />
         )}
       </ThemeContext.Consumer>
     );
   }
 
-  // These next lines are not necessary,
-  // But they do give the component a better display name in DevTools,
-  // e.g. "ForwardRef(withTheme(MyComponent))"
-  // highlight-range{1-2}
-  const name = Component.displayName || Component.name;
-  ThemedComponent.displayName = `withTheme(${name})`;
-
-  // Tell React to pass the "ref" to ThemedComponent.
-  // highlight-next-line
-  return React.forwardRef(ThemedComponent);
+  // Note the second param "ref" provided by React.forwardRef.
+  // We can pass it along to ThemedComponent as a regular prop, e.g. "forwardedRef"
+  // And it can then be attached to the Component.
+  // highlight-range{1-3}
+  return React.forwardRef((props, ref) => (
+    <ThemedComponent {...props} forwardedRef={ref} />
+  ));
 }
 
 // highlight-next-line

--- a/examples/16-3-release-blog-post/forward-ref-example.js
+++ b/examples/16-3-release-blog-post/forward-ref-example.js
@@ -20,21 +20,9 @@ function withTheme(Component) {
   // We can pass it along to ThemedComponent as a regular prop, e.g. "forwardedRef"
   // And it can then be attached to the Component.
   // highlight-range{1-3}
-  function refForwarder(props, ref) {
-    return (
-      <ThemedComponent {...props} forwardedRef={ref} />
-    );
-  }
-
-  // These next lines are not necessary,
-  // But they do give the component a better display name in DevTools,
-  // e.g. "ForwardRef(withTheme(MyComponent))"
-  // highlight-range{1-2}
-  const name = Component.displayName || Component.name;
-  refForwarder.displayName = `withTheme(${name})`;
-
-  // highlight-next-line
-  return React.forwardRef(refForwarder);
+  return React.forwardRef((props, ref) => (
+    <ThemedComponent {...props} forwardedRef={ref} />
+  ));
 }
 
 // highlight-next-line


### PR DESCRIPTION
`React.forwardRef` accepts a function like `render(props: Props, ref: Refs)`, which is similar with Functional Component but Functional Component accepts a legacy context as the 2nd argument.

I know `React.forwardRef` works fine with Functional Component in most case but  I think it should distinguish between them.