### PR TITLE
Update forwarding-refs-fancy-button.js

### DIFF
--- a/examples/context/forwarding-refs-fancy-button.js
+++ b/examples/context/forwarding-refs-fancy-button.js
@@ -11,6 +11,6 @@ class FancyButton extends React.Component {
 // highlight-range{1,3}
 export default React.forwardRef((props, ref) => (
   <ThemeContext.Consumer>
-    {theme => <Button {...props} theme={theme} ref={ref} />}
+    {theme => <FancyButton {...props} theme={theme} ref={ref} />}
   </ThemeContext.Consumer>
 ));


### PR DESCRIPTION
This should be `FancyButton` or else it wouldn't make sense



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
