### PR TITLE
Remove overwriting a default rule from .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,6 @@
   "bracketSpacing": false,
   "jsxBracketSameLine": true,
   "parser": "flow",
-  "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
According to http://json.schemastore.org/prettierrc, printWidth default is already 80.
