### PR TITLE
Fix setState bug on hooks-effect and hooks-state documentation page

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -74,7 +74,7 @@ class Example extends React.Component {
     return (
       <div>
         <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+        <button onClick={() => this.setState((state) => ({ count: state.count + 1 }))}>
           Click me
         </button>
       </div>

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -47,7 +47,7 @@ class Example extends React.Component {
     return (
       <div>
         <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+        <button onClick={() => this.setState((state) => ({ count: state.count + 1 }))}>
           Click me
         </button>
       </div>

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -174,7 +174,7 @@ In a function, we can use `count` directly:
 In a class, we need to call `this.setState()` to update the `count` state:
 
 ```js{1}
-  <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+  <button onClick={() => this.setState((state) => ({ count: state.count + 1 }))}>
     Click me
   </button>
 ```


### PR DESCRIPTION
### Description
- The `setState` function to update the count depends on the current state. So, it should use the second form of setState, which accepts a function (with the current state as its argument) to update the count.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
