### PR TITLE
Update Hooks Intro Example() to `import React`

### DIFF
--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -23,7 +23,7 @@ This is a fast-paced overview. If you get confused, look for a yellow box like t
 This example renders a counter. When you click the button, it increments the value:
 
 ```js{1,4,5}
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 function Example() {
   // Declare a new state variable, which we'll call "count"


### PR DESCRIPTION
Hi there! 👋 

I was trying to test out Hooks for fun (cheers to the React team!). I copied the first example into my project and tried exporting that function to use as a component in another component and kept getting this error `Uncaught ReferenceError: React is not defined`.

I realized it was because I wasn't import `React` along with the `useState` hook.

So, I thought I would propose this change to update the example to import React so that future readers don't run into the same error.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
