### PR TITLE
Remove meeting notes section because core-notes no longer maintained

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -161,9 +161,13 @@ You may be interested in watching [this short video](https://www.youtube.com/wat
 
 For a realistic overview of what it _feels_ like to contribute to React for the first time, check out [this entertaining ReactNYC talk](https://www.youtube.com/watch?v=GWCcZ6fnpn4).
 
-### Meeting Notes
+### Request for Comments (RFC)
 
-React team meets once a week to discuss the development of React, future plans, and priorities. You can find the meeting notes in a [dedicated repository](https://github.com/reactjs/core-notes/).
+Many changes, including bug fixes and documentation improvements can be implemented and reviewed via the normal GitHub pull request workflow.
+
+Some changes though are "substantial", and we ask that these be put through a bit of a design process and produce a consensus among the React core team.
+
+The "RFC" (request for comments) process is intended to provide a consistent and controlled path for new features to enter the project. You can contribute by visiting the [rfcs repository](https://github.com/reactjs/rfcs).
 
 ### License
 


### PR DESCRIPTION
See [core-notes issue 40](https://github.com/reactjs/core-notes/issues/40#issuecomment-352648271) for more details. The core-notes repository is no longer being maintained but documentation still refers people to go to that repository.

We could update it to tell people to visit the rfcs repository instead and if necessary I can make that change as well but I agree with what @seanmadsen mentioned which is we shouldn't be mentioning it in the documentation anymore.

Feel free to reject/close if unnecessary :)