### PR TITLE
Make componentDidUpdate work better. (No need compare props all the time)

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -217,6 +217,10 @@ componentDidUpdate(prevProps) {
   if (this.props.userID !== prevProps.userID) {
     this.fetchData(this.props.userID);
   }
+  // No need to compare props if type props is always boolean:
+  if (this.props.isShow) {
+    this.showSomething()
+  }
 }
 ```
 


### PR DESCRIPTION
This is my opinion that I think if not have this case it force everyone always compare props in componentDidUpdate.
That look strange. And I think this is better.
