### PR TITLE
Remove event param from arrow function example

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -130,7 +130,7 @@ class LoggingButton extends React.Component {
   render() {
     // This syntax ensures `this` is bound within handleClick
     return (
-      <button onClick={(e) => this.handleClick(e)}>
+      <button onClick={() => this.handleClick()}>
         Click me
       </button>
     );


### PR DESCRIPTION
As a newer JS/React dev, I found it confusing that the event was being passed in the arrow function in the callback, when it is not used in the referenced function. 

I updated the code example and removed the event param, so that other devs might not also get confused that the event needs to be passed in this example, even though it isn't used in the referenced callback.

<img width="981" alt="screenshot 2019-01-10 at 09 08 40" src="https://user-images.githubusercontent.com/9959680/50954662-576f6680-14b7-11e9-8604-b85631375db7.png">
