### PR TITLE
Updated useReducer reducer example to show default case

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -190,6 +190,10 @@ function reducer(state, action) {
       return {count: state.count + 1};
     case 'decrement':
       return {count: state.count - 1};
+    default:
+      // A reducer must always return a valid state.
+      // Alternatively you can throw an error if an invalid action is dispatched.
+      return state;
   }
 }
 
@@ -223,6 +227,10 @@ function reducer(state, action) {
       return {count: state.count + 1};
     case 'decrement':
       return {count: state.count - 1};
+    default:
+      // A reducer must always return a valid state.
+      // Alternatively you can throw an error if an invalid action is dispatched.
+      return state;
   }
 }
 


### PR DESCRIPTION
I don't think our example should show a reducer that potentially has an undefined return value, since this isn't supported. I wasn't sure whether to return `state` as-is or throw in the example, so I opted for an inline comment. Happy to change it. Suggestions?