### PR TITLE
Add a sentence to the end of componentWillUnmount()

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -329,7 +329,7 @@ If your component implements the `getSnapshotBeforeUpdate()` lifecycle, the valu
 componentWillUnmount()
 ```
 
-`componentWillUnmount()` is invoked immediately before a component is unmounted and destroyed. Perform any necessary cleanup in this method, such as invalidating timers, canceling network requests, or cleaning up any subscriptions that were created in `componentDidMount()`.
+`componentWillUnmount()` is invoked immediately before a component is unmounted and destroyed. Perform any necessary cleanup in this method, such as invalidating timers, canceling network requests, or cleaning up any subscriptions that were created in `componentDidMount()`. You should not call `setState()` here because the component will never be re-rendered.
 
 * * *
 


### PR DESCRIPTION
Adds a sentence explaining not to use setState in componentWillUnmount, see https://github.com/facebook/react/issues/12111