### PR TITLE
Adding a couple of redirects for pages returning 404

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -5,6 +5,7 @@ layout: community
 sectionid: community
 permalink: community/support.html
 redirect_from:
+  - "community/"
   - "support.html"
 ---
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -5,6 +5,7 @@ layout: tutorial
 sectionid: tutorial
 permalink: tutorial/tutorial.html
 redirect_from:
+  - "tutorial/"
   - "docs/tutorial.html"
   - "docs/why-react.html"
   - "docs/tutorial-ja-JP.html"
@@ -215,7 +216,7 @@ Congratulations! You've just "passed a prop" from a parent Board component to a 
 
 ### Making an Interactive Component
 
-Let's fill the Square component with an "X" when we click it. 
+Let's fill the Square component with an "X" when we click it.
 First, change the button tag that is returned from the Square component's `render()` function to this:
 
 ```javascript{4}
@@ -1003,7 +1004,7 @@ In JavaScript, arrays have a [`map()` method](https://developer.mozilla.org/en-U
 ```js
 const numbers = [1, 2, 3];
 const doubled = numbers.map(x => x * 2); // [2, 4, 6]
-``` 
+```
 
 Using the `map` method, we can map our history of moves to React elements representing buttons on the screen, and display a list of buttons to "jump" to past moves.
 

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -147,7 +147,7 @@ module.exports = async ({graphql, actions}) => {
   const newestBlogNode = newestBlogEntry.data.allMarkdownRemark.edges[0].node;
 
   // Blog landing page should always show the most recent blog entry.
-  ['/blog/', '/blog'].map(slug => {
+  ['/blog/', '/blog'].forEach(slug => {
     createRedirect({
       fromPath: slug,
       redirectInBrowser: true,

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -45,7 +45,6 @@ class CodeEditor extends Component {
   }
 
   render() {
-    const {children} = this.props;
     const {
       compiledES6,
       code,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,6 @@ import {colors, media, sharedStyles} from 'theme';
 import loadScript from 'utils/loadScript';
 import createOgUrl from 'utils/createOgUrl';
 import {babelURL} from 'site-constants';
-import ReactDOM from 'react-dom';
 import logoWhiteSvg from 'icons/logo-white.svg';
 
 class Home extends Component {
@@ -309,13 +308,6 @@ Home.propTypes = {
     marketing: PropTypes.object.isRequired,
   }).isRequired,
 };
-
-function renderExamplePlaceholder(containerId) {
-  ReactDOM.render(
-    <h4>Loading code example...</h4>,
-    document.getElementById(containerId),
-  );
-}
 
 const CtaItem = ({children, primary = false}) => (
   <div

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,6 +17,7 @@ import {colors, media, sharedStyles} from 'theme';
 import loadScript from 'utils/loadScript';
 import createOgUrl from 'utils/createOgUrl';
 import {babelURL} from 'site-constants';
+import ReactDOM from 'react-dom';
 import logoWhiteSvg from 'icons/logo-white.svg';
 
 class Home extends Component {
@@ -308,6 +309,13 @@ Home.propTypes = {
     marketing: PropTypes.object.isRequired,
   }).isRequired,
 };
+
+function renderExamplePlaceholder(containerId) {
+  ReactDOM.render(
+    <h4>Loading code example...</h4>,
+    document.getElementById(containerId),
+  );
+}
 
 const CtaItem = ({children, primary = false}) => (
   <div

--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -81,10 +81,7 @@ class Section extends React.Component {
                   ? activeItemId === item.id
                   : isItemActive(location, item),
                 item: section.isOrdered
-                  ? {
-                      ...item,
-                      title: `${index + 1}. ${item.title}`,
-                    }
+                  ? {...item, title: `${index + 1}. ${item.title}`}
                   : item,
                 location,
                 onLinkClick,


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

**This Pull Request does a couple of simple things:**

- [ ] Adds a couple of redirects to improve accesibility in some sections, these URL's were returning a 404 before so it shouldn't be a problem:
- `/community` for `/community/support.html`
- `/tutorial` for `/tutorial/tutorial.html`
- [ ] Improves and Deletes some blocks of unused code
- [ ] Fixes liting errors

Another reason behind the added redirects is that that `/blog` and `/docs` are behaving in this same way so maybe it's a good idea to have this as a consistent behavior between sections.