### PR TITLE
Revert "Extended JS environment requirements polyfills list with a promise"

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -11,7 +11,6 @@ React 16 depends on the collection types [Map](https://developer.mozilla.org/en-
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
-import 'core-js/es6/promise';
 import 'core-js/es6/map';
 import 'core-js/es6/set';
 


### PR DESCRIPTION
Reverts reactjs/reactjs.org#1553

This creates a wrong impression that Promise is required for React to work, which is not the case. (It never makes sense to add a *new* runtime requirement without a major release.)

We can instead add a disclaimer about Lazy specifically — probably as a note on the page for `lazy` itself.