### PR TITLE
update community testing tools

### DIFF
--- a/content/community/tools-testing.md
+++ b/content/community/tools-testing.md
@@ -6,7 +6,7 @@ permalink: community/testing.html
 ---
 
 * **[Enzyme](https://github.com/airbnb/enzyme/):** a JavaScript Testing utility for React that makes it easier to assert, manipulate, and traverse your React Components' output.
-* **[Expect-jsx](https://github.com/algolia/expect-jsx):** toEqualJSX for [expect.js](https://github.com/mjackson/expect)
+* **[react-testing-library](https://github.com/kentcdodds/react-testing-library):** 🐐 Simple and complete React DOM testing utilities that encourage good testing practices.
 * **[Jest](https://facebook.github.io/jest/):** Delightful JavaScript testing used by Facebook to test all JavaScript code including React applications.
 * **[React-unit](https://github.com/pzavolinsky/react-unit):** a lightweight unit test library for ReactJS with very few (js-only) dependencies.
 * **[Skin-deep](https://github.com/glenjamin/skin-deep):** Testing helpers for use with React's shallowRender test utils.

--- a/content/community/tools-testing.md
+++ b/content/community/tools-testing.md
@@ -6,8 +6,8 @@ permalink: community/testing.html
 ---
 
 * **[Enzyme](https://github.com/airbnb/enzyme/):** a JavaScript Testing utility for React that makes it easier to assert, manipulate, and traverse your React Components' output.
-* **[react-testing-library](https://github.com/kentcdodds/react-testing-library):** 🐐 Simple and complete React DOM testing utilities that encourage good testing practices.
 * **[Jest](https://facebook.github.io/jest/):** Delightful JavaScript testing used by Facebook to test all JavaScript code including React applications.
+* **[react-testing-library](https://github.com/kentcdodds/react-testing-library):** 🐐 Simple and complete React DOM testing utilities that encourage good testing practices.
 * **[React-unit](https://github.com/pzavolinsky/react-unit):** a lightweight unit test library for ReactJS with very few (js-only) dependencies.
 * **[Skin-deep](https://github.com/glenjamin/skin-deep):** Testing helpers for use with React's shallowRender test utils.
 * **[Unexpected-react](https://github.com/bruderstein/unexpected-react/):** Plugin for the [unexpected](http://unexpected.js.org) assertion library that makes it easy to assert over your React Components and trigger events.


### PR DESCRIPTION
Removed expect-jsx as it has been deprecated. Added react-testing-library in its place.