### PR TITLE
Fix: added missing component instantiation within the 'forwardRef' AP…

### DIFF
--- a/examples/16-3-release-blog-post/forward-ref-example.js
+++ b/examples/16-3-release-blog-post/forward-ref-example.js
@@ -24,6 +24,10 @@ function withTheme(Component) {
   return React.forwardRef(ThemedComponent);
 }
 
+// Here we assume that FancyButton has been imported into the current scope
+const FancyThemedButton = withTheme(FancyButton);
+
+// Create a ref using the new Referenace API, as above
 // highlight-next-line
 const fancyButtonRef = React.createRef();
 


### PR DESCRIPTION
Adding in missing component instantiation within the `fowardRef API` example, on the latest blog post about the release of v16.3. The omission of the instantiation could be a bit confusing for some people as the component is used before being defined. 

thanks,