### PR TITLE
Replace unmaintained react-loadable package with loadable-components.

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -115,7 +115,7 @@ parse the dynamic import syntax but is not transforming it. For that you will ne
 
 > Note:
 >
-> `React.lazy` and Suspense is not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we recommend [Loadable Components](https://github.com/smooth-code/loadable-components) or [React Universal Component](https://github.com/faceyspacey/react-universal-component).
+> `React.lazy` and Suspense is not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we recommend [Loadable Components](https://github.com/smooth-code/loadable-components). It has a nice [guide for bundle splitting with server-side rendering](https://github.com/smooth-code/loadable-components/blob/master/packages/server/README.md).
 
 The `React.lazy` function lets you render a dynamic import as a regular component.
 

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -115,7 +115,7 @@ parse the dynamic import syntax but is not transforming it. For that you will ne
 
 > Note:
 >
-> `React.lazy` and Suspense is not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we still recommend [React Loadable](https://github.com/thejameskyle/react-loadable). It has a nice [guide for bundle splitting with server-side rendering](https://github.com/thejameskyle/react-loadable#------------server-side-rendering).
+> `React.lazy` and Suspense is not yet available for server-side rendering. If you want to do code-splitting in a server rendered app, we recommend [Loadable Components](https://github.com/smooth-code/loadable-components) or [React Universal Component](https://github.com/faceyspacey/react-universal-component).
 
 The `React.lazy` function lets you render a dynamic import as a regular component.
 


### PR DESCRIPTION
`react-loadable` no longer has an active maintainer and has no support for Webpack 4 or Babel 7. Only personal forks are available. This isn't clear at all from the github page, and can only be discovered by digging into issues such as https://github.com/jamiebuilds/react-loadable/pull/151.

This PR links to two actively-developed projects which accomplish the same thing - split on the server and load all bundles in parallel.

Closes https://github.com/reactjs/reactjs.org/issues/1146, which was about the react-loadable license (which has since been reverted).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
