### PR TITLE
Add a link to Formik

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -292,3 +292,7 @@ setTimeout(function() {
 ## Alternatives to Controlled Components
 
 It can sometimes be tedious to use controlled components, because you need to write an event handler for every way your data can change and pipe all of the input state through a React component. This can become particularly annoying when you are converting a preexisting codebase to React, or integrating a React application with a non-React library. In these situations, you might want to check out [uncontrolled components](/docs/uncontrolled-components.html), an alternative technique for implementing input forms.
+
+## Fully-Fledged Solutions
+
+If you're looking for a complete solution including validation, keeping track of the visited fields, and handling form submission, [Formik](https://jaredpalmer.com/formik) is one of the popular choices. However, it is built on the same principles of controlled components and managing state — so don't neglect to learn them.


### PR DESCRIPTION
Why:

* I talked to lots of people and they are really happy about it
* It's confusing "Forms" doc doesn't say anything about validation
* There is already a precedent of pointing to specific libs (e.g. React Virtualized)

Why not mention others: I feel like if we mention two or three, people will keep wanting to see more solutions there. And that defeats the purpose of having a clear recommendation. I think Formik is good and it's reasonable to link to it specifically. We can always re-evaluate if something sufficiently better comes along. Also this isn't in your face — just at the end.