### PR TITLE
More complete syntax

### DIFF
--- a/content/docs/reference-glossary.md
+++ b/content/docs/reference-glossary.md
@@ -97,7 +97,7 @@ If you need to modify some value in response to user input or a network response
 `props.children` is available on every component. It contains the content between the opening and closing tags of a component. For example:
 
 ```js
-<Welcome>Hello world!</Welcome>
+const welcome = <Welcome>Hello world!</Welcome>;
 ```
 
 The string `Hello world!` is available in `props.children` in the `Welcome` component:


### PR DESCRIPTION
Hello,

I made the props.children section that describes how props.children is available on every component. I think it is more clear to put the example in a variable and add a semi-colon.

Thank you,

Brice

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
