### PR TITLE
Fix node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "unist-util-visit": "^1.1.3"
   },
   "engines": {
-    "node": "^8.4.0"
+    "node": ">=8.4.0"
   },
   "homepage": "https://reactjs.org/",
   "keywords": [


### PR DESCRIPTION
### Read me said node support >=8.4.
**Getting started**
Prerequisites
Git
**Node: install version 8.4 or greater**

when i **yarn** to install the website's npm dependencies, i got these messages , it only works for node 8.4.0.  so, i fixed  "node": "^8.4.0" => "node": ">=8.4.0" :)
(my node version is v9.4.0)

![2018-06-26 10 54 54](https://user-images.githubusercontent.com/26598542/41917252-e0af6e86-7994-11e8-985b-6a87312c9fae.png)


