### PR TITLE
fix: Small typo in the article

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -115,7 +115,7 @@ However, sometimes the same data needs to be accessible by many components in th
 const MyContext = React.createContext(defaultValue);
 ```
 
-Creates an Context object. When React renders a component that subscribes to this Context object it will read the current context value from the closest matching `Provider` above it in the tree.
+Creates a Context object. When React renders a component that subscribes to this Context object it will read the current context value from the closest matching `Provider` above it in the tree.
 
 The `defaultValue` argument is **only** used when a component does not have a matching Provider above it in the tree. This can be helpful for testing components in isolation without wrapping them. Note: passing `undefined` as a Provider value does not cause consuming components to use `defaultValue`.
 


### PR DESCRIPTION
Fixed a one-character typo in the documentation. Don't think contribution guidelines should play a role here ;)