### PR TITLE
Modified getSnapshotBeforeUpdate content to indicate that it is in th…

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -307,7 +307,7 @@ For example:
 
 `embed:react-component-reference/get-snapshot-before-update.js`
 
-In the above examples, it is important to read the `scrollHeight` property in `getSnapshotBeforeUpdate` because there may be delays between "render" phase lifecycles (like `render`) and "commit" phase lifecycles (like `getSnapshotBeforeUpdate` and `componentDidUpdate`).
+In the above examples, it is important to read the `scrollHeight` property in `getSnapshotBeforeUpdate` because there may be delays between "render" phase lifecycles (like `render`) and "commit" phase lifecycles (like `componentDidUpdate`). `getSnapshotBeforeUpdate` lives between the "render" phase lifecycles and "commit" phase lifecycles in the "pre-commit" phase before React updates the DOM and refs. It presents the last opportunity to read the previously committed DOM and return the values to be used by the "commit" phase lifecycles. 
 
 * * *
 


### PR DESCRIPTION
Modified getSnapshotBeforeUpdate content to indicate that it is in the Pre Commit Phase instead of Commit Phase and added new information about the method being the last point to get DOM information before it is committed.

This PR is related to #1137 

Related screenshot after change
<img width="1387" alt="screen shot 2018-08-27 at 1 27 21 pm" src="https://user-images.githubusercontent.com/35116035/44676941-a2a24480-aa02-11e8-89e3-a59634a39f3e.png">
