### PR TITLE
Fixed typo

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -95,7 +95,7 @@ import("./math").then(math => {
 
 > Note:
 >
-> The dynamic `import()` syntax is a ECMAScript (JavaScript)
+> The dynamic `import()` syntax is an ECMAScript (JavaScript)
 > [proposal](https://github.com/tc39/proposal-dynamic-import) not currently
 > part of the language standard. It is expected to be accepted in the
 > near future.


### PR DESCRIPTION
~a~ ECMAScript proposal => **an** ECMAScript proposal
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
