### PR TITLE
Add propTypes to class properties list

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -114,6 +114,7 @@ Each component also provides some other APIs:
 
 ### Class Properties
 
+  - [`propTypes`](/docs/typechecking-with-proptypes.html)
   - [`defaultProps`](#defaultprops)
   - [`displayName`](#displayname)
 


### PR DESCRIPTION
The list of class properties valid for a `React.Component` class should include `propTypes`.