### PR TITLE
Fix broken URL in the components-and-props.md page

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -89,7 +89,7 @@ Let's recap what happens in this example:
 >
 >React treats components starting with lowercase letters as DOM tags. For example, `<div />` represents an HTML div tag, but `<Welcome />` represents a component and requires `Welcome` to be in scope.
 >
->You can read more about the reasoning behind this convention [here.](https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized)
+>You can read more about the reasoning behind this convention [here.](/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized)
 
 ## Composing Components
 


### PR DESCRIPTION
The absolute URL is treated as relative, which leads to Page Not Found.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
