### PR TITLE
Removed unused parameter from example code

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -193,7 +193,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialCount}) {
+function Counter() {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
Looks like a parameter from the next example was accidentally included in this one as well.

I did not edit the last line of the file, there might be a newline at the end of the file that GitHub's editor may have added or removed and it's highlighting that in the diff.