### PR TITLE
Revert "Specify articleLayout.container.flexDirection to 'column'"

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -115,7 +115,6 @@ const sharedStyles = {
   articleLayout: {
     container: {
       display: 'flex',
-      flexDirection: 'column',
       minHeight: 'calc(100vh - 60px)',
       [media.greaterThan('sidebarFixed')]: {
         maxWidth: 840,


### PR DESCRIPTION
Reverts reactjs/reactjs.org#1414

I just realized it broke sidebar on desktop. Ooops.