### PR TITLE
Add signature to getSnapshotBeforeUpdate section

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -293,6 +293,10 @@ Note that this method is fired on *every* render, regardless of the cause. This 
 
 ### `getSnapshotBeforeUpdate()`
 
+```javascript
+getSnapshotBeforeUpdate(prevProps, prevState)
+```
+
 `getSnapshotBeforeUpdate()` is invoked right before the most recently rendered output is committed to e.g. the DOM. It enables your component to capture some information from the DOM (e.g. scroll position) before it is potentially changed. Any value returned by this lifecycle will be passed as a parameter to `componentDidUpdate()`.
 
 This use case is not common, but it may occur in UIs like a chat thread that need to handle scroll position in a special way.


### PR DESCRIPTION
Add the signature for `getSnapshotBeforeUpdate` to its section, just like all other lifecycle method sections have.