### PR TITLE
Added arrow function to props.onClick

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -586,7 +586,7 @@ Replace the Square class with this function:
 ```javascript
 function Square(props) {
   return (
-    <button className="square" onClick={props.onClick}>
+    <button className="square" onClick={() => props.onClick()}>
       {props.value}
     </button>
   );


### PR DESCRIPTION
Earlier in the example it even warns about setting onClick={<function>} as it will call that function on every render call.
This simply wraps it to prevent that inefficiency and only call the function on click.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
