### PR TITLE
Repeating link to main website corrected

### DIFF
--- a/content/blog/2013-06-05-why-react.md
+++ b/content/blog/2013-06-05-why-react.md
@@ -80,7 +80,7 @@ some pretty cool things with it:
   (including IE8) and automatically use
   [event delegation](http://davidwalsh.name/event-delegate).
 
-Head on over to https://reactjs.org to check out what we have
+Head on over to [https://reactjs.org](https://reactjs.org) to check out what we have
 built. Our documentation is geared towards building apps with the framework,
 but if you are interested in the nuts and bolts
 [get in touch](/support.html) with us!


### PR DESCRIPTION
Clicking on the previous link redirected to: https://reactjs.org/https://reactjs.org
Its a 404 page.
Maybe instead of the whole link, we can use something like: [https://reactjs.org](/)



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
