### PR TITLE
typo fix in context paragraph

### DIFF
--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -46,7 +46,7 @@ In [React 16.3](/blog/2018/03/29/react-v-16-3.html) we introduced the official C
 const MyContext = React.createContext();
 ```
 
-We've heard feedback that adopting the new render prop API can be difficult in class components. So we've add a convenience API to [consume a context value from within a class component](/docs/context.html#classcontexttype).
+We've heard feedback that adopting the new render prop API can be difficult in class components. So we've added a convenience API to [consume a context value from within a class component](/docs/context.html#classcontexttype).
 
 ```js
 class MyClass extends React.Component {


### PR DESCRIPTION
minor typo in the 16.6 release blog post
reference https://reactjs.org/blog/2018/10/23/react-v-16-6.html