### PR TITLE
Update all Babel links to v7 in "Quickly Try JSX"

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -149,7 +149,7 @@ return (
 
 These two code snippets are equivalent. While **JSX is [completely optional](/docs/react-without-jsx.html)**, many people find it helpful for writing UI code -- both with React and with other libraries.
 
-You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-6.12&version=7.0.0&envVersion=).
+You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-8&version=7.0.0-rc.3&envVersion=).
 
 ### Quickly Try JSX
 
@@ -170,7 +170,7 @@ Adding JSX to a project doesn't require complicated tools like a bundler or a de
 Go to your project folder in the terminal, and paste these two commands:
 
 1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@4`
+2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@5`
 
 >Tip
 >

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -170,7 +170,7 @@ Adding JSX to a project doesn't require complicated tools like a bundler or a de
 Go to your project folder in the terminal, and paste these two commands:
 
 1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install @babel/core @babel/cli @babel/preset-react`
+2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@3`
 
 >Tip
 >
@@ -184,7 +184,7 @@ Congratulations! You just added a **production-ready JSX setup** to your project
 Create a folder called `src` and run this terminal command:
 
 ```
-npx babel --watch src --out-dir . --presets @babel/preset-react 
+npx babel --watch src --out-dir . --presets react-app/prod
 ```
 
 >Note

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -170,7 +170,7 @@ Adding JSX to a project doesn't require complicated tools like a bundler or a de
 Go to your project folder in the terminal, and paste these two commands:
 
 1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@3`
+2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@4`
 
 >Tip
 >

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -149,7 +149,7 @@ return (
 
 These two code snippets are equivalent. While **JSX is [completely optional](/docs/react-without-jsx.html)**, many people find it helpful for writing UI code -- both with React and with other libraries.
 
-You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-8&version=7.0.0-rc.3&envVersion=).
+You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-8&version=7.0.0&envVersion=).
 
 ### Quickly Try JSX
 
@@ -170,7 +170,7 @@ Adding JSX to a project doesn't require complicated tools like a bundler or a de
 Go to your project folder in the terminal, and paste these two commands:
 
 1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install @babel/core @babel/cli babel-preset-react-app@5`
+2. **Step 2:** Run `npm install @babel/core @babel/cli @babel/preset-react @babel/preset-env`
 
 >Tip
 >
@@ -184,7 +184,7 @@ Congratulations! You just added a **production-ready JSX setup** to your project
 Create a folder called `src` and run this terminal command:
 
 ```
-npx babel --watch src --out-dir . --presets react-app/prod
+npx babel --watch src --out-dir . --presets=@babel/preset-react,@babel/preset-env
 ```
 
 >Note

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -149,14 +149,14 @@ return (
 
 These two code snippets are equivalent. While **JSX is [completely optional](/docs/react-without-jsx.html)**, many people find it helpful for writing UI code -- both with React and with other libraries.
 
-You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-6.12&version=6.26.0&envVersion=).
+You can play with JSX using [this online converter](http://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=Q&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2%2Cstage-3&prettier=true&targets=Node-6.12&version=7.0.0&envVersion=).
 
 ### Quickly Try JSX
 
 The quickest way to try JSX in your project is to add this `<script>` tag to your page:
 
 ```html
-<script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
 ```
 
 Now you can use JSX in any `<script>` tag by adding `type="text/babel"` attribute to it. Here is [an example HTML file with JSX](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html) that you can download and play with.
@@ -170,7 +170,7 @@ Adding JSX to a project doesn't require complicated tools like a bundler or a de
 Go to your project folder in the terminal, and paste these two commands:
 
 1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install babel-cli@6 babel-preset-react-app@3`
+2. **Step 2:** Run `npm install @babel/core @babel/cli @babel/preset-react`
 
 >Tip
 >
@@ -184,7 +184,7 @@ Congratulations! You just added a **production-ready JSX setup** to your project
 Create a folder called `src` and run this terminal command:
 
 ```
-npx babel --watch src --out-dir . --presets react-app/prod 
+npx babel --watch src --out-dir . --presets @babel/preset-react 
 ```
 
 >Note

--- a/static/html/single-file-example.html
+++ b/static/html/single-file-example.html
@@ -7,7 +7,7 @@
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
     
     <!-- Don't use this in production: -->
-    <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
**What's changed?**

Updated the Babel links to v7 in "Add React to a Website" section on the website
