### PR TITLE
Add link to prop-types documentation

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -94,6 +94,7 @@ Each component also provides some other APIs:
 
 ### Class Properties
 
+  - [`propTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html)
   - [`defaultProps`](#defaultprops)
   - [`displayName`](#displayname)
 


### PR DESCRIPTION
This commit adds a link to the `propTypes` documentation page, as requested in [this tweet](https://twitter.com/dan_abramov/status/1005931094871609344).

Thanks for providing me and the rest of the community with such low-hanging fruit pull request opportunities. I'm now going to strut around the office all day. 😀 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
