### PR TITLE
Define mountNode on homepage

### DIFF
--- a/content/home/examples/a-simple-component.js
+++ b/content/home/examples/a-simple-component.js
@@ -8,9 +8,6 @@ class HelloMessage extends React.Component {
   }
 }
 
-// DOM element to render React inside
-const mountNode = document.querySelector("#hello-message")
-
 ReactDOM.render(
   <HelloMessage name="Taylor" />,
   mountNode

--- a/content/home/examples/a-simple-component.js
+++ b/content/home/examples/a-simple-component.js
@@ -8,6 +8,9 @@ class HelloMessage extends React.Component {
   }
 }
 
+// DOM element to render React inside
+const mountNode = document.querySelector("#hello-message")
+
 ReactDOM.render(
   <HelloMessage name="Taylor" />,
   mountNode

--- a/content/home/examples/a-simple-component.md
+++ b/content/home/examples/a-simple-component.md
@@ -6,3 +6,7 @@ order: 0
 React components implement a `render()` method that takes input data and returns what to display. This example uses an XML-like syntax called JSX. Input data that is passed into the component can be accessed by `render()` via `this.props`.
 
 **JSX is optional and not required to use React.** Try the [Babel REPL](babel://es5-syntax-example) to see the raw JavaScript code produced by the JSX compilation step.
+
+```js
+const mountNode = document.querySelector("#app")
+```


### PR DESCRIPTION
see #1017

`mountNode` is actually defined somewhere on the page so defining it in the example breaks it...

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
