### PR TITLE
fix: prevent gatsby file detection from breaking path field

### DIFF
--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const path = require('path');
+
 // Parse date information out of blog post filename.
 const BLOG_POST_FILENAME_REGEX = /([0-9]+)\-([0-9]+)\-([0-9]+)\-(.+)\.md$/;
 
@@ -30,7 +32,7 @@ module.exports = exports.onCreateNode = ({node, actions, getNode}) => {
   switch (node.internal.type) {
     case 'MarkdownRemark':
       const {permalink, redirect_from} = node.frontmatter;
-      const {relativePath} = getNode(node.parent);
+      const {relativePath, sourceInstanceName} = getNode(node.parent);
 
       let slug = permalink;
 
@@ -71,10 +73,11 @@ module.exports = exports.onCreateNode = ({node, actions, getNode}) => {
       });
 
       // Used to generate a GitHub edit link.
+      // this presumes that the name in gastby-config.js refers to parent folder
       createNodeField({
         node,
         name: 'path',
-        value: relativePath,
+        value: path.join(sourceInstanceName, relativePath),
       });
 
       // Used by createPages() above to register redirects.

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -112,7 +112,7 @@ const MarkdownPage = ({
                   <div css={{marginTop: 80}}>
                     <a
                       css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/reactjs.org/tree/master/content/${
+                      href={`https://github.com/reactjs/reactjs.org/tree/master/${
                         markdownRemark.fields.path
                       }`}>
                       Edit this page

--- a/src/pages/docs/error-decoder.html.js
+++ b/src/pages/docs/error-decoder.html.js
@@ -107,9 +107,7 @@ export const pageQuery = graphql`
     markdownRemark(fields: {slug: {eq: $slug}}) {
       html
       fields {
-        path {
-          id
-        }
+        path
       }
       frontmatter {
         title

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -58,9 +58,7 @@ export const pageQuery = graphql`
       }
       fields {
         date(formatString: "MMMM DD, YYYY")
-        path {
-          id
-        }
+        path
         slug
       }
     }

--- a/src/templates/community.js
+++ b/src/templates/community.js
@@ -33,9 +33,7 @@ export const pageQuery = graphql`
         prev
       }
       fields {
-        path {
-          id
-        }
+        path
         slug
       }
     }

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -38,9 +38,7 @@ export const pageQuery = graphql`
         prev
       }
       fields {
-        path {
-          id
-        }
+        path
         slug
       }
     }

--- a/src/templates/tutorial.js
+++ b/src/templates/tutorial.js
@@ -36,9 +36,7 @@ export const pageQuery = graphql`
         prev
       }
       fields {
-        path {
-          id
-        }
+        path
         slug
       }
     }


### PR DESCRIPTION
Fixes #1088

This should fix the path issues that people intermittently run into.
Gatsby sees the relative path (and the parent node with an absolute
path), joins on the parent path and the relative path, and presumes it's
a file... which is normally good, but which here is not what we want
beacuse then we're getting a resolver of type file instead of type
string referring to the relative path of the document.

This seems to fix a (long standing?) bug where the "Edit this Page"
button is broken, as well. e.g. see [a current community page](https://reactjs.org/community/support.html) vs. [deploy preview community page](https://deploy-preview-1226--reactjs.netlify.com/community/support.html)

I'd need to think more as to whether there's a cleaner fix here, but
this seems to work pretty well!



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
