### PR TITLE
Specify articleLayout.container.flexDirection to 'column'

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -115,6 +115,7 @@ const sharedStyles = {
   articleLayout: {
     container: {
       display: 'flex',
+      flexDirection: 'column',
       minHeight: 'calc(100vh - 60px)',
       [media.greaterThan('sidebarFixed')]: {
         maxWidth: 840,


### PR DESCRIPTION
`articleLayout.container.flexDirection` is supposed to be column direction since the layout is vertical.

Fixes #1404 
