### PR TITLE
fix: revert buddy line indenting

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "unist-util-visit": "^1.1.3"
   },
   "engines": {
+    "node": "^8.4.0",
     "yarn": "^1.3.2"
   },
   "homepage": "https://reactjs.org/",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gatsby-remark-copy-linked-files": "^2.0.0",
     "gatsby-remark-embed-snippet": "^3.0.0",
     "gatsby-remark-images": "^2.0.0",
-    "gatsby-remark-prismjs": "^3.0.0",
+    "gatsby-remark-prismjs": "3.0.0-beta.6",
     "gatsby-remark-responsive-iframe": "^2.0.0",
     "gatsby-remark-smartypants": "^2.0.0",
     "gatsby-source-filesystem": "^2.0.0",
@@ -56,7 +56,6 @@
     "unist-util-visit": "^1.1.3"
   },
   "engines": {
-    "node": "^8.4.0",
     "yarn": "^1.3.2"
   },
   "homepage": "https://reactjs.org/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,13 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime@7.0.0-beta.52":
+  version "7.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.52.tgz#3f3b42b82b92b4e1a283fc78df1bb2fd4ba8d0c7"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
@@ -4792,11 +4799,11 @@ gatsby-remark-images@^2.0.0:
     unist-util-select "^1.5.0"
     unist-util-visit-parents "^2.0.1"
 
-gatsby-remark-prismjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.0.0.tgz#d88e8b2cc6ed76a85b55fc491885cb68f3544ee8"
+gatsby-remark-prismjs@3.0.0-beta.6:
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.0.0-beta.6.tgz#cb57759a89d51adbbdd5827f0e2ee8f7162879d9"
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "7.0.0-beta.52"
     parse-numeric-range "^0.0.2"
     unist-util-visit "^1.3.0"
 


### PR DESCRIPTION
Note: I'll work on fixing this in gatsby-remark-prismjs soon, but this
is a temporary patch fix for now :)

Fixes #1201
