### PR TITLE
add missing semi-colon in conditional rendering codeblock

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -98,7 +98,7 @@ class LoginControl extends React.Component {
     if (isLoggedIn) {
       button = <LogoutButton onClick={this.handleLogoutClick} />;
     } else {
-      button = <LoginButton onClick={this.handleLoginClick} />
+      button = <LoginButton onClick={this.handleLoginClick} />;
     }
 
     return (


### PR DESCRIPTION
I'm sure these discussions have been going on, but personally I think running all of the examples through prettier's default settings would go a long way, not just in the react docs, but basically everywhere. seems like the closest thing to a standard js has ever come by.

anyways, you dropped this `;`

😎 