### PR TITLE
Explicitly order Main Concepts

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -9,6 +9,7 @@
     - id: cdn-links
       title: CDN Links
 - title: Main Concepts
+  isOrdered: true
   items:
     - id: hello-world
       title: Hello World

--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -69,7 +69,7 @@ class Section extends React.Component {
               display: isActive ? 'block' : 'none',
             },
           }}>
-          {section.items.map(item => (
+          {section.items.map((item, index) => (
             <li
               key={item.id}
               css={{
@@ -79,7 +79,12 @@ class Section extends React.Component {
                 isActive: isScrollSync
                   ? activeItemId === item.id
                   : isItemActive(location, item),
-                item,
+                item: section.isOrdered
+                  ? {
+                      ...item,
+                      title: `${index + 1}. ${item.title}`,
+                    }
+                  : item,
                 location,
                 onLinkClick,
                 section,


### PR DESCRIPTION
They were always supposed to be read in order but seems like a lot of people don't realize that.
I'm just making this explicit for this particular section.

<img width="322" alt="screen shot 2018-06-11 at 2 48 31 am" src="https://user-images.githubusercontent.com/810438/41209239-1d6b3adc-6d22-11e8-8a88-d860e294afa2.png">

12 is a nice number. The next main concept will be unlucky.