### PR TITLE
Small changes to "classnames" tip on "Styling and CSS" page

### DIFF
--- a/content/docs/faq-styling.md
+++ b/content/docs/faq-styling.md
@@ -28,7 +28,9 @@ render() {
 }
 ```
 
-If you often find yourself writing code like this, [classnames](https://www.npmjs.com/package/classnames) package can simplify it.
+>Tip
+>
+>If you often find yourself writing code like this, [classnames](https://www.npmjs.com/package/classnames#usage-with-reactjs) package can simplify it.
 
 ### Can I use inline styles?
 


### PR DESCRIPTION
Just two small changes on "Styling and CSS" page:
* tip regarding "classnames" has been placed in quote box to visually emphasize it
* link to "classnames" package now points to React related section on the page
