### PR TITLE
articleLayout.container.flexDirection='column' only when media is less than 'small'

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -115,6 +115,7 @@ const sharedStyles = {
   articleLayout: {
     container: {
       display: 'flex',
+      flexDirection: 'column',
       minHeight: 'calc(100vh - 60px)',
       [media.greaterThan('sidebarFixed')]: {
         maxWidth: 840,

--- a/src/theme.js
+++ b/src/theme.js
@@ -115,12 +115,14 @@ const sharedStyles = {
   articleLayout: {
     container: {
       display: 'flex',
-      flexDirection: 'column',
       minHeight: 'calc(100vh - 60px)',
       [media.greaterThan('sidebarFixed')]: {
         maxWidth: 840,
         marginLeft: 'auto',
         marginRight: 'auto',
+      },
+      [media.lessThan('small')]: {
+        flexDirection: 'column'
       },
     },
     content: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -122,7 +122,7 @@ const sharedStyles = {
         marginRight: 'auto',
       },
       [media.lessThan('small')]: {
-        flexDirection: 'column'
+        flexDirection: 'column',
       },
     },
     content: {


### PR DESCRIPTION
`articleLayout.container.flexDirection` is will be set to 'column' only when the media is less than 'small'

My #1414 previously broke desktop layout because the `flexDirection: column` applied to desktop as well, where it shouldn't had because `flexDirection: row | initial` is required for the sidebar to be placed next to the article

This should now work on both desktop and mobile:

![output2](https://user-images.githubusercontent.com/1332975/48772928-d68abe80-ed00-11e8-9934-ace785afdbc1.gif)

Fixes #1404 
