### PR TITLE
Added redirects for old React versions

### DIFF
--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,9 +1,12 @@
 - title: '16.2.0'
   path: /version/16.2
   url: https://5abc31d8be40f1556f06c4be--reactjs.netlify.com
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1620-november-28-2017
 - title: '16.1.1'
   path: /version/16.1
   url: https://5a1dbcf14c4b93299e65b9a9--reactjs.netlify.com
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1611-november-13-2017
 - title: '16.0.0'
   path: /version/16.0
   url: https://5a046bf5a6188f4b8fa4938a--reactjs.netlify.com
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1600-september-26-2017

--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,3 +1,5 @@
+- title: '16.3.1'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1631-april-3-2018
 - title: '16.2.0'
   path: /version/16.2
   url: https://5abc31d8be40f1556f06c4be--reactjs.netlify.com

--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,0 +1,9 @@
+- title: '16.2.0'
+  path: /version/16.2
+  url: https://5abc31d8be40f1556f06c4be--reactjs.netlify.com
+- title: '16.1.1'
+  path: /version/16.1
+  url: https://5a1dbcf14c4b93299e65b9a9--reactjs.netlify.com
+- title: '16.0.0'
+  path: /version/16.0
+  url: https://5a046bf5a6188f4b8fa4938a--reactjs.netlify.com

