### PR TITLE
fixed minor typo in 16.6 blog post

### DIFF
--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -76,7 +76,7 @@ React 16 introduced [Error Boundaries](/blog/2017/07/26/error-handling-in-react-
 
 Before that is fired, we render `null` in place of the tree that threw an error. This sometimes breaks parent components that don't expect their refs to be empty. It also doesn't work to recover from errors on the server since the `Did` lifecycle methods don't fire during server-side rendering.
 
-We've adding another error method that lets you render the fallback UI before the render completes. See the docs for [`getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror).
+We've added another error method that lets you render the fallback UI before the render completes. See the docs for [`getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror).
 
 > Note: `getDerivedStateFromError()` is not yet available for server-side rendering. It is designed to work with server-side rendering in a future release. We're releasing it early so that you can start preparing to use it.
 

--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -76,7 +76,7 @@ React 16 introduced [Error Boundaries](/blog/2017/07/26/error-handling-in-react-
 
 Before that is fired, we render `null` in place of the tree that threw an error. This sometimes breaks parent components that don't expect their refs to be empty. It also doesn't work to recover from errors on the server since the `Did` lifecycle methods don't fire during server-side rendering.
 
-We've added another error method that lets you render the fallback UI before the render completes. See the docs for [`getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror).
+We're adding another error method that lets you render the fallback UI before the render completes. See the docs for [`getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror).
 
 > Note: `getDerivedStateFromError()` is not yet available for server-side rendering. It is designed to work with server-side rendering in a future release. We're releasing it early so that you can start preparing to use it.
 


### PR DESCRIPTION
Just fixed a minor typo in the 16.6 release blog post
