### PR TITLE
docs(error-boundaries):remove react beta reference

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -84,7 +84,7 @@ componentDidCatch(error, info) {
 
 ## Live Demo
 
-Check out [this example of declaring and using an error boundary](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) with [React 16 beta](https://github.com/facebook/react/issues/10294).
+Check out [this example of declaring and using an error boundary](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) with [React 16](https://reactjs.org/blog/2017/09/26/react-v16.0.html).
 
 
 ## Where to Place Error Boundaries


### PR DESCRIPTION
Noticed a reference to React Beta while going through the Error Boundaries documentation.
I believe it should point to the React 16 release notes instead.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
