### PR TITLE
Update React.lazy first code snippet

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -147,6 +147,8 @@ function MyComponent() {
 }
 ```
 
+_*Note*: in order to make this snippet work you also need `Suspense`, please keep reading._
+
 This will automatically load the bundle containing the `OtherComponent` when this component gets rendered.
 
 `React.lazy` takes a function that must call a dynamic `import()`. This must return a `Promise` which resolves to a module with a `default` export containing a React component.


### PR DESCRIPTION
`React.lazy` first code snippet was not working out of the box. 

After the snippet it stated: _This will automatically load the bundle containing the `OtherComponent` when this component gets rendered._

But that's simply not true, *it'd simply throw* without `Suspense`. I got confused by this first example and needed to test it out on an isolated [CodeSandbox](https://codesandbox.io/s/mjz3p3w7xy) to verify that Suspense is actually needed. I think it'd be better to change the snippet and make it work out of the box, so copy-pasting will work (and the phrase _This will automatically load the bundle containing the `OtherComponent` when this component gets rendered._ will hold `true` 😄 ).
