### PR TITLE
Update hooks-intro.md

### DIFF
--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -53,7 +53,7 @@ React doesn't offer a way to "attach" reusable behavior to a component (for exam
 
 With Hooks, you can extract stateful logic from a component so it can be tested independently and reused. **Hooks allow you to reuse stateful logic without changing your component hierarchy.** This makes it easy to share Hooks among many components or with the community.
 
-We'll discuss this more in [Writing Custom Hooks](/docs/hooks-custom.html#using-a-custom-hook).
+We'll discuss this more in [Writing Custom Hooks](/docs/hooks-custom.html).
 
 ### Complex components become hard to understand
 


### PR DESCRIPTION
What changed
===========
Made link to Writing Custom Hooks lead to the top of the page rather than to Using a Custom Hook

Before the change
==============
When you clicked the link to _Writing Custom Hooks_ from `hooks-intro.html`:

![image](https://user-images.githubusercontent.com/6312838/47554799-b7fbf800-d8f9-11e8-9ed9-da26193ee60c.png)

You would be taken to `/docs/hooks-custom.html#using-a-custom-hook`:

![image](https://user-images.githubusercontent.com/6312838/47554829-c9450480-d8f9-11e8-8213-caac2faba863.png)


After the change
============
Now when you click the link, you are taken to the top of the page, `/docs/hooks-custom.html`, as you would expect:

![image](https://user-images.githubusercontent.com/6312838/47554853-dfeb5b80-d8f9-11e8-9ea7-61b95af16a14.png)