### PR TITLE
Fix anchor link for getDerivedStateFromError

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -83,7 +83,7 @@ This method is called when a component is being removed from the DOM:
 
 These methods are called when there is an error during rendering, in a lifecycle method, or in the constructor of any child component.
 
-- [`static getDerivedStateFromError()`](#getderivedstatefromerror)
+- [`static getDerivedStateFromError()`](#static-getderivedstatefromerror)
 - [`componentDidCatch()`](#componentdidcatch)
 
 ### Other APIs


### PR DESCRIPTION
The anchor for `getDerivedStateFromError` was previously `#getderivedstatefromerror` when it should be `#static-getderivedstatefromerror`



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
