### PR TITLE
Cleaned up footprint of checking to see if we have a sidebar or not

### DIFF
--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -16,175 +16,182 @@ import {sectionListCommunity, sectionListDocs} from 'utils/sectionList';
 
 import ossLogoPng from 'images/oss_logo.png';
 
-const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
-  <footer
-    css={{
-      backgroundColor: colors.darker,
-      color: colors.white,
-      paddingTop: 10,
-      paddingBottom: 50,
+const Footer = ({pathname}: {pathname: string}) => {
+  let layoutHasSidebar =
+    pathname.match(
+      /^\/(docs|tutorial|community|blog|contributing|warnings)/,
+    ) !== null;
 
-      [media.size('sidebarFixed')]: {
-        paddingTop: 40,
-      },
-    }}>
-    <Container>
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'row',
-          flexWrap: 'wrap',
+  return (
+    <footer
+      css={{
+        backgroundColor: colors.darker,
+        color: colors.white,
+        paddingTop: 10,
+        paddingBottom: 50,
 
-          [media.between('small', 'medium')]: {
-            paddingRight: layoutHasSidebar ? 240 : null,
-          },
-
-          [media.between('large', 'largerSidebar')]: {
-            paddingRight: layoutHasSidebar ? 280 : null,
-          },
-          [media.between('largerSidebar', 'sidebarFixed', true)]: {
-            paddingRight: layoutHasSidebar ? 380 : null,
-          },
-        }}>
+        [media.size('sidebarFixed')]: {
+          paddingTop: 40,
+        },
+      }}>
+      <Container>
         <div
           css={{
-            flexWrap: 'wrap',
             display: 'flex',
+            flexDirection: 'row',
+            flexWrap: 'wrap',
 
-            [media.lessThan('large')]: {
-              width: '100%',
+            [media.between('small', 'medium')]: {
+              paddingRight: layoutHasSidebar ? 240 : null,
             },
-            [media.greaterThan('xlarge')]: {
-              width: 'calc(100% / 3 * 2)',
-              paddingLeft: 40,
+
+            [media.between('large', 'largerSidebar')]: {
+              paddingRight: layoutHasSidebar ? 280 : null,
+            },
+            [media.between('largerSidebar', 'sidebarFixed', true)]: {
+              paddingRight: layoutHasSidebar ? 380 : null,
             },
           }}>
-          <FooterNav layoutHasSidebar={layoutHasSidebar}>
-            <MetaTitle onDark={true}>Docs</MetaTitle>
-            {sectionListDocs.map(section => {
-              const defaultItem = section.items[0];
-              return (
+          <div
+            css={{
+              flexWrap: 'wrap',
+              display: 'flex',
+
+              [media.lessThan('large')]: {
+                width: '100%',
+              },
+              [media.greaterThan('xlarge')]: {
+                width: 'calc(100% / 3 * 2)',
+                paddingLeft: 40,
+              },
+            }}>
+            <FooterNav layoutHasSidebar={layoutHasSidebar}>
+              <MetaTitle onDark={true}>Docs</MetaTitle>
+              {sectionListDocs.map(section => {
+                const defaultItem = section.items[0];
+                return (
+                  <FooterLink
+                    to={`/docs/${defaultItem.id}.html`}
+                    key={section.title}>
+                    {section.title}
+                  </FooterLink>
+                );
+              })}
+            </FooterNav>
+            <FooterNav layoutHasSidebar={layoutHasSidebar}>
+              <MetaTitle onDark={true}>Channels</MetaTitle>
+              <ExternalFooterLink
+                href="https://github.com/facebook/react"
+                target="_blank"
+                rel="noopener">
+                GitHub
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="http://stackoverflow.com/questions/tagged/reactjs"
+                target="_blank"
+                rel="noopener">
+                Stack Overflow
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="https://discuss.reactjs.org"
+                target="_blank"
+                rel="noopener">
+                Discussion Forum
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="https://discord.gg/0ZcbPKXt5bZjGY5n"
+                target="_blank"
+                rel="noopener">
+                Reactiflux Chat
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="https://dev.to/t/react"
+                target="_blank"
+                rel="noopener">
+                DEV Community
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="https://www.facebook.com/react"
+                target="_blank"
+                rel="noopener">
+                Facebook
+              </ExternalFooterLink>
+              <ExternalFooterLink
+                href="https://twitter.com/reactjs"
+                target="_blank"
+                rel="noopener">
+                Twitter
+              </ExternalFooterLink>
+            </FooterNav>
+            <FooterNav layoutHasSidebar={layoutHasSidebar}>
+              <MetaTitle onDark={true}>Community</MetaTitle>
+              {sectionListCommunity.map(section => (
                 <FooterLink
-                  to={`/docs/${defaultItem.id}.html`}
+                  to={`/community/${section.items[0].id}.html`}
                   key={section.title}>
                   {section.title}
                 </FooterLink>
-              );
-            })}
-          </FooterNav>
-          <FooterNav layoutHasSidebar={layoutHasSidebar}>
-            <MetaTitle onDark={true}>Channels</MetaTitle>
-            <ExternalFooterLink
-              href="https://github.com/facebook/react"
-              target="_blank"
-              rel="noopener">
-              GitHub
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="http://stackoverflow.com/questions/tagged/reactjs"
-              target="_blank"
-              rel="noopener">
-              Stack Overflow
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="https://discuss.reactjs.org"
-              target="_blank"
-              rel="noopener">
-              Discussion Forum
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="https://discord.gg/0ZcbPKXt5bZjGY5n"
-              target="_blank"
-              rel="noopener">
-              Reactiflux Chat
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="https://dev.to/t/react"
-              target="_blank"
-              rel="noopener">
-              DEV Community
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="https://www.facebook.com/react"
-              target="_blank"
-              rel="noopener">
-              Facebook
-            </ExternalFooterLink>
-            <ExternalFooterLink
-              href="https://twitter.com/reactjs"
-              target="_blank"
-              rel="noopener">
-              Twitter
-            </ExternalFooterLink>
-          </FooterNav>
-          <FooterNav layoutHasSidebar={layoutHasSidebar}>
-            <MetaTitle onDark={true}>Community</MetaTitle>
-            {sectionListCommunity.map(section => (
-              <FooterLink
-                to={`/community/${section.items[0].id}.html`}
-                key={section.title}>
-                {section.title}
+              ))}
+            </FooterNav>
+            <FooterNav layoutHasSidebar={layoutHasSidebar}>
+              <MetaTitle onDark={true}>More</MetaTitle>
+              <FooterLink to="/tutorial/tutorial.html">Tutorial</FooterLink>
+              <FooterLink to="/blog/">Blog</FooterLink>
+              <FooterLink to="/acknowledgements.html">
+                Acknowledgements
               </FooterLink>
-            ))}
-          </FooterNav>
-          <FooterNav layoutHasSidebar={layoutHasSidebar}>
-            <MetaTitle onDark={true}>More</MetaTitle>
-            <FooterLink to="/tutorial/tutorial.html">Tutorial</FooterLink>
-            <FooterLink to="/blog/">Blog</FooterLink>
-            <FooterLink to="/acknowledgements.html">
-              Acknowledgements
-            </FooterLink>
-            <ExternalFooterLink
-              href="http://facebook.github.io/react-native/"
+              <ExternalFooterLink
+                href="http://facebook.github.io/react-native/"
+                target="_blank"
+                rel="noopener">
+                React Native
+              </ExternalFooterLink>
+            </FooterNav>
+          </div>
+          <section
+            css={{
+              paddingTop: 40,
+              display: 'block !important', // Override 'Installation' <style> specifics
+
+              [media.greaterThan('xlarge')]: {
+                width: 'calc(100% / 3)',
+                order: -1,
+              },
+              [media.greaterThan('large')]: {
+                order: -1,
+                width: layoutHasSidebar ? null : 'calc(100% / 3)',
+              },
+              [media.lessThan('large')]: {
+                textAlign: 'center',
+                width: '100%',
+                paddingTop: 40,
+              },
+            }}>
+            <a
+              href="https://code.facebook.com/projects/"
               target="_blank"
               rel="noopener">
-              React Native
-            </ExternalFooterLink>
-          </FooterNav>
-        </div>
-        <section
-          css={{
-            paddingTop: 40,
-            display: 'block !important', // Override 'Installation' <style> specifics
-
-            [media.greaterThan('xlarge')]: {
-              width: 'calc(100% / 3)',
-              order: -1,
-            },
-            [media.greaterThan('large')]: {
-              order: -1,
-              width: layoutHasSidebar ? null : 'calc(100% / 3)',
-            },
-            [media.lessThan('large')]: {
-              textAlign: 'center',
-              width: '100%',
-              paddingTop: 40,
-            },
-          }}>
-          <a
-            href="https://code.facebook.com/projects/"
-            target="_blank"
-            rel="noopener">
-            <img
-              alt="Facebook Open Source"
+              <img
+                alt="Facebook Open Source"
+                css={{
+                  maxWidth: 160,
+                  height: 'auto',
+                }}
+                src={ossLogoPng}
+              />
+            </a>
+            <p
               css={{
-                maxWidth: 160,
-                height: 'auto',
-              }}
-              src={ossLogoPng}
-            />
-          </a>
-          <p
-            css={{
-              color: colors.subtleOnDark,
-              paddingTop: 15,
-            }}>
-            Copyright © 2018 Facebook Inc.
-          </p>
-        </section>
-      </div>
-    </Container>
-  </footer>
-);
+                color: colors.subtleOnDark,
+                paddingTop: 15,
+              }}>
+              Copyright © 2018 Facebook Inc.
+            </p>
+          </section>
+        </div>
+      </Container>
+    </footer>
+  );
+};
 
 export default Footer;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -31,16 +31,6 @@ class Template extends Component<Props> {
   render() {
     const {children, location} = this.props;
 
-    // TODO - is there a better way to check if we need we have a sidebar?
-    let layoutHasSidebar = false;
-    if (
-      location.pathname.match(
-        /^\/(docs|tutorial|community|blog|contributing|warnings)/,
-      )
-    ) {
-      layoutHasSidebar = true;
-    }
-
     return (
       <div
         css={{
@@ -66,7 +56,7 @@ class Template extends Component<Props> {
           }}>
           {children()}
         </Flex>
-        <Footer layoutHasSidebar={layoutHasSidebar} />
+        <Footer pathname={location.pathname} />
       </div>
     );
   }


### PR DESCRIPTION
I was going through the source code and saw someone had added a To Do in **layouts/index.js** about finding a better way to determine if there is a sidebar.
```
    // TODO - is there a better way to check if we need we have a sidebar?
    let layoutHasSidebar = false;
    if (
      location.pathname.match(
        /^\/(docs|tutorial|community|blog|contributing|warnings)/,
      )
    ) {
      layoutHasSidebar = true;
    }
``` 
I wasn't able to find a better way of checking, but I thought it might be nice to move that logic out of layouts/index.js and into Footer directly seeing as the Footer is the only place that needs this information.

Just a small tweak, but I think it makes layouts/index.js look cleaner.