### PR TITLE
add symbol polyfill to the list

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -6,13 +6,14 @@ category: Reference
 permalink: docs/javascript-environment-requirements.html
 ---
 
-React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js) or [babel-polyfill](https://babeljs.io/docs/usage/polyfill/).
+React 16 depends on newer JavaScript runtime features like: the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), and [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js) or [babel-polyfill](https://babeljs.io/docs/usage/polyfill/).
 
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
 import 'core-js/es6/map';
 import 'core-js/es6/set';
+import 'core-js/es6/symbol';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -23,7 +24,7 @@ ReactDOM.render(
 );
 ```
 
-React also depends on `requestAnimationFrame` (even in test environments).  
+React also depends on `requestAnimationFrame` (even in test environments).
 You can use the [raf](https://www.npmjs.com/package/raf) package to shim `requestAnimationFrame`:
 
 ```js


### PR DESCRIPTION
Now that react-is is proliferating the ecosystem for things like
ForwardRef handling and such, symbols have become a requirement.
