### PR TITLE
Fix cDU to correctly make async request

### DIFF
--- a/examples/update-on-async-rendering/updating-external-data-when-props-change-after.js
+++ b/examples/update-on-async-rendering/updating-external-data-when-props-change-after.js
@@ -25,7 +25,7 @@ class ExampleComponent extends React.Component {
 
   // highlight-range{1-5}
   componentDidUpdate(prevProps, prevState) {
-    if (prevState.externalData === null) {
+    if (this.state.externalData === null) {
       this._loadAsyncData(this.props.id);
     }
   }


### PR DESCRIPTION
When a new `id` prop is passed in, `getDerivedStateFromProps` sets `this.state.externalData` to `null`. If I understand the new API correctly the return value of gDSFP() either becomes the new state or is merged into the prev state? If so, then `componentDidUpdate` should examine the new state (`this.state.externalData`), not `prevState.externalData`. Otherwise the async request will never happen.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
