### PR TITLE
Added updating nested context default value example

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -97,6 +97,9 @@ A more complex example with dynamic values for the theme:
 
 It is often necessary to update the context from a component that is nested somewhere deeply in the component tree. In this case you can pass a function down through the context to allow consumers to update the context:
 
+**theme-context.js**
+`embed:context/updating-nested-context-context.js`
+
 **theme-toggler-button.js**
 `embed:context/updating-nested-context-theme-toggler-button.js`
 

--- a/examples/context/updating-nested-context-context.js
+++ b/examples/context/updating-nested-context-context.js
@@ -4,7 +4,7 @@
 // highlight-range{2-4}
 export const ThemeContext = React.createContext({
   theme: themes.dark,
-  // optionally you can pass functions that log an error
+  // implement default behavior...
   toggleTheme: () =>
     console.error('default toggleTheme called'),
 });

--- a/examples/context/updating-nested-context-context.js
+++ b/examples/context/updating-nested-context-context.js
@@ -1,0 +1,10 @@
+// highlight-range{1-2}
+// Make sure the shape of the default value passed to
+// createContext matches the shape that the consumers expect!
+// highlight-range{2-4}
+export const ThemeContext = React.createContext({
+  theme: themes.dark,
+  // optionally you can pass functions that log an error
+  toggleTheme: () =>
+    console.error('default toggleTheme called'),
+});

--- a/examples/context/updating-nested-context-context.js
+++ b/examples/context/updating-nested-context-context.js
@@ -1,10 +1,8 @@
 // highlight-range{1-2}
 // Make sure the shape of the default value passed to
 // createContext matches the shape that the consumers expect!
-// highlight-range{2-4}
+// highlight-range{2-3}
 export const ThemeContext = React.createContext({
   theme: themes.dark,
-  // implement default behavior...
-  toggleTheme: () =>
-    console.error('default toggleTheme called'),
+  toggleTheme: () => {},
 });


### PR DESCRIPTION
Small addition to https://github.com/reactjs/reactjs.org/pull/776
It was missing an example showing how the default value for the context needs to change to match the value passed to the provider.