### PR TITLE
Update Hooks Docs to refer to the correct react version

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -6,7 +6,7 @@ next: hooks-reference.html
 prev: hooks-rules.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 Building your own Hooks lets you extract component logic into reusable functions.
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -6,7 +6,7 @@ next: hooks-rules.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 The *Effect Hook* lets you perform side effects in function components:
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-faq.html
 prev: hooks-reference.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 This page answers some of the frequently asked questions about [Hooks](/docs/hooks-overview.html).
 

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-intro.html
 next: hooks-overview.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 ```js{4,5}
 import { useState } from 'react';

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -6,7 +6,7 @@ next: hooks-state.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). This page provides an overview of Hooks for experienced React users.
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -6,7 +6,7 @@ prev: hooks-custom.html
 next: hooks-faq.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 This page describes the APIs for the built-in Hooks in React.
 

--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -6,7 +6,7 @@ next: hooks-custom.html
 prev: hooks-effect.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 Hooks are JavaScript functions, but you need to follow two rules when using them. We provide a [linter plugin](https://www.npmjs.com/package/eslint-plugin-react-hooks) to enforce these rules automatically:
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -6,7 +6,7 @@ next: hooks-effect.html
 prev: hooks-overview.html
 ---
 
-*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.
+*Hooks* are an upcoming feature that lets you use state and other React features without writing a class. They're currently in React v16.7.0-alpha.2.
 
 The [previous page](/docs/hooks-intro.html) introduced Hooks with this example:
 


### PR DESCRIPTION
Hooks documentation had the wrong version of the alpha release for hooks. 