### PR TITLE
Clarify change propagation in Context API

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -6,7 +6,7 @@ permalink: docs/context.html
 
 Context provides a way to pass data through the component tree without having to pass props down manually at every level.
 
-In a typical React application, data is passed top-down (parent to child) via props, but this can be cumbersome for certain types of props (e.g. locale preference, UI theme) that are required by many components within an application. Context provides a way to share values like this between components without having to explicitly pass a prop through every level of the tree.
+In a typical React application, data is passed top-down (parent to child) via props, but this can be cumbersome for certain types of props (e.g. locale preference, UI theme) that are required by many components within an application. Context provides a way to share values like these between components without having to explicitly pass a prop through every level of the tree.
 
 - [When to Use Context](#when-to-use-context)
 - [API](#api)
@@ -72,11 +72,17 @@ A React component that subscribes to context changes.
 
 Requires a [function as a child](/docs/render-props.html#using-props-other-than-render). The function receives the current context value and returns a React node. The `value` argument passed to the function will be equal to the `value` prop of the closest Provider for this context above in the tree. If there is no Provider for this context above, the `value` argument will be equal to the `defaultValue` that was passed to `createContext()`.
 
-All Consumers are re-rendered whenever the Provider value changes. Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). (This can cause some issues when passing objects as `value`: see [Caveats](#caveats).)
+> Note
+> 
+> For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
+
+All Consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant Consumers is not subject to the `shouldComponentUpdate` method, so the Consumer is updated even when an ancestor component bails out of the update.
+
+Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
 
 > Note
 > 
-> For more information about this pattern, see [render props](/docs/render-props.html).
+> The way changes are determined can cause some issues when passing objects as `value`: see [Caveats](#caveats).
 
 ## Examples
 


### PR DESCRIPTION
In regards to #895, I think a cursory mention of how Providers communicate with Consumers in the context of `shouldComponentUpdate` returning `false` goes a long way in creating the appropriate mental model for this feature. May not be the best phrasing, but I'd appreciate something along these lines for 3hrs-ago me :)