### PR TITLE
Update conference date

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -58,7 +58,7 @@ August 16-17 in Salt Lake City, Utah USA
 [Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
 
 ### #byteconf\_react\_2018
-August 23-24 streamed online, via Twitch
+August 30-31 streamed online, via Twitch
 
 [Website](https://byteconf.com) - [Twitter](https://twitter.com/byteconf)
 


### PR DESCRIPTION
We've adjusted the date for #byteconf_react_2018 after https://github.com/reactjs/reactjs.org/pull/777 to avoid conflicts with another conference!

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
