### PR TITLE
Update footer copyright to be current year

### DIFF
--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -16,6 +16,8 @@ import {sectionListCommunity, sectionListDocs} from 'utils/sectionList';
 
 import ossLogoPng from 'images/oss_logo.png';
 
+const getCurrentYear = () => new Date().getFullYear();
+
 const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
   <footer
     css={{
@@ -179,7 +181,7 @@ const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
               color: colors.subtleOnDark,
               paddingTop: 15,
             }}>
-            Copyright © 2018 Facebook Inc.
+            {`Copyright © ${getCurrentYear()} Facebook Inc.`}
           </p>
         </section>
       </div>


### PR DESCRIPTION
The PR updates the footer to dynamically update the copyright year based on the current year rather than being hard coded.
 
![screenshot 2019-01-11 at 12 10 54](https://user-images.githubusercontent.com/3579905/51033082-1734e480-159a-11e9-9e0e-d37e67245351.png)