### PR TITLE
feat: navigating pages via right and left arrow keys

### DIFF
--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -9,13 +9,15 @@ import Container from 'components/Container';
 import Flex from 'components/Flex';
 import MarkdownHeader from 'components/MarkdownHeader';
 import NavigationFooter from 'templates/components/NavigationFooter';
-import React from 'react';
+import React, {Component} from 'react';
 import StickyResponsiveSidebar from 'components/StickyResponsiveSidebar';
 import TitleAndMetaTags from 'components/TitleAndMetaTags';
 import findSectionForPath from 'utils/findSectionForPath';
 import toCommaSeparatedList from 'utils/toCommaSeparatedList';
 import {sharedStyles} from 'theme';
 import createOgUrl from 'utils/createOgUrl';
+import slugify from 'utils/slugify';
+import {navigateTo} from 'gatsby-link';
 
 import type {Node} from 'types';
 
@@ -29,9 +31,18 @@ type Props = {
   markdownRemark: Node,
   sectionList: Array<Object>, // TODO: Add better flow type once we have the Section component
   titlePostfix: string,
+  enableKeyboardNavigation: boolean,
 };
 
-const getPageById = (sectionList: Array<Object>, templateFile: ?string) => {
+type Page = {
+  id: string,
+  title: string,
+};
+
+const getPageById = (
+  sectionList: Array<Object>,
+  templateFile: ?string,
+): ?Page => {
   if (!templateFile) {
     return null;
   }
@@ -43,106 +54,160 @@ const getPageById = (sectionList: Array<Object>, templateFile: ?string) => {
   return flattenedSectionItems.find(item => item.id === linkId);
 };
 
-const MarkdownPage = ({
-  authors = [],
-  createLink,
-  date,
-  enableScrollSync,
-  ogDescription,
-  location,
-  markdownRemark,
-  sectionList,
-  titlePostfix = '',
-}: Props) => {
-  const hasAuthors = authors.length > 0;
-  const titlePrefix = markdownRemark.frontmatter.title || '';
+class MarkdownPage extends Component<Props> {
+  ARROW_RIGHT: number = 39;
+  ARROW_LEFT: number = 37;
 
-  const prev = getPageById(sectionList, markdownRemark.frontmatter.prev);
-  const next = getPageById(sectionList, markdownRemark.frontmatter.next);
+  prevPage: ?Page = getPageById(
+    this.props.sectionList,
+    this.props.markdownRemark.frontmatter.prev,
+  );
+  nextPage: ?Page = getPageById(
+    this.props.sectionList,
+    this.props.markdownRemark.frontmatter.next,
+  );
 
-  return (
-    <Flex
-      direction="column"
-      grow="1"
-      shrink="0"
-      halign="stretch"
-      css={{
-        width: '100%',
-        flex: '1 0 auto',
-        position: 'relative',
-        zIndex: 0,
-      }}>
-      <TitleAndMetaTags
-        ogDescription={ogDescription}
-        ogUrl={createOgUrl(markdownRemark.fields.slug)}
-        title={`${titlePrefix}${titlePostfix}`}
-      />
-      <div css={{flex: '1 0 auto'}}>
-        <Container>
-          <div css={sharedStyles.articleLayout.container}>
-            <Flex type="article" direction="column" grow="1" halign="stretch">
-              <MarkdownHeader title={titlePrefix} />
+  navigate = (pageId: string) => {
+    const section = findSectionForPath(
+      this.props.location.pathname,
+      this.props.sectionList,
+    );
 
-              {(date || hasAuthors) && (
-                <div css={{marginTop: 15}}>
-                  {date}{' '}
-                  {hasAuthors && (
-                    <span>
-                      by{' '}
-                      {toCommaSeparatedList(authors, author => (
-                        <a
-                          css={sharedStyles.link}
-                          href={author.frontmatter.url}
-                          key={author.frontmatter.name}>
-                          {author.frontmatter.name}
-                        </a>
-                      ))}
-                    </span>
-                  )}
-                </div>
-              )}
+    if (section && typeof section.directory === 'string') {
+      navigateTo(slugify(pageId, section.directory));
+    }
+  };
 
-              <div css={sharedStyles.articleLayout.content}>
-                <div
-                  css={[sharedStyles.markdown]}
-                  dangerouslySetInnerHTML={{__html: markdownRemark.html}}
-                />
+  handleKeyboardNavigation = (event: SyntheticKeyboardEvent<*>) => {
+    switch (event.keyCode) {
+      case this.ARROW_RIGHT:
+        if (this.nextPage) {
+          this.navigate(this.nextPage.id);
+        }
+        break;
+      case this.ARROW_LEFT:
+        if (this.prevPage) {
+          this.navigate(this.prevPage.id);
+        }
+        break;
+    }
+  };
 
-                {markdownRemark.fields.path && (
-                  <div css={{marginTop: 80}}>
-                    <a
-                      css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/reactjs.org/tree/master/content/${
-                        markdownRemark.fields.path
-                      }`}>
-                      Edit this page
-                    </a>
+  componentDidMount() {
+    if (this.props.enableKeyboardNavigation) {
+      window.addEventListener('keydown', this.handleKeyboardNavigation);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.enableKeyboardNavigation) {
+      window.removeEventListener('keydown', this.handleKeyboardNavigation);
+    }
+  }
+
+  render() {
+    const {
+      authors = [],
+      createLink,
+      date,
+      enableScrollSync,
+      ogDescription,
+      location,
+      markdownRemark,
+      sectionList,
+      titlePostfix = '',
+    } = this.props;
+    const hasAuthors = authors.length > 0;
+    const titlePrefix = markdownRemark.frontmatter.title || '';
+
+    return (
+      <Flex
+        direction="column"
+        grow="1"
+        shrink="0"
+        halign="stretch"
+        css={{
+          width: '100%',
+          flex: '1 0 auto',
+          position: 'relative',
+          zIndex: 0,
+        }}>
+        <TitleAndMetaTags
+          ogDescription={ogDescription}
+          ogUrl={createOgUrl(markdownRemark.fields.slug)}
+          title={`${titlePrefix}${titlePostfix}`}
+        />
+        <div css={{flex: '1 0 auto'}}>
+          <Container>
+            <div css={sharedStyles.articleLayout.container}>
+              <Flex type="article" direction="column" grow="1" halign="stretch">
+                <MarkdownHeader title={titlePrefix} />
+
+                {(date || hasAuthors) && (
+                  <div css={{marginTop: 15}}>
+                    {date}{' '}
+                    {hasAuthors && (
+                      <span>
+                        by{' '}
+                        {toCommaSeparatedList(authors, author => (
+                          <a
+                            css={sharedStyles.link}
+                            href={author.frontmatter.url}
+                            key={author.frontmatter.name}>
+                            {author.frontmatter.name}
+                          </a>
+                        ))}
+                      </span>
+                    )}
                   </div>
                 )}
+
+                <div css={sharedStyles.articleLayout.content}>
+                  <div
+                    css={[sharedStyles.markdown]}
+                    dangerouslySetInnerHTML={{__html: markdownRemark.html}}
+                  />
+
+                  {markdownRemark.fields.path && (
+                    <div css={{marginTop: 80}}>
+                      <a
+                        css={sharedStyles.articleLayout.editLink}
+                        href={`https://github.com/reactjs/reactjs.org/tree/master/content/${
+                          markdownRemark.fields.path
+                        }`}>
+                        Edit this page
+                      </a>
+                    </div>
+                  )}
+                </div>
+              </Flex>
+
+              <div css={sharedStyles.articleLayout.sidebar}>
+                <StickyResponsiveSidebar
+                  enableScrollSync={enableScrollSync}
+                  createLink={createLink}
+                  defaultActiveSection={findSectionForPath(
+                    location.pathname,
+                    sectionList,
+                  )}
+                  location={location}
+                  sectionList={sectionList}
+                />
               </div>
-            </Flex>
-
-            <div css={sharedStyles.articleLayout.sidebar}>
-              <StickyResponsiveSidebar
-                enableScrollSync={enableScrollSync}
-                createLink={createLink}
-                defaultActiveSection={findSectionForPath(
-                  location.pathname,
-                  sectionList,
-                )}
-                location={location}
-                sectionList={sectionList}
-              />
             </div>
-          </div>
-        </Container>
-      </div>
+          </Container>
+        </div>
 
-      {(next || prev) && (
-        <NavigationFooter location={location} next={next} prev={prev} />
-      )}
-    </Flex>
-  );
-};
+        {(this.nextPage || this.prevPage) && (
+          <NavigationFooter
+            location={location}
+            next={this.nextPage}
+            prev={this.prevPage}
+          />
+        )}
+      </Flex>
+    );
+  }
+}
 
 export default MarkdownPage;

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -31,7 +31,7 @@ type Props = {
   markdownRemark: Node,
   sectionList: Array<Object>, // TODO: Add better flow type once we have the Section component
   titlePostfix: string,
-  enableKeyboardNavigation: boolean,
+  enableKeyboardNavigation?: boolean,
 };
 
 type Page = {

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -17,6 +17,7 @@ const Docs = ({data, location}) => (
     markdownRemark={data.markdownRemark}
     sectionList={sectionListDocs}
     titlePostfix=" - React"
+    enableKeyboardNavigation
   />
 );
 


### PR DESCRIPTION
Adds the ability to navigate through pages by using the left and right arrow keys. Opt-in via the `enableKeyboardNavigation` prop on specific documentation pages (currently enabled for [docs](https://reactjs.org/docs/hello-world.html)). Any pages that have the `prev` or `next` prop defined would be able to use this logic.

This is just an idea that I had and it is completely WIP and implemented on the go, feedback is welcome and I would not take it personally if this feature does not make it in after all :-)