### PR TITLE
Type Error

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -119,7 +119,7 @@ class AutoFocusTextInput extends React.Component {
   }
 
   componentDidMount() {
-    this.textInput.current.focusTextInput();
+    this.focusTextInput();
   }
 
   render() {


### PR DESCRIPTION
Uncaught TypeError: this.textInput.current.focusTextInput is not a function



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
