### PR TITLE
Add -webkit-overflow-scrolling to prism styles

### DIFF
--- a/src/prism-styles.js
+++ b/src/prism-styles.js
@@ -31,6 +31,7 @@ css.global('.gatsby-highlight', {
   borderRadius: 10,
   overflow: 'auto',
   tabSize: '1.5em',
+  WebkitOverflowScrolling: 'touch',
 });
 
 css.global(


### PR DESCRIPTION
Adding `-webkit-overflow-scrolling: touch` to the code examples will give them nice momentum scrolling in webkit browsers.

## Before

![screen recording 2018-12-03 at 2 34 19 pm](https://user-images.githubusercontent.com/1153686/49398685-214b0400-f70d-11e8-8266-62a692dce029.gif)

## After

![untitled](https://user-images.githubusercontent.com/1153686/49398701-2740e500-f70d-11e8-84ce-2c98af08ddd4.gif)
