### PR TITLE
Fix wrong references in the examples of extracting components section

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -164,8 +164,8 @@ First, we will extract `Avatar`:
 function Avatar(props) {
   return (
     <img className="Avatar"
-      src={props.user.avatarUrl}
-      alt={props.user.name}
+      src={props.avatarUrl}
+      alt={props.name}
     />
   );
 }

--- a/examples/components-and-props/extracting-components-continued.js
+++ b/examples/components-and-props/extracting-components-continued.js
@@ -6,8 +6,8 @@ function Avatar(props) {
   return (
     <img
       className="Avatar"
-      src={props.user.avatarUrl}
-      alt={props.user.name}
+      src={props.avatarUrl}
+      alt={props.name}
     />
   );
 }


### PR DESCRIPTION
This PR fixes some wrong references in the examples of the "Extracting Components" section, when splitting a bigger component in smaller components the structure of props was different and did not match the original component.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
