### PR TITLE
Fix a link in the error code blog post

### DIFF
--- a/content/blog/2016-07-11-introducing-reacts-error-code-system.md
+++ b/content/blog/2016-07-11-introducing-reacts-error-code-system.md
@@ -13,6 +13,6 @@ In order to make debugging in production easier, we're introducing an Error Code
 
 While we hope you don't see errors often, you can see how it works [here](/docs/error-decoder.html?invariant=109&args[]=Foo). This is what the same error from above will look like:
 
-> Minified React error #109; visit https://reactjs.org/docs/error-decoder.html?invariant=109&args[]=Foo for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
+> Minified React error #109; visit [https://reactjs.org/docs/error-decoder.html?invariant=109&args[]=Foo](/docs/error-decoder.html?invariant=109&args[]=Foo) for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
 
 We do this so that the developer experience is as good as possible, while also keeping the production bundle size as small as possible. This feature shouldn't require any changes on your side — use the `min.js` files in production or bundle your application code with `process.env.NODE_ENV === 'production'` and you should be good to go!


### PR DESCRIPTION
Thanks to @CatChen for finding this issue.

![image](https://user-images.githubusercontent.com/2268452/43806446-d1fcda4c-9a58-11e8-8c52-8ee4b945bd52.png)

^ the link above is an absolute link which takes the user to https://reactjs.org/blog/2016/07/11/https://reactjs.org/docs/error-decoder.html. Changing it to a relative link fixed the problem.