### PR TITLE
Remove domain from links

### DIFF
--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -50,7 +50,7 @@ render() {
 }
 ```
 
-To address this limitation, React 16.0 added support for [returning an array of elements from a component's `render` method](https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings). Instead of wrapping the children in a DOM element, you can put them into an array:
+To address this limitation, React 16.0 added support for [returning an array of elements from a component's `render` method](/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings). Instead of wrapping the children in a DOM element, you can put them into an array:
 
 ```jsx
 render() {
@@ -67,7 +67,7 @@ render() {
 However, this has some confusing differences from normal JSX:
 
 - Children in an array must be separated by commas.
-- Children in an array must have a key to prevent React's [key warning](https://reactjs.org/docs/lists-and-keys.html#keys).
+- Children in an array must have a key to prevent React's [key warning](/docs/lists-and-keys.html#keys).
 - Strings must be wrapped in quotes.
 
 To provide a more consistent authoring experience for fragments, React now provides a first-class `Fragment` component that can be used in place of arrays.

--- a/content/warnings/unknown-prop.md
+++ b/content/warnings/unknown-prop.md
@@ -7,7 +7,7 @@ The unknown-prop warning will fire if you attempt to render a DOM element with a
 
 There are a couple of likely reasons this warning could be appearing:
 
-1. Are you using `{...this.props}` or `cloneElement(element, this.props)`? Your component is transferring its own props directly to a child element (eg. https://reactjs.org/docs/transferring-props.html). When transferring props to a child component, you should ensure that you are not accidentally forwarding props that were intended to be interpreted by the parent component.
+1. Are you using `{...this.props}` or `cloneElement(element, this.props)`? Your component is transferring its own props directly to a child element (eg. [transferring props](/docs/transferring-props.html)). When transferring props to a child component, you should ensure that you are not accidentally forwarding props that were intended to be interpreted by the parent component.
 
 2. You are using a non-standard DOM attribute on a native DOM node, perhaps to represent custom data. If you are trying to attach custom data to a standard DOM element, consider using a custom data attribute as described [on MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes).
 


### PR DESCRIPTION
These were the only links I could find that would be broken because they previously included the https://reactjs.org domain name.

Address #862, which was first noticed up by #861.