### PR TITLE
Update focus managing section

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -232,14 +232,15 @@ this.inputElement.current.focus();
 When using a HOC to extend components, it is recommended to [forward the ref](/docs/forwarding-refs.html) to the wrapped component using the `forwardRef` function of React. If a third party HOC
 does not implement ref forwarding, the above pattern can still be used as a fallback.
 
-A great focus management example is the [react-aria-modal](https://github.com/davidtheclark/react-aria-modal). This is a relatively rare example of a fully accessible modal window. Not only does it set initial focus on
-the cancel button (preventing the keyboard user from accidentally activating the success action) and trap keyboard focus inside the modal, it also resets focus back to the element that
-initially triggered the modal.
-
 >Note:
 >
 >While this is a very important accessibility feature, it is also a technique that should be used judiciously. Use it to repair the keyboard focus flow when it is disturbed, not to try and anticipate how
->users want to use applications.
+>users want to use applications. 
+
+There are just a few situations, when you have to manage your focus - _autofocus_ or when you have to apply _restrictions_; Modal Dialog is a great example.
+You need to manage a focus, to prevent a user from leaving a Modal, or any other _focused_ task. Or else: a user will be "lost" in the partially disabled application; which could be suspended while modal is active.
+
+To resolve situations like this you have to use _Focus Traps_, to bound focus to a specific location, and not let user to _tab-out_. For example - [react-focus-lock](https://github.com/theKashey/react-focus-lock).  
 
 ## Mouse and pointer events
 


### PR DESCRIPTION
A few reasons to update this section:
- Focus and Scroll Locks are very dangerous tools. They could completely "lock" customer, and not let them properly use an application.
- The section does not explain why they could be necessary. 
- `react-aria-modal` was not a great example, as long as it does not work properly on iOS, will prevent operations with _portaled_ context(dropdowns), and does not explain how focus could be managed.

> PS: while `scroll lock`(no-scroll) was a part of `react-aria-modal`, I am not mentioning it here, as long as this is a wrong section for it.

Reasons to mention `react-focus-lock`(TLDR - it just works):
- does not prevent "clicking" on elements outside the lock and does not fight with other focus-lock solutions (_incidents free_)
- works with `portals`
- works with any possible `tabIndexes`, and locks scattered to multiple nodes