### PR TITLE
Use correct component name in context doc example

### DIFF
--- a/examples/context/forwarding-refs-fancy-button.js
+++ b/examples/context/forwarding-refs-fancy-button.js
@@ -11,6 +11,6 @@ class FancyButton extends React.Component {
 // highlight-range{1,3}
 export default React.forwardRef((props, ref) => (
   <ThemeContext.Consumer>
-    {theme => <Button {...props} theme={theme} ref={ref} />}
+    {theme => <FancyButton {...props} theme={theme} ref={ref} />}
   </ThemeContext.Consumer>
 ));

--- a/examples/context/forwarding-refs-fancy-button.js
+++ b/examples/context/forwarding-refs-fancy-button.js
@@ -11,6 +11,8 @@ class FancyButton extends React.Component {
 // highlight-range{1,3}
 export default React.forwardRef((props, ref) => (
   <ThemeContext.Consumer>
-    {theme => <FancyButton {...props} theme={theme} ref={ref} />}
+    {theme => (
+      <FancyButton {...props} theme={theme} ref={ref} />
+    )}
   </ThemeContext.Consumer>
 ));


### PR DESCRIPTION
I'm assuming the intention was to reference the `FancyButton` component defined directly above, unless I'm misunderstanding how to read this example.
