### PR TITLE
Reset button should set the state back to `initialCount`

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -55,7 +55,7 @@ function Counter({initialCount}) {
   return (
     <>
       Count: {count}
-      <button onClick={() => setCount(0)}>Reset</button>
+      <button onClick={() => setCount(initialCount)}>Reset</button>
       <button onClick={() => setCount(prevCount => prevCount + 1)}>+</button>
       <button onClick={() => setCount(prevCount => prevCount - 1)}>-</button>
     </>


### PR DESCRIPTION
Reset button should set the state back to `initialCount` instead of `0` in this code snippet. https://reactjs.org/docs/hooks-reference.html#functional-updates