### PR TITLE
Add missing single quotes to argument

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -25,7 +25,7 @@ compiles into:
 
 ```js
 React.createElement(
-  MyButton,
+  'MyButton',
   {color: 'blue', shadowSize: 2},
   'Click Me'
 )


### PR DESCRIPTION
First argument passed to React.createElement should be of type string but single quotes were omitted
