### PR TITLE
Add contributing guidelines reference to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 ## Contributing
 
+### Guidelines
+
+Different documentation sections have a different tone and style on purpose. Before contributing, make yourself familiar with the intended style for a certain section by reading the [contributing guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md).
+
 ### Create a branch
 
 1. `git checkout master` from any folder in your local `reactjs.org` repository

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 ### Guidelines
 
-Different documentation sections have a different tone and style on purpose. Before contributing, make yourself familiar with the intended style for a certain section by reading the [contributing guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md).
+The documentation is divided into several sections with a different tone and purpose. If you plan to write more than a few sentences, you might find it helpful to get familiar with the [contributing guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#guidelines-for-text) for the appropriate sections.
 
 ### Create a branch
 


### PR DESCRIPTION
Figured since the guidelines already exist, might as well reference them in the "how to contribute" section :)