### PR TITLE
added link to webpack config tool

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -89,6 +89,6 @@ A JavaScript build toolchain typically consists of:
 
 * A **compiler** such as [Babel](http://babeljs.io/). It lets you write modern JavaScript code that still works in older browsers.
 
-If you prefer to set up your own JavaScript toolchain from scratch, [check out this guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) that re-creates some of the Create React App functionality.
+If you prefer to set up your own JavaScript toolchain from scratch, [check out this guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) that re-creates some of the Create React App functionality. You can also use this [webpack config tool](https://webpack.jakoblind.no/) to create a custom React project with webpack in your browser.
 
 Don't forget to ensure your custom toolchain [is correctly set up for production](/docs/optimizing-performance.html#use-the-production-build).


### PR DESCRIPTION
People who want to get started with React and webpack can use this webpack config tool to visually create a webpack config in the browser. It's helpful for a lot of people who wants to learn how to create their webpack config from scratch.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
