### PR TITLE
Typo in useReducer docs, the initialCount prop is unused

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -194,7 +194,7 @@ function reducer(state, action) {
 }
 
 function Counter({initialCount}) {
-  const [state, dispatch] = useReducer(reducer, initialCount);
+  const [state, dispatch] = useReducer(reducer, {count: initialCount});
   return (
     <>
       Count: {state.count}

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -194,7 +194,7 @@ function reducer(state, action) {
 }
 
 function Counter({initialCount}) {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, dispatch] = useReducer(reducer, initialCount);
   return (
     <>
       Count: {state.count}


### PR DESCRIPTION
Unless I'm misunderstanding something, the initialCount prop should be passed as initial state to the useReducer hook.