### PR TITLE
Extended JS environment requirements polyfills list with a promise

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -11,6 +11,7 @@ React 16 depends on the collection types [Map](https://developer.mozilla.org/en-
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
+import 'core-js/es6/promise';
 import 'core-js/es6/map';
 import 'core-js/es6/set';
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

IE11 needs a Promise polyfill for React 16.7. (not only Set and Map polyfills)
If you are using Lazy and Suspense feature, IE throws a null error. In 'readLazyComponentType' function implementation.


https://github.com/reactjs/reactjs.org/issues/1552