--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,5 +1,5 @@
-- title: '16.3.1'
-  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1631-april-3-2018
+- title: '16.3.2'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1632-april-16-2018
 - title: '16.2.0'
   path: /version/16.2
   url: https://5abc31d8be40f1556f06c4be--reactjs.netlify.com

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,6 +20,7 @@ module.exports = {
     'gatsby-source-react-error-codes',
     'gatsby-transformer-authors-yaml',
     'gatsby-transformer-home-example-code',
+    'gatsby-transformer-versions-yaml',
     'gatsby-plugin-netlify',
     'gatsby-plugin-glamor',
     'gatsby-plugin-react-next',

--- a/plugins/gatsby-transformer-versions-yaml/create-redirects.js
+++ b/plugins/gatsby-transformer-versions-yaml/create-redirects.js
@@ -1,0 +1,65 @@
+const {appendFile, exists, readFile, writeFile} = require('fs-extra');
+
+const HEADER_COMMENT = `## Created with gatsby-transformer-versions-yaml`;
+
+module.exports = async function writeRedirectsFile(redirects, publicFolder) {
+  if (!redirects.length) {
+    return null;
+  }
+
+  const FILE_PATH = publicFolder(`_redirects`);
+
+  // Map redirect data to the format Netlify expects
+  // https://www.netlify.com/docs/redirects/
+  redirects = redirects.map(redirect => {
+    const {
+      fromPath,
+      isPermanent,
+      redirectInBrowser, // eslint-disable-line no-unused-vars
+      toPath,
+      ...rest
+    } = redirect;
+
+    // The order of the first 3 parameters is significant.
+    // The order for rest params (key-value pairs) is arbitrary.
+    const pieces = [
+      fromPath,
+      toPath,
+      isPermanent ? 301 : 302, // Status
+    ];
+
+    for (let key in rest) {
+      const value = rest[key];
+
+      if (typeof value === `string` && value.indexOf(` `) >= 0) {
+        console.warn(
+          `Invalid redirect value "${value}" specified for key "${key}". ` +
+            `Values should not contain spaces.`,
+        );
+      } else {
+        pieces.push(`${key}=${value}`);
+      }
+    }
+
+    return pieces.join(`  `);
+  });
+
+  let appendToFile = false;
+
+  // Websites may also have statically defined redirects
+  // In that case we should append to them (not overwrite)
+  // Make sure we aren't just looking at previous build results though
+  const fileExists = await exists(FILE_PATH);
+  if (fileExists) {
+    const fileContents = await readFile(FILE_PATH);
+    if (fileContents.indexOf(HEADER_COMMENT) < 0) {
+      appendToFile = true;
+    }
+  }
+
+  const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`;
+
+  return appendToFile
+    ? appendFile(FILE_PATH, `\n\n${data}`)
+    : writeFile(FILE_PATH, data);
+};

--- a/plugins/gatsby-transformer-versions-yaml/create-redirects.js
+++ b/plugins/gatsby-transformer-versions-yaml/create-redirects.js
@@ -2,12 +2,15 @@ const {appendFile, exists, readFile, writeFile} = require('fs-extra');
 
 const HEADER_COMMENT = `## Created with gatsby-transformer-versions-yaml`;
 
-module.exports = async function writeRedirectsFile(redirects, publicFolder) {
+// Patterned after the 'gatsby-plugin-netlify' plug-in:
+// https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-netlify/src/create-redirects.js
+module.exports = async function writeRedirectsFile(
+  redirects,
+  redirectsFilePath,
+) {
   if (!redirects.length) {
     return null;
   }
-
-  const FILE_PATH = publicFolder(`_redirects`);
 
   // Map redirect data to the format Netlify expects
   // https://www.netlify.com/docs/redirects/
@@ -20,8 +23,7 @@ module.exports = async function writeRedirectsFile(redirects, publicFolder) {
       ...rest
     } = redirect;
 
-    // The order of the first 3 parameters is significant.
-    // The order for rest params (key-value pairs) is arbitrary.
+    // The order of these parameters is significant.
     const pieces = [
       fromPath,
       toPath,
@@ -49,9 +51,9 @@ module.exports = async function writeRedirectsFile(redirects, publicFolder) {
   // Websites may also have statically defined redirects
   // In that case we should append to them (not overwrite)
   // Make sure we aren't just looking at previous build results though
-  const fileExists = await exists(FILE_PATH);
+  const fileExists = await exists(redirectsFilePath);
   if (fileExists) {
-    const fileContents = await readFile(FILE_PATH);
+    const fileContents = await readFile(redirectsFilePath);
     if (fileContents.indexOf(HEADER_COMMENT) < 0) {
       appendToFile = true;
     }
@@ -60,6 +62,6 @@ module.exports = async function writeRedirectsFile(redirects, publicFolder) {
   const data = `${HEADER_COMMENT}\n\n${redirects.join(`\n`)}`;
 
   return appendToFile
-    ? appendFile(FILE_PATH, `\n\n${data}`)
-    : writeFile(FILE_PATH, data);
+    ? appendFile(redirectsFilePath, `\n\n${data}`)
+    : writeFile(redirectsFilePath, data);
 };

--- a/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
@@ -20,7 +20,7 @@ exports.onPostBuild = async ({store}) => {
 
   // versions.yml structure is [{path: string, url: string, ...}, ...]
   createRedirects(
-    versions.map(version => ({
+    versions.filter(version => version.path && version.url).map(version => ({
       fromPath: version.path,
       toPath: version.url,
     })),

--- a/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
@@ -7,26 +7,23 @@ const path = require('path');
 // Reads versions.yml data into GraphQL.
 // This is used to generate redirect rules for older documentation versions.
 exports.onPostBuild = async ({store}) => {
-  const path = resolve(__dirname, '../../content/versions.yml');
-  const file = readFileSync(path, 'utf8');
+  const versionsFile = resolve(__dirname, '../../content/versions.yml');
+  const file = readFileSync(versionsFile, 'utf8');
   const versions = safeLoad(file);
 
-  // versions.yml structure is [{title: string, path: string, url: string}, ...]
+  const {program} = store.getState();
+  const redirectsFilePath = path.join(
+    program.directory,
+    'public',
+    '_redirects',
+  );
+
+  // versions.yml structure is [{path: string, url: string, ...}, ...]
   createRedirects(
     versions.map(version => ({
       fromPath: version.path,
       toPath: version.url,
     })),
-    getPublicFolder(store),
+    redirectsFilePath,
   );
 };
-
-function buildPrefixer(prefix, ...paths) {
-  return (...subpaths) => path.join(prefix, ...paths, ...subpaths);
-}
-
-function getPublicFolder(store) {
-  const {program} = store.getState();
-
-  return buildPrefixer(program.directory, `public`);
-}

--- a/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
@@ -1,0 +1,32 @@
+const readFileSync = require('fs').readFileSync;
+const resolve = require('path').resolve;
+const safeLoad = require('js-yaml').safeLoad;
+const createRedirects = require('./create-redirects');
+const path = require('path');
+
+// Reads versions.yml data into GraphQL.
+// This is used to generate redirect rules for older documentation versions.
+exports.onPostBuild = async ({store}) => {
+  const path = resolve(__dirname, '../../content/versions.yml');
+  const file = readFileSync(path, 'utf8');
+  const versions = safeLoad(file);
+
+  // versions.yml structure is [{title: string, path: string, url: string}, ...]
+  createRedirects(
+    versions.map(version => ({
+      fromPath: version.path,
+      toPath: version.url,
+    })),
+    getPublicFolder(store),
+  );
+};
+
+function buildPrefixer(prefix, ...paths) {
+  return (...subpaths) => path.join(prefix, ...paths, ...subpaths);
+}
+
+function getPublicFolder(store) {
+  const {program} = store.getState();
+
+  return buildPrefixer(program.directory, `public`);
+}

--- a/plugins/gatsby-transformer-versions-yaml/package.json
+++ b/plugins/gatsby-transformer-versions-yaml/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "gatsby-transformer-versions-yaml",
+  "version": "0.0.1"
+}

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -10,9 +10,9 @@ import HeaderLink from './HeaderLink';
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, fonts, media} from 'theme';
+import {version} from 'site-constants';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';
 import DocSearch from './DocSearch';
-import VersionToggler from './VersionToggler';
 
 import logoSvg from 'icons/logo.svg';
 
@@ -146,7 +146,25 @@ const Header = ({location}: {location: Location}) => (
               width: 'calc(100% / 6)',
             },
           }}>
-          <VersionToggler />
+          <a
+            css={{
+              padding: '5px 10px',
+              whiteSpace: 'nowrap',
+              ...fonts.small,
+
+              ':hover': {
+                color: colors.brand,
+              },
+
+              ':focus': {
+                outline: 0,
+                backgroundColor: colors.lighter,
+                borderRadius: 15,
+              },
+            }}
+            href="/versions">
+            v{version}
+          </a>
           <a
             css={{
               padding: '5px 10px',

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -10,9 +10,9 @@ import HeaderLink from './HeaderLink';
 import Link from 'gatsby-link';
 import React from 'react';
 import {colors, fonts, media} from 'theme';
-import {version} from 'site-constants';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';
 import DocSearch from './DocSearch';
+import VersionToggler from './VersionToggler';
 
 import logoSvg from 'icons/logo.svg';
 
@@ -146,27 +146,7 @@ const Header = ({location}: {location: Location}) => (
               width: 'calc(100% / 6)',
             },
           }}>
-          <a
-            css={{
-              padding: '5px 10px',
-              whiteSpace: 'nowrap',
-              ...fonts.small,
-
-              ':hover': {
-                color: colors.brand,
-              },
-
-              ':focus': {
-                outline: 0,
-                backgroundColor: colors.lighter,
-                borderRadius: 15,
-              },
-            }}
-            href="https://github.com/facebook/react/releases"
-            target="_blank"
-            rel="noopener">
-            v{version}
-          </a>
+          <VersionToggler />
           <a
             css={{
               padding: '5px 10px',

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -39,11 +39,13 @@ const Versions = () => (
                     Changelog
                   </a>
                 </li>
-                <li>
-                  <a href={version.path} rel="nofollow">
-                    Documentation
-                  </a>
-                </li>
+                {version.path && (
+                  <li>
+                    <a href={version.path} rel="nofollow">
+                      Documentation
+                    </a>
+                  </li>
+                )}
               </ul>
             </div>
           ))}

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * @emails react-core
+ * @flow
+ */
+
+import Container from 'components/Container';
+import Header from 'components/Header';
+import TitleAndMetaTags from 'components/TitleAndMetaTags';
+import React from 'react';
+import {sharedStyles} from 'theme';
+
+const Versions = () => (
+  <Container>
+    <div css={sharedStyles.articleLayout.container}>
+      <div css={sharedStyles.articleLayout.content}>
+        <Header>React Versions</Header>
+        <TitleAndMetaTags title="React - Versions" />
+        <div css={sharedStyles.markdown}>
+          <p>
+            A complete release history for React is available{' '}
+            <a
+              href="https://github.com/facebook/react/releases"
+              target="_blank"
+              rel="noopener">
+              in GitHub
+            </a>.
+          </p>
+          <p>Documentation for recent releases can also be accessed below:</p>
+          <ul>
+            <li>
+              <a href="/version/16.2" rel="nofollow">
+                16.2.0
+              </a>
+            </li>
+            <li>
+              <a href="/version/16.1" rel="nofollow">
+                16.1.1
+              </a>
+            </li>
+            <li>
+              <a href="/version/16.0" rel="nofollow">
+                16.0.0
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </Container>
+);
+
+export default Versions;

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -11,6 +11,9 @@ import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import React from 'react';
 import {sharedStyles} from 'theme';
 
+// $FlowFixMe This is a valid path
+import versions from '../../content/versions.yml';
+
 const Versions = () => (
   <Container>
     <div css={sharedStyles.articleLayout.container}>
@@ -29,21 +32,13 @@ const Versions = () => (
           </p>
           <p>Documentation for recent releases can also be accessed below:</p>
           <ul>
-            <li>
-              <a href="/version/16.2" rel="nofollow">
-                16.2.0
-              </a>
-            </li>
-            <li>
-              <a href="/version/16.1" rel="nofollow">
-                16.1.1
-              </a>
-            </li>
-            <li>
-              <a href="/version/16.0" rel="nofollow">
-                16.0.0
-              </a>
-            </li>
+            {versions.map(version => (
+              <li key={version.title}>
+                <a href={version.path} rel="nofollow">
+                  {version.title}
+                </a>
+              </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -28,18 +28,25 @@ const Versions = () => (
               target="_blank"
               rel="noopener">
               in GitHub
-            </a>.
+            </a>. Documentation for recent releases can also be found below:
           </p>
-          <p>Documentation for recent releases can also be accessed below:</p>
-          <ul>
-            {versions.map(version => (
-              <li key={version.title}>
-                <a href={version.path} rel="nofollow">
-                  {version.title}
-                </a>
-              </li>
-            ))}
-          </ul>
+          {versions.map(version => (
+            <div key={version.title}>
+              <h3>{version.title}</h3>
+              <ul>
+                <li>
+                  <a href={version.changelog} target="_blank" rel="noopener">
+                    Changelog
+                  </a>
+                </li>
+                <li>
+                  <a href={version.path} rel="nofollow">
+                    Documentation
+                  </a>
+                </li>
+              </ul>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,5 @@
 /html-jsx.html  http://magic.reactjs.net/htmltojsx.htm  301
 /tips/controlled-input-null-value.html  /docs/forms.html#controlled-input-null-value
+
+## Testing
+/version/16.2.0/*  https://5abc31d8be40f1556f06c4be--reactjs.netlify.com/:splat  200

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,2 @@
 /html-jsx.html  http://magic.reactjs.net/htmltojsx.htm  301
 /tips/controlled-input-null-value.html  /docs/forms.html#controlled-input-null-value
-
-## Testing
-/version/16.2.0/*  https://5abc31d8be40f1556f06c4be--reactjs.netlify.com/:splat  200

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,2 @@
 /html-jsx.html  http://magic.reactjs.net/htmltojsx.htm  301
 /tips/controlled-input-null-value.html  /docs/forms.html#controlled-input-null-value
-
-/version/16.2  https://5abc31d8be40f1556f06c4be--reactjs.netlify.com/  301
-/version/16.1  https://5a1dbcf14c4b93299e65b9a9--reactjs.netlify.com/  301
-/version/16.0  https://5a046bf5a6188f4b8fa4938a--reactjs.netlify.com/  301

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,6 @@
 /html-jsx.html  http://magic.reactjs.net/htmltojsx.htm  301
 /tips/controlled-input-null-value.html  /docs/forms.html#controlled-input-null-value
+
+/version/16.2  https://5abc31d8be40f1556f06c4be--reactjs.netlify.com/  301
+/version/16.1  https://5a1dbcf14c4b93299e65b9a9--reactjs.netlify.com/  301
+/version/16.0  https://5a046bf5a6188f4b8fa4938a--reactjs.netlify.com/  301

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /version/


### PR DESCRIPTION
Use [Netlify's redirects API](https://www.netlify.com/docs/redirects/)- and the fact that Netlify caches immutable builds of older versions of the site- to expose previous versions of the React documentation via a [**new "React Versions" page**](https://deploy-preview-801--reactjs.netlify.com/versions).

I did the following to identify the correct revisions to use:
1. Lookd at the [`CHANGELOG`](https://github.com/facebook/react/blob/master/CHANGELOG.md) for release dates.
2. Cross-references [Netlify build history for the `master` branch](https://app.netlify.com/sites/reactjs/deploys?filter=master)
3. Picked the most recent build _before_ we updated the site (e.g. merged a PR that adds new API docs)

Unfortunately, our Netlify history begins with version 16 RC3 (so we can't link back to an old 15.6 release).

Since Netlify has built this PR preview as [5ad0def873f2cf6608e0d48a--reactjs.netlify.com](https://5ad0def873f2cf6608e0d48a--reactjs.netlify.com/), we should be able to test these new redirects as:
* 16.0: https://5ad0def873f2cf6608e0d48a--reactjs.netlify.com/version/16.0
* 16.1: https://5ad0def873f2cf6608e0d48a--reactjs.netlify.com/version/16.1
* 16.2: https://5ad0def873f2cf6608e0d48a--reactjs.netlify.com/version/16.2

A `robots.txt` file has also been added- along with `rel="nofollow"` attributes- to prevent search crawlers from indexing older versions of the site. (We want the latest release to be what shows up in search engines at all times.)

This versioning strategy should also work well by default with any [localization strategy](https://github.com/reactjs/reactjs.org/issues/82) we use.

**TODO**:
- [x] Add a UI mechanism for viewing old revisions
- [x] Don't let search engines crawl older versions
- [x] Make versions configurable via a single YAML file
- [ ] Determine if there's a way to use a subdomain of reactjs.org for versions rather than the netlify URL

Resolves issue #85

### Screenshot
<img width="402" alt="screen shot 2018-04-14 at 9 53 34 am" src="https://user-images.githubusercontent.com/29597/38770561-bee19cc0-3fc9-11e8-9b70-bc1b01773eec.png">