### PR TITLE
Fix example indentation

### DIFF
--- a/src/prism-styles.js
+++ b/src/prism-styles.js
@@ -31,7 +31,6 @@ css.global('.gatsby-highlight', {
   borderRadius: 10,
   overflow: 'auto',
   tabSize: '1.5em',
-  padding: '1rem',
 });
 
 css.global(
@@ -40,7 +39,9 @@ css.global(
 .gatsby-highlight pre[class*="gatsby-code-"],
 .gatsby-highlight pre.prism-code`,
   {
+    display: 'block',
     height: 'auto !important',
+    margin: '1rem',
     fontSize: 14,
     lineHeight: '20px',
     whiteSpace: 'pre-wrap',

--- a/src/prism-styles.js
+++ b/src/prism-styles.js
@@ -31,6 +31,7 @@ css.global('.gatsby-highlight', {
   borderRadius: 10,
   overflow: 'auto',
   tabSize: '1.5em',
+  padding: '1rem',
 });
 
 css.global(
@@ -40,7 +41,6 @@ css.global(
 .gatsby-highlight pre.prism-code`,
   {
     height: 'auto !important',
-    margin: '1rem',
     fontSize: 14,
     lineHeight: '20px',
     whiteSpace: 'pre-wrap',


### PR DESCRIPTION
Addresses #1084

Not sure why having margin set on the `<pre>` causes the weird indentation, but moving the margin to a padding in the wrapping element fixes it, and is my preferred spacing solution.

Alternatively adding `display: block;` to the `<pre>` tag styling also fixes the issue, but I am not sure if we always want the pre/code elements to be block. Are they ever displayed inline?

**Update**
Adding `display: block;` to the `<pre>` tag styling may be the better solution as the examples appear to not always be rendered inside the `.gatsby-highlight` class