### PR TITLE
Fix elmish-react link on static-type-checking

### DIFF
--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -319,4 +319,4 @@ JetBrains develops and maintains several tools specifically for the React commun
 
 ## Other Languages
 
-Note there are other statically typed languages that compile to JavaScript and are thus React compatible. For example, [F#/Fable](http://fable.io) with [elmish-react](https://fable-elmish.github.io/react). Check out their respective sites for more information, and feel free to add more statically typed languages that work with React to this page!
+Note there are other statically typed languages that compile to JavaScript and are thus React compatible. For example, [F#/Fable](http://fable.io) with [elmish-react](https://elmish.github.io/react). Check out their respective sites for more information, and feel free to add more statically typed languages that work with React to this page!


### PR DESCRIPTION
`fable-elmish` org is now simply `elmish`, thus the link to `elmish-react` was 404.

ref https://github.com/elmish/elmish/issues/145

