### PR TITLE
Render Props API -> Context API

### DIFF
--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -46,7 +46,7 @@ In [React 16.3](/blog/2018/03/29/react-v-16-3.html) we introduced the official C
 const MyContext = React.createContext();
 ```
 
-We've heard feedback that adopting the new render prop API can be difficult in class components. So we've add a convenience API to [consume a context value from within a class component](/docs/context.html#classcontexttype).
+We've heard feedback that adopting the new Context API can be difficult in class components. So we've add a convenience API to [consume a context value from within a class component](/docs/context.html#classcontexttype).
 
 ```js
 class MyClass extends React.Component {


### PR DESCRIPTION
## Overview
Thank you for quite good post for I could catch up v16.6.0!

I found out 1 nitpick there.(I think `Context API` is correct at here)
New Context API syntax form is similar to render props(children) pattern, so I guess who attempted to mention it here.(e.g. render props like new Context API)

Thank you😀