### PR TITLE
Add Install React App Guide div id

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -18,7 +18,7 @@ This page describes a few popular React toolchains which help with tasks like:
 * Live-editing CSS and JS in development.
 * Optimizing the output for production.
 
-The toolchains recommended on this page **don't require configuration to get started**.
+The toolchains recommended on this page **don't require configuration to get started** [Installation Guide](https://github.com/facebook/create-react-app).
 
 ## You Might Not Need a Toolchain
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -18,7 +18,7 @@ This page describes a few popular React toolchains which help with tasks like:
 * Live-editing CSS and JS in development.
 * Optimizing the output for production.
 
-The toolchains recommended on this page **don't require configuration to get started** [Installation Guide](https://github.com/facebook/create-react-app).
+The toolchains recommended on this page **don't require configuration to get started** [Install React App Guide](/docs/create-a-new-react-app.html#create-react-app).
 
 ## You Might Not Need a Toolchain
 


### PR DESCRIPTION
Add installation Guide for React App div id URL to `create-a-new-react-app.html` in the top of page

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
