### PR TITLE
Update 2018-05-23-react-v-16-4.md example fix

### DIFF
--- a/content/blog/2018-05-23-react-v-16-4.md
+++ b/content/blog/2018-05-23-react-v-16-4.md
@@ -62,7 +62,7 @@ One possible way to fix this is to compare the incoming value to the previous va
 
 ```js
 static getDerivedStateFromProps(props, state) {
-  const prevProps = state.prevProps;
+  const prevProps = state.prevProps || {};
   // Compare the incoming prop to previous prop
   const controlledValue =
     prevProps.value !== props.value


### PR DESCRIPTION
Minor "fix" to the suggested fix in the blog post to default back to empty object if `state.prevProps` isn't yet set. This will help anyone copying the example as-is who has stumbled across this blog post.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
