### PR TITLE
Fixes broken link on the community support section

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -31,4 +31,4 @@ Each community consists of many thousands of React users.
 
 ## News
 
-For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs) and the [official React blog](/blog) on this website.
+For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs) and the [official React blog](/blog/) on this website.


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
The link to go to the official blog is broken on https://reactjs.org/community/support.html
![broken-link](https://user-images.githubusercontent.com/8060530/46241290-c69fcf80-c38c-11e8-9972-605df353f298.png)

It's missing a `/` at the end of the link.
