### PR TITLE
Misleading useReducer lazy init example

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -196,7 +196,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialCount}) {
+function Counter({initialCount = 0}) {
   const [state, dispatch] = useReducer(reducer, {count: initialCount});
   return (
     <>


### PR DESCRIPTION
For more context see: https://github.com/reactjs/rfcs/pull/68#issuecomment-449568020

The example just assumes that `initialCount` value will be passed from a parent. When it isn't, the state becomes `undefined` and later `NaN` when trying to inc/dec a value.
