### PR TITLE
Call second arg of React.memo a function not a method

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -127,7 +127,7 @@ function areEqual(prevProps, nextProps) {
 export default React.memo(MyComponent, areEqual);
 ```
 
-This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
+This function only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
 
 > Note
 >


### PR DESCRIPTION
The 'preventing render' warning about the second arg of React.memo looks like it's been copy-pasted from the equivalent `shouldComponentUpdate` warning, but the second arg of React.memo is a function not a method.