### PR TITLE
Fixing id to 'What Are We Building?' section

### DIFF
--- a/content/tutorial/nav.yml
+++ b/content/tutorial/nav.yml
@@ -5,7 +5,7 @@
       href: /tutorial/tutorial.html#before-we-start-the-tutorial
       forceInternal: true
       subitems:
-        - id: what-were-building
+        - id: what-are-we-building
           title: What Are We Building?
           href: /tutorial/tutorial.html#what-are-we-building
           forceInternal: true


### PR DESCRIPTION
Found an issue in ["What are we building?" section](https://reactjs.org/tutorial/tutorial.html#what-are-we-building) - it's not highlighted, despite clicking or scrolling trough it. Fixed it locally and created this HUGE pull request.