### PR TITLE
rename useImperativeMethods -> useImperativeHandle

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -304,7 +304,7 @@ This might look strange at first, but an update during rendering is exactly what
 
 ### Can I make a ref to a function component?
 
-While you shouldn't need this often, you may expose some imperative methods to a parent component with the [`useImperativeMethods`](/docs/hooks-reference.html#useimperativemethods) Hook.
+While you shouldn't need this often, you may expose some imperative methods to a parent component with the [`useImperativeHandle`](/docs/hooks-reference.html#useimperativehandle) Hook.
 
 ### What does `const [thing, setThing] = useState()` mean?
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -324,7 +324,7 @@ Note that `useRef()` is useful for more than the `ref` attribute. It's [handy fo
 ### `useImperativeHandle`
 
 ```js
-useImperativeHandle(ref, createInstance, [inputs])
+useImperativeHandle(ref, createHandle, [inputs])
 ```
 
 `useImperativeHandle` customizes the instance value that is exposed to parent components when using `ref`. As always, imperative code using refs should be avoided in most cases. `useImperativeHandle` should be used with `forwardRef`:

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -21,7 +21,7 @@ If you're new to Hooks, you might want to check out [the overview](/docs/hooks-o
   - [`useCallback`](#usecallback)
   - [`useMemo`](#usememo)
   - [`useRef`](#useref)
-  - [`useImperativeMethods`](#useimperativemethods)
+  - [`useImperativeHandle`](#useimperativehandle)
   - [`useLayoutEffect`](#uselayouteffect)
 
 ## Basic Hooks
@@ -321,18 +321,18 @@ function TextInputWithFocusButton() {
 
 Note that `useRef()` is useful for more than the `ref` attribute. It's [handy for keeping any mutable value around](/docs/hooks-faq.html#is-there-something-like-instance-variables) similar to how you'd use instance fields in classes.
 
-### `useImperativeMethods`
+### `useImperativeHandle`
 
 ```js
-useImperativeMethods(ref, createInstance, [inputs])
+useImperativeHandle(ref, createInstance, [inputs])
 ```
 
-`useImperativeMethods` customizes the instance value that is exposed to parent components when using `ref`. As always, imperative code using refs should be avoided in most cases. `useImperativeMethods` should be used with `forwardRef`:
+`useImperativeHandle` customizes the instance value that is exposed to parent components when using `ref`. As always, imperative code using refs should be avoided in most cases. `useImperativeHandle` should be used with `forwardRef`:
 
 ```js
 function FancyInput(props, ref) {
   const inputRef = useRef();
-  useImperativeMethods(ref, () => ({
+  useImperativeHandle(ref, () => ({
     focus: () => {
       inputRef.current.focus();
     }


### PR DESCRIPTION
A followup from https://github.com/facebook/react/pull/14565; don't merge this till we land that one. thanks!