### PR TITLE
Dynamically append path alias (aaa/bbb.html = aaa/bbb = aaa/bbb/) int…

### DIFF
--- a/content/docs/reference-pure-render-mixin.md
+++ b/content/docs/reference-pure-render-mixin.md
@@ -3,7 +3,7 @@ id: pure-render-mixin
 title: PureRenderMixin
 layout: docs
 category: Reference
-permalink: docs/pure-render-mixin.html
+permalink: docs/pure-render-mixin-old.html
 ---
 
 > Note

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -10,16 +10,14 @@
 const BLOG_POST_FILENAME_REGEX = /([0-9]+)\-([0-9]+)\-([0-9]+)\-(.+)\.md$/;
 
 function buildRedirectString(permalink, redirect_from) {
-  if (!permalink || permalink.indexOf('.html') === -1) {
-    return '';
+  if (!permalink || !permalink.endsWith('.html')) {
+    return redirect_from ? JSON.stringify(redirect_from) : '';
   }
 
-  let basePath = permalink.slice(0, permalink.indexOf('.html'));
+  let basePath = permalink.slice(0, -'.html'.length);
   let redirects = [basePath, basePath + '/'];
   if (Array.isArray(redirect_from)) {
     redirects = redirects.concat(redirect_from);
-  //} else if (redirect_from) {
-  //  redirects.push(redirect_from);
   }
 
   return JSON.stringify(redirects);

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -9,20 +9,20 @@
 // Parse date information out of blog post filename.
 const BLOG_POST_FILENAME_REGEX = /([0-9]+)\-([0-9]+)\-([0-9]+)\-(.+)\.md$/;
 
-function addPathAliasToRedirects(permalink, redirect_from) {
-  if (!permalink || !redirect_from || permalink.indexOf('.html') === -1) {
-    return redirect_from;
+function buildRedirectString(permalink, redirect_from) {
+  if (!permalink || permalink.indexOf('.html') === -1) {
+    return '';
   }
 
   let basePath = permalink.slice(0, permalink.indexOf('.html'));
   let redirects = [basePath, basePath + '/'];
   if (Array.isArray(redirect_from)) {
     redirects = redirects.concat(redirect_from);
-  } else {
-    redirects.push(redirect_from);
+  //} else if (redirect_from) {
+  //  redirects.push(redirect_from);
   }
 
-  return redirects;
+  return JSON.stringify(redirects);
 }
 
 // Add custom fields to MarkdownRemark nodes.
@@ -83,7 +83,7 @@ module.exports = exports.onCreateNode = ({node, boundActionCreators, getNode}) =
       createNodeField({
         node,
         name: 'redirect',
-        value: redirect_from ? JSON.stringify(addPathAliasToRedirects(permalink, redirect_from)) : '',
+        value: buildRedirectString(permalink, redirect_from),
       });
 
       return;

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -9,6 +9,22 @@
 // Parse date information out of blog post filename.
 const BLOG_POST_FILENAME_REGEX = /([0-9]+)\-([0-9]+)\-([0-9]+)\-(.+)\.md$/;
 
+function addPathAliasToRedirects(permalink, redirect_from) {
+  if (!permalink || !redirect_from || permalink.indexOf('.html') === -1) {
+    return redirect_from;
+  }
+
+  let basePath = permalink.slice(0, permalink.indexOf('.html'));
+  let redirects = [basePath, basePath + '/'];
+  if (Array.isArray(redirect_from)) {
+    redirects = redirects.concat(redirect_from);
+  } else {
+    redirects.push(redirect_from);
+  }
+
+  return redirects;
+}
+
 // Add custom fields to MarkdownRemark nodes.
 module.exports = exports.onCreateNode = ({node, boundActionCreators, getNode}) => {
   const {createNodeField} = boundActionCreators;
@@ -67,8 +83,9 @@ module.exports = exports.onCreateNode = ({node, boundActionCreators, getNode}) =
       createNodeField({
         node,
         name: 'redirect',
-        value: redirect_from ? JSON.stringify(redirect_from) : '',
+        value: redirect_from ? JSON.stringify(addPathAliasToRedirects(permalink, redirect_from)) : '',
       });
+
       return;
   }
 };


### PR DESCRIPTION
This PR tries to fix #605 

The issue is following 404 pages, such as:

* [`https://reactjs.org/docs/hello-world`](https://reactjs.org/docs/hello-world)
* [`https://reactjs.org/docs/hello-world/`](https://reactjs.org/docs/hello-world/)

As we can see, only https://reactjs.org/docs/hello-world.html can work correctly. The common alias we consider the same as it won't work.

The brute force approach for this issue might be simply modifying all *.md files for the `redirect_from` to include the **alias** paths. However, I think a better approach will be to append those **alias** path dynamically during gatsby's `onCreateNode` API. 
