### PR TITLE
Change highlight color

### DIFF
--- a/src/prism-styles.js
+++ b/src/prism-styles.js
@@ -12,7 +12,7 @@ const prismColors = {
   char: '#D8DEE9',
   comment: '#999999',
   keyword: '#c5a5c5',
-  lineHighlight: '#14161a',
+  lineHighlight: '#353b45', // colors.dark + extra lightness
   primitive: '#5a9bcf',
   string: '#8dc891',
   variable: '#d7deea',


### PR DESCRIPTION
That's something that looked odd to me since the redesign, and after talking to a designer they found it confusing too that our highlighting is inverted. Text editors don't do that. Why do we?

<img width="593" alt="screen shot 2018-09-29 at 7 21 47 pm" src="https://user-images.githubusercontent.com/810438/46249189-f4345980-c41c-11e8-9551-6ab6a0c8eaaa.png">

So I'm changing it to be lighter instead:

<img width="731" alt="screen shot 2018-09-29 at 7 19 56 pm" src="https://user-images.githubusercontent.com/810438/46249192-fe565800-c41c-11e8-989c-c10ec6291fa4.png">

This is similar to what I see editors do:

<img width="892" alt="image 2018-09-28 at 7 12 40 pm 1" src="https://user-images.githubusercontent.com/810438/46249196-09a98380-c41d-11e8-99c2-295b5d450cb5.png">
<img width="723" alt="screen shot 2018-09-29 at 7 22 50 pm" src="https://user-images.githubusercontent.com/810438/46249200-129a5500-c41d-11e8-9402-0ccc13a1e210.png">

I tried to not make it *too* light since it's meant to emphasize code. I think this is acceptable. I'm happy to darken it a few notches if somebody wants to.