### PR TITLE
Updated article link to the canonical source

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -177,7 +177,7 @@ To do this in Chrome:
 
 6. React events will be grouped under the **User Timing** label.
 
-For a more detailed walkthrough, check out [this article by Ben Schwarz](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad).
+For a more detailed walkthrough, check out [this article by Ben Schwarz](https://calibreapp.com/blog/2017-11-28-debugging-react/).
 
 Note that **the numbers are relative so components will render faster in production**. Still, this should help you realize when unrelated UI gets updated by mistake, and how deep and how often your UI updates occur.
 


### PR DESCRIPTION
Hi all!

I'm the author of the linked post - Thanks for including it in the offical documentation 💖 

The article was dual published on Calibre's blog as well as Medium, but we definitely consider the blog as the canonical source. This change updates the link to point there. ✌️