### PR TITLE
Changing state to prevState

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -359,8 +359,8 @@ To fix it, use a second form of `setState()` that accepts a function rather than
 
 ```js
 // Correct
-this.setState((state, props) => ({
-  counter: state.counter + props.increment
+this.setState((prevState, props) => ({
+  counter: prevState.counter + props.increment
 }));
 ```
 
@@ -368,9 +368,9 @@ We used an [arrow function](https://developer.mozilla.org/en/docs/Web/JavaScript
 
 ```js
 // Correct
-this.setState(function(state, props) {
+this.setState(function(prevState, props) {
   return {
-    counter: state.counter + props.increment
+    counter: prevState.counter + props.increment
   };
 });
 ```


### PR DESCRIPTION
 In the second form of setState() that accepts a function, the first argument to the function is the previous state. In the code example though, it is called state which is counter intuitive to beginners. function(prevState, props) makes more sense IMHO.
I'm new by the way and don't know your rules and conventions. I apologize in advance if I should have proceeded differently.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
