### PR TITLE
Move constructor out of render

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -147,21 +147,22 @@ To set focus in React, we can use [Refs to DOM elements](/docs/refs-and-the-dom.
 Using this, we first create a ref to an element in the JSX of a component class:
 
 ```javascript{4-5,8-9,13}
-render() {
+class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
     // Create a ref to store the textInput DOM element
     this.textInput = React.createRef();
   }
-  // ...
+  render() {
   // Use the `ref` callback to store a reference to the text input DOM
   // element in an instance field (for example, this.textInput).
-  return (
-    <input
-      type="text"
-      ref={this.textInput}
-    />
-  );
+    return (
+      <input
+        type="text"
+        ref={this.textInput}
+      />
+    );
+  }
 }
 ```
 


### PR DESCRIPTION
Fix React.createRef example.

Before:
<img width="658" alt="screen shot 2018-04-05 at 2 18 08 pm" src="https://user-images.githubusercontent.com/6605437/38384337-deadc23e-38dc-11e8-8926-dd687b83474d.png">

After:
<img width="645" alt="screen shot 2018-04-05 at 2 17 54 pm" src="https://user-images.githubusercontent.com/6605437/38384344-e4b76df6-38dc-11e8-89ee-0f2a1c41cf74.png">

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
