### PR TITLE
dont write state updation methods in constructor

### DIFF
--- a/examples/context/updating-nested-context-app.js
+++ b/examples/context/updating-nested-context-app.js
@@ -5,29 +5,31 @@ class App extends React.Component {
   constructor(props) {
     super(props);
 
-    this.toggleTheme = () => {
-      this.setState(state => ({
-        theme:
-          state.theme === themes.dark
-            ? themes.light
-            : themes.dark,
-      }));
-    };
-
-    // highlight-range{1-2,5}
+    // highlight-range{1-2}
     // State also contains the updater function so it will
     // be passed down into the context provider
     this.state = {
-      theme: themes.light,
-      toggleTheme: this.toggleTheme,
+      theme: themes.light
     };
   }
 
+  toggleTheme = () => {
+    this.setState(state => ({
+      theme:
+        state.theme === themes.dark
+          ? themes.light
+          : themes.dark,
+    }));
+  };
+
   render() {
-    // highlight-range{1,3}
-    // The entire state is passed to the provider
+    // highlight-range{1,3-6}
+    // The relevant state and state updaters are passed to the provider
     return (
-      <ThemeContext.Provider value={this.state}>
+      <ThemeContext.Provider value={{
+        theme: this.state.theme,
+        toggleTheme: this.toggleTheme
+      }}>
         <Content />
       </ThemeContext.Provider>
     );


### PR DESCRIPTION
Advantages of this approach-

1. No need to keep state updation methods in state.
1. In modern js class syntax, we don't need constructor generally, but because of the current implementation, we have to define constructor method.

With the approach I propose, we can just do -
```jsx
class App extends React.Component {
  state = {
    theme: themes.light
  }
}
```
1. More in line to how most of us commonly process a component code, (define initial state in constructor, then all class methods and at last render method)
1, Only the state needed by other nested components has to be passed to provider. The App component can still keep it's internal state hidden.