### PR TITLE
Correction of the sequence of parameters

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -146,7 +146,7 @@ Inside a loop it is common to want to pass an extra parameter to an event handle
 
 ```js
 <button onClick={(e) => this.deleteRow(id, e)}>Delete Row</button>
-<button onClick={this.deleteRow.bind(this, id)}>Delete Row</button>
+<button onClick={this.deleteRow.bind(id, this)}>Delete Row</button>
 ```
 
 The above two lines are equivalent, and use [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) respectively.


### PR DESCRIPTION
In accordance with the following sentence:  
> In both cases, the `e` argument representing the React event will be passed as a **second argument after the ID**.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
