### PR TITLE
Add react-input-trigger to UI Components

### DIFF
--- a/content/community/tools-ui-components.md
+++ b/content/community/tools-ui-components.md
@@ -37,6 +37,7 @@ permalink: community/ui-components.html
 * **[react-highlight](https://github.com/akiran/react-highlight):** React component for syntax highlighting
 * **[react-image](https://github.com/mbrevda/react-image):** Like `<img />` and Enhanced Image Component for React.
 * **[react-input-autosize](https://github.com/JedWatson/react-input-autosize):** Like `<input />` but resizes automatically to fit all its content.
+* **[react-input-trigger](https://github.com/abinavseelan/react-input-trigger):** React component for handling character triggers inside textareas and input fields.
 * **[react-intense](https://github.com/brycedorn/react-intense):** A component for viewing large images up close
 * **[react-joyride](https://github.com/gilbarbara/react-joyride):** Create walkthroughs and guided tours for your ReactJS apps.
 * **[react-ladda](https://github.com/jsdir/react-ladda):** React wrapper for Ladda buttons.


### PR DESCRIPTION
Firstly, thank you maintaining these docs. ❤️ 😄 

## What does this PR bring?

Adds [react-input-trigger](https://github.com/abinavseelan/react-input-trigger) to the list of free UI components.

[npm](https://www.npmjs.com/package/react-input-trigger)
[github](https://github.com/abinavseelan/react-input-trigger)
[live example](https://abinavseelan.com/react-input-trigger/)

## What does this component do?

React component for handling character triggers inside textareas and input fields. 🐼

Useful for building applications that need Slack-like emoji suggestions (triggered by typing `:`) or Github-like user mentions (triggered by typing `@`).

![screenshot](https://user-images.githubusercontent.com/6417910/36937827-0e615e4e-1f3f-11e8-9623-c4141bda3d2e.gif)