### PR TITLE
Patch the DOM to fix Google Translate

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -10,6 +10,7 @@ import 'array-from';
 import 'string.prototype.includes';
 import 'string.prototype.repeat';
 
+import patchDOMForGoogleTranslate from 'utils/patchDOMForGoogleTranslate';
 import React, {Component} from 'react';
 import Flex from 'components/Flex';
 import Footer from 'components/LayoutFooter';
@@ -21,6 +22,8 @@ import '../prism-styles';
 import 'glamor/reset';
 import 'css/reset.css';
 import 'css/algolia.css';
+
+patchDOMForGoogleTranslate();
 
 type Props = {
   children: Function,

--- a/src/utils/patchDOMForGoogleTranslate.js
+++ b/src/utils/patchDOMForGoogleTranslate.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * @emails react-core
+ * @flow
+ */
+
+// This is not pretty.
+// See https://github.com/facebook/react/issues/11538#issuecomment-417504600
+// We need this because we don't even offer official translations.
+// https://github.com/facebook/react/issues/12460
+
+export default function patchDOMForGoogleTranslate() {
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function(child) {
+    if (child.parentNode !== this) {
+      if (typeof console !== 'undefined') {
+        console.error(
+          'Cannot remove a child from a different parent',
+          child,
+          this,
+        );
+      }
+      return;
+    }
+    return originalRemoveChild.apply(this, arguments);
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function(newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (typeof console !== 'undefined') {
+        console.error(
+          'Cannot insert before a reference node from a different parent',
+          referenceNode,
+          this,
+        );
+      }
+      return;
+    }
+    return originalInsertBefore.apply(this, arguments);
+  };
+}


### PR DESCRIPTION
I think it's unacceptable to have Google Translate broken on our website, especially considering we don't yet offer any official translations. See https://github.com/facebook/react/issues/12460.

So I'm adding a hack described in https://github.com/facebook/react/issues/11538#issuecomment-417504600. I'm not too worried about performance since this is mostly a static website anyway.

Before the hack:

![](https://dzwonsemrish7.cloudfront.net/items/2F3M2y1x1O2y1A241J2O/Screen%20Recording%202018-08-31%20at%2001.15%20am.gif?v=dae37f12)

After the hack:

![](https://dzwonsemrish7.cloudfront.net/items/2w0P2l2a0J1o062p2Y2f/Screen%20Recording%202018-08-31%20at%2001.11%20am.gif)