### PR TITLE
Remove Unnecessary this.bind(this)

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -78,16 +78,14 @@ It will render either `<LoginButton />` or `<LogoutButton />` depending on its c
 class LoginControl extends React.Component {
   constructor(props) {
     super(props);
-    this.handleLoginClick = this.handleLoginClick.bind(this);
-    this.handleLogoutClick = this.handleLogoutClick.bind(this);
     this.state = {isLoggedIn: false};
   }
 
-  handleLoginClick() {
+  handleLoginClick = () => {
     this.setState({isLoggedIn: true});
   }
 
-  handleLogoutClick() {
+  handleLogoutClick = () => {
     this.setState({isLoggedIn: false});
   }
 
@@ -211,10 +209,9 @@ class Page extends React.Component {
   constructor(props) {
     super(props);
     this.state = {showWarning: true};
-    this.handleToggleClick = this.handleToggleClick.bind(this);
-  }
+    }
 
-  handleToggleClick() {
+  handleToggleClick = () => {
     this.setState(state => ({
       showWarning: !state.showWarning
     }));


### PR DESCRIPTION
Hi,

I updated post to use ES6/ES2018 fat arrow functions which fixes the scoping error that requires the this.bind(this).

confirming that works is codepen link:
https://codepen.io/olivercarlson/pen/MZWYRE



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
