### PR TITLE
Update 2018-06-07-you-probably-dont-need-derived-state.md

### DIFF
--- a/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
+++ b/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
@@ -338,7 +338,7 @@ When using memoization, remember a couple of constraints:
 
 1. In most cases, you'll want to **attach the memoized function to a component instance**. This prevents multiple instances of a component from resetting each other's memoized keys.
 1. Typically you'll want to use a memoization helper with a **limited cache size** in order to prevent memory leaks over time. (In the example above, we used `memoize-one` because it only caches the most recent argument and result.)
-1. None of the implementations shown in this section will work if `props.items` is recreated each time the parent component renders. But in most cases, this setup is appropriate.
+1. None of the implementations shown in this section will work if `props.list` is recreated each time the parent component renders. But in most cases, this setup is appropriate.
 
 ## In closing
 


### PR DESCRIPTION
Typo: I think it should be props.list instead of props.items.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
