### PR TITLE
Add learnreact.design course link and description

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -35,3 +35,5 @@ permalink: community/courses.html
 - [React Training: Advanced React.js](https://courses.reacttraining.com/p/advanced-react) - Take your React skills to the next level.
 
 - [Tyler McGinnis](https://tylermcginnis.com/courses) - Tyler McGinnis provides access to his courses for a monthly fee. Courses include "React Fundamentals" and "Universal React".
+
+- [React Essentials for Designers](https://learnreact.design) - React courses tailored for designers: the fundamentals, capabilities, limitations and how they relate to design.


### PR DESCRIPTION
This PR adds the link and description of learnreact.design, a series of React courses. It's unique because the courses are tailored for designers, not developers.
