### PR TITLE
Update lifecycles.js - minor fix of example code

### DIFF
--- a/examples/context/lifecycles.js
+++ b/examples/context/lifecycles.js
@@ -13,7 +13,7 @@ class Button extends React.Component {
   render() {
     const {theme, children} = this.props;
     return (
-      <button className={theme ? 'dark' : 'light'}>
+      <button className={theme || 'light'}>
         {children}
       </button>
     );


### PR DESCRIPTION
`theme ? 'dark' : 'light'` will always use the dark theme no matter what `theme` is set to in context. Guessing this is not what was intended? This PR fixes it.