### PR TITLE
Updated react-lifecycles-compat example to show 2.0 named export

### DIFF
--- a/examples/update-on-async-rendering/using-react-lifecycles-compat.js
+++ b/examples/update-on-async-rendering/using-react-lifecycles-compat.js
@@ -1,6 +1,6 @@
 import React from 'react';
 // highlight-next-line
-import polyfill from 'react-lifecycles-compat';
+import {polyfill} from 'react-lifecycles-compat';
 
 class ExampleComponent extends React.Component {
   // highlight-next-line


### PR DESCRIPTION
Corresponds to reactjs/react-lifecycles-compat/pull/11