### PR TITLE
Fixed invalid getSnapshotBeforeUpdate() example code

### DIFF
--- a/examples/react-component-reference/get-snapshot-before-update.js
+++ b/examples/react-component-reference/get-snapshot-before-update.js
@@ -1,5 +1,8 @@
 class ScrollingList extends React.Component {
-  listRef = React.createRef();
+  constructor(props) {
+    super(props);
+    this.listRef = React.createRef();
+  }
 
   getSnapshotBeforeUpdate(prevProps, prevState) {
     // Are we adding new items to the list?

--- a/examples/react-component-reference/get-snapshot-before-update.js
+++ b/examples/react-component-reference/get-snapshot-before-update.js
@@ -3,9 +3,10 @@ class ScrollingList extends React.Component {
 
   getSnapshotBeforeUpdate(prevProps, prevState) {
     // Are we adding new items to the list?
-    // Capture the current height of the list so we can adjust scroll later.
+    // Capture the scroll position so we can adjust scroll later.
     if (prevProps.list.length < this.props.list.length) {
-      return this.listRef.current.scrollHeight;
+      const list = this.listRef.current;
+      return list.scrollHeight - list.scrollTop;
     }
     return null;
   }
@@ -13,9 +14,10 @@ class ScrollingList extends React.Component {
   componentDidUpdate(prevProps, prevState, snapshot) {
     // If we have a snapshot value, we've just added new items.
     // Adjust scroll so these new items don't push the old ones out of view.
+    // (snapshot here is the value returned from getSnapshotBeforeUpdate)
     if (snapshot !== null) {
-      this.listRef.current.scrollTop +=
-        this.listRef.current.scrollHeight - snapshot;
+      const list = this.listRef.current;
+      list.scrollTop = list.scrollHeight - snapshot;
     }
   }
 

--- a/examples/update-on-async-rendering/react-dom-properties-before-update-after.js
+++ b/examples/update-on-async-rendering/react-dom-properties-before-update-after.js
@@ -1,12 +1,14 @@
 class ScrollingList extends React.Component {
   listRef = null;
 
-  // highlight-range{1-8}
+  // highlight-range{1-10}
   getSnapshotBeforeUpdate(prevProps, prevState) {
     // Are we adding new items to the list?
-    // Capture the current height of the list so we can adjust scroll later.
+    // Capture the scroll position so we can adjust scroll later.
     if (prevProps.list.length < this.props.list.length) {
-      return this.listRef.scrollHeight;
+      return (
+        this.listRef.scrollHeight - this.listRef.scrollTop
+      );
     }
     return null;
   }
@@ -17,7 +19,7 @@ class ScrollingList extends React.Component {
     // Adjust scroll so these new items don't push the old ones out of view.
     // (snapshot here is the value returned from getSnapshotBeforeUpdate)
     if (snapshot !== null) {
-      this.listRef.scrollTop +=
+      this.listRef.scrollTop =
         this.listRef.scrollHeight - snapshot;
     }
   }

--- a/examples/update-on-async-rendering/react-dom-properties-before-update-before.js
+++ b/examples/update-on-async-rendering/react-dom-properties-before-update-before.js
@@ -1,25 +1,26 @@
 class ScrollingList extends React.Component {
   listRef = null;
-  previousScrollHeight = null;
+  previousScrollOffset = null;
 
-  // highlight-range{1-7}
+  // highlight-range{1-8}
   componentWillUpdate(nextProps, nextState) {
     // Are we adding new items to the list?
-    // Capture the current height of the list so we can adjust scroll later.
+    // Capture the scroll position so we can adjust scroll later.
     if (this.props.list.length < nextProps.list.length) {
-      this.previousScrollHeight = this.listRef.scrollHeight;
+      this.previousScrollOffset =
+        this.listRef.scrollHeight - this.listRef.scrollTop;
     }
   }
 
   // highlight-range{1-10}
   componentDidUpdate(prevProps, prevState) {
-    // If previousScrollHeight is set, we've just added new items.
+    // If previousScrollOffset is set, we've just added new items.
     // Adjust scroll so these new items don't push the old ones out of view.
-    if (this.previousScrollHeight !== null) {
-      this.listRef.scrollTop +=
+    if (this.previousScrollOffset !== null) {
+      this.listRef.scrollTop =
         this.listRef.scrollHeight -
-        this.previousScrollHeight;
-      this.previousScrollHeight = null;
+        this.previousScrollOffset;
+      this.previousScrollOffset = null;
     }
   }
 


### PR DESCRIPTION
Realized the code example for `getSnapshotBeforeUpdate()` didn't make sense. It's been fixed (and can be played with [here](https://codesandbox.io/s/2w2zrnz89r)).

The two sections that have been updated are [the component reference](https://deploy-preview-799--reactjs.netlify.com/docs/react-component.html#getsnapshotbeforeupdate) and [this update recipe](https://deploy-preview-799--reactjs.netlify.com/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update).

Related Twitter thread: https://twitter.com/brian_d_vaughn/status/984604747511382016