### PR TITLE
Update conditional-rendering.md

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -191,10 +191,10 @@ Just like in JavaScript, it is up to you to choose an appropriate style based on
 
 In rare cases you might want a component to hide itself even though it was rendered by another component. To do this return `null` instead of its render output.
 
-In the example below, the `<WarningBanner />` is rendered depending on the value of the prop called `warn`. If the value of the prop is `false`, then the component does not render:
+In the example below, the `<warningBanner />` is rendered depending on the value of the prop called `warn`. If the value of the prop is `false`, then the component does not render:
 
 ```javascript{2-4,29}
-function WarningBanner(props) {
+function warningBanner(props) {
   if (!props.warn) {
     return null;
   }
@@ -222,7 +222,7 @@ class Page extends React.Component {
   render() {
     return (
       <div>
-        <WarningBanner warn={this.state.showWarning} />
+        <warningBanner warn={this.state.showWarning} />
         <button onClick={this.handleToggleClick}>
           {this.state.showWarning ? 'Hide' : 'Show'}
         </button>


### PR DESCRIPTION
Using WarningBanner with a capital W, causes IDE warns me that "Primitive value returned from constructor will be lost when called with 'new'".
IDE expect function names to start with a lowercase letter. Since WarningBanner function is called with a capital W, it thinks it's a class declaration.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
