### PR TITLE
docs(refs-and-the-dom): typo in CustomTextInput

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -87,7 +87,7 @@ class CustomTextInput extends React.Component {
   }
 
   render() {
-    // tell React that we want the associate the <input> ref
+    // tell React that we want to associate the <input> ref
     // with the `textInput` that we created in the constructor
     return (
       <div>


### PR DESCRIPTION
Correct a typo in the render method comments for the "CustomTextInput" component of the "Adding a Ref to a DOM Element" example.  The first line of the comments reads "tell React that we want the associate the <input> ref".  The word "the" should be "to" resulting in the comment "tell React that we want to associate the <input> ref".



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
