### PR TITLE
correction: returning `null` does fire components lifecycle methods

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -240,4 +240,4 @@ ReactDOM.render(
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/Xjoqwm?editors=0010)
 
-Returning `null` from a component's `render` method does not affect the firing of the component's lifecycle methods. For instance `componentDidUpdate` will still be called.
+Returning `null` from a component's `render` method does affect the firing of the component's lifecycle methods. For instance `componentDidUpdate` will still be called.


### PR DESCRIPTION
removed the word __not__

See class `WarningBanner2` in https://codepen.io/icbm504/pen/OBbEBB?editors=1111
... and check console when clicking `show/hide` button



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
