### PR TITLE
Halogen link is missing

### DIFF
--- a/content/community/tools-ui-components.md
+++ b/content/community/tools-ui-components.md
@@ -12,7 +12,6 @@ permalink: community/ui-components.html
 * **[chartify](https://github.com/kirillstepkin/chartify)**: Ultra lightweight and customizable React.js chart component.
 * **[Elemental UI](http://elemental-ui.com):** A UI toolkit for React websites and apps, themeable and composed of individually packaged components
 * **[Grommet](http://grommet.io)** The most advanced open source UX framework for enterprise applications.
-* **[Halogen](http://madscript.com/halogen):** A collection of highly customizable loading spinner animations with React.
 * **[Khan Academy's component library](http://khan.github.io/react-components/)**
 * **[markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx)**: compiles markdown into safe React JSX without using dangerous escape hatches.
 * **[Material-UI](https://material-ui.com/):** React components that implement Google's Material Design.


### PR DESCRIPTION
I found http://madscript.com/halogen is missing.


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
