### PR TITLE
#445 Accessibility: Add a link to skip the twitter blocks

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -40,5 +40,6 @@ Some developers also hang out in [#reactjs on Freenode](http://irc.lc/freenode/r
 ## Facebook and Twitter
 
 For the latest news about React, [like us on Facebook](https://facebook.com/react) and [follow **@reactjs** on Twitter](https://twitter.com/reactjs). In addition, you can use the [#reactjs](https://twitter.com/hashtag/reactjs) hashtag to see what others are saying or add to the conversation.
-
+<a href=#continue>Skip</a>
 <div><a class="twitter-timeline" data-dnt="true" data-chrome="nofooter noheader transparent" href="https://twitter.com/search?q=%23reactjs" data-widget-id="342522405270470656"></a></div>
+<div id=continue/>


### PR DESCRIPTION
I added a simple skip link before the twitter block to allow someone navigating the page via keyboard to skip the twitter block all together.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
