### PR TITLE
Update version expected to include hooks

### DIFF
--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -43,7 +43,7 @@ Before we continue, note that Hooks are:
 
 * **Completely opt-in.** You can try Hooks in a few components without rewriting any existing code. But you don't have to learn or use Hooks right now if you don't want to.
 * **100% backwards-compatible.** Hooks don't contain any breaking changes.
-* **Available now.** Hooks are currently in an alpha release, and we hope to include them in React 16.7 after receiving community feedback.
+* **Available now.** Hooks are currently in an alpha release, and we hope to include them in React 16.8 after receiving community feedback.
 
 **There are no plans to remove classes from React.** You can read more about the gradual adoption strategy for Hooks in the [bottom section](#gradual-adoption-strategy) of this page.
 

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -43,7 +43,7 @@ Before we continue, note that Hooks are:
 
 * **Completely opt-in.** You can try Hooks in a few components without rewriting any existing code. But you don't have to learn or use Hooks right now if you don't want to.
 * **100% backwards-compatible.** Hooks don't contain any breaking changes.
-* **Available now.** Hooks are currently in an alpha release, and we hope to include them in React 16.8 after receiving community feedback.
+* **Available now.** Hooks are currently in an alpha release, and we hope to include them in React 16.x after receiving community feedback.
 
 **There are no plans to remove classes from React.** You can read more about the gradual adoption strategy for Hooks in the [bottom section](#gradual-adoption-strategy) of this page.
 


### PR DESCRIPTION
This example from intro on hooks
```
import { useState } from 'react';

function Example() {
  // Declare a new state variable, which we'll call "count"
  const [count, setCount] = useState(0);

  return (
    <div>
      <p>You clicked {count} times</p>
      <button onClick={() => setCount(count + 1)}>
        Click me
      </button>
    </div>
  );
}
```
blows up in `react@16.7.0`, but works in `react@16.7.0-alpha.2`, so I guess the release version to expect hooks is 16.8.0. That's just my guess, React team could have other plans.