### PR TITLE
button outline fix

### DIFF
--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -30,6 +30,7 @@ class Section extends React.Component {
           aria-expanded={isActive}
           aria-controls={uid}
           css={{
+            outline: 'none',
             cursor: 'pointer',
             backgroundColor: 'transparent',
             border: 0,


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

On click of the button, outline comes in docs which doesn't look good.

Before:

<img width="294" alt="screenshot 2019-01-30 at 11 57 08 am" src="https://user-images.githubusercontent.com/10574227/51962496-4dbd9b00-2486-11e9-83fb-bf3ddcaf7842.png">

After : 

<img width="287" alt="screenshot 2019-01-30 at 11 58 52 am" src="https://user-images.githubusercontent.com/10574227/51962543-7776c200-2486-11e9-82f5-d1cabf79bcdd.png">
