### PR TITLE
Fix typo

### DIFF
--- a/content/blog/2018-09-10-introducing-the-react-profiler.md
+++ b/content/blog/2018-09-10-introducing-the-react-profiler.md
@@ -173,7 +173,7 @@ The tracing API is still new and we will cover it in more detail in a future blo
 
 ### No profiling data has been recorded for the selected root
 
-If your your application has multiple "roots", you may see the following message after profiling:
+If your application has multiple "roots", you may see the following message after profiling:
 ![No profiling data has been recorded for the selected root](../images/blog/introducing-the-react-profiler/no-profiler-data-multi-root.png)
 
 This message indicates that no performance data was recorded for the root that's selected in the "Elements" panel.

--- a/content/blog/2018-10-01-create-react-app-v2.md
+++ b/content/blog/2018-10-01-create-react-app-v2.md
@@ -55,7 +55,7 @@ Run `npm install` (or `yarn`, if you use it). **For many projects, this one-line
 
 <blockquote class="twitter-tweet" data-conversation="none" data-dnt="true"><p lang="en" dir="ltr">working here... thanks for all the new functionality 👍</p>&mdash; Stephen Haney (@sdothaney) <a href="https://twitter.com/sdothaney/status/1046822703116607490?ref_src=twsrc%5Etfw">October 1, 2018</a></blockquote>
 
-Here's a few more tips to get you started.
+Here are a few more tips to get you started.
 
 **When you run `npm start` for the first time after the upgrade,** you'll get a prompt asking about which browsers you'd like to support. Press `y` to accept the default ones. They'll be written to your `package.json` and you can edit them any time. Create React App will use this information to produce smaller or polyfilled CSS bundles depending on whether you target modern browsers or older browsers.
 

--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -187,7 +187,7 @@ Currently Chrome, Edge, and IE are the only browsers supporting this feature, bu
 
 `react-dom` 16.5+ and `react-native` 0.57+ provide enhanced profiling capabilities in DEV mode with the React DevTools Profiler.
 An overview of the Profiler can be found in the blog post ["Introducing the React Profiler"](/blog/2018/09/10/introducing-the-react-profiler.html).
-A video walk through of the profiler is also [available on YouTube](https://www.youtube.com/watch?v=nySib7ipZdk).
+A video walkthrough of the profiler is also [available on YouTube](https://www.youtube.com/watch?v=nySib7ipZdk).
 
 If you haven't yet installed the React DevTools, you can find them here:
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -142,7 +142,7 @@ As a last resort, you can pass an item's index in the array as a key. This can w
 
 Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like uncontrolled inputs can get mixed up and updated in unexpected ways.
 
-[Here](codepen://reconciliation/index-used-as-key) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](codepen://reconciliation/no-index-used-as-key) is a updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
+[Here](codepen://reconciliation/index-used-as-key) is an example of the issues that can be caused by using indexes as keys on CodePen, and [here](codepen://reconciliation/no-index-used-as-key) is an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues.
 
 ## Tradeoffs
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -164,7 +164,7 @@ The `ShoppingList` component above only renders built-in DOM components like `<d
 
 If you're going to work on the tutorial **in your browser,** open this code in a new tab: **[Starter Code](https://codepen.io/gaearon/pen/oWWQNa?editors=0010)**. If you're going to work on the tutorial **locally,** instead open `src/index.js` in your project folder (you have already touched this file during the [setup](#setup-option-2-local-development-environment)).
 
-This Starter Code is the base of what we're building. We've provided the CSS styling so that you only need focus on learning React and programming the tic-tac-toe game.
+This Starter Code is the base of what we're building. We've provided the CSS styling so that you only need to focus on learning React and programming the tic-tac-toe game.
 
 By inspecting the code, you'll notice that we have three React components:
 


### PR DESCRIPTION
This PR fixes the following typo:
* `your your` -> `your`
* `Here's a few more tips` -> `Here are a few more tips`
* `walk through` -> `walkthrough`
* `a updated ` -> `an updated `
* `you only need focus on ` -> `you only need to focus on`
