### PR TITLE
Mention getSnapshotBeforeUpdate should return.

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -297,6 +297,8 @@ Note that this method is fired on *every* render, regardless of the cause. This 
 
 This use case is not common, but it may occur in UIs like a chat thread that need to handle scroll position in a special way.
 
+A snapshot value (or `null`) should be returned.
+
 For example:
 
 `embed:react-component-reference/get-snapshot-before-update.js`


### PR DESCRIPTION
If getSnapshotBeforeUpdate does not return a snapshot value or null
it will cause a warning.  Document that it should return this value.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
