### PR TITLE
Update Render Props.md to include link to Robin Wieruch's article

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -323,3 +323,5 @@ class MouseTracker extends React.Component {
 ```
 
 In cases where you cannot define the prop statically (e.g. because you need to close over the component's props and/or state) `<Mouse>` should extend `React.Component` instead.
+
+If you'd like another explanation of the render props pattern, check out [this explanation by Robin Wieruch](https://www.robinwieruch.de/react-render-props-pattern/). The article is one of the most approachable explanations of the render prop pattern on the internet backed by highlighted code examples throughout.

--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -324,4 +324,6 @@ class MouseTracker extends React.Component {
 
 In cases where you cannot define the prop statically (e.g. because you need to close over the component's props and/or state) `<Mouse>` should extend `React.Component` instead.
 
+## Further Reading
+
 If you'd like another explanation of the render props pattern, check out [this explanation by Robin Wieruch](https://www.robinwieruch.de/react-render-props-pattern/). The article is one of the most approachable explanations of the render prop pattern on the internet backed by highlighted code examples throughout.


### PR DESCRIPTION
Robin's article on render props uses a real-life example to explain the render prop pattern. I've felt for a while it's so good it belongs somewhere in the official docs. 

Let me know if this isn't the best place to include his article. I'll gladly create another PR to include it somewhere else in the React docs.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
