### PR TITLE
Fixes cdn-link typo

### DIFF
--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -24,7 +24,7 @@ To load a specific version of `react` and `react-dom`, replace `16` with the ver
 
 ### Why the `crossorigin` Attribute?
 
-If you serve React from a CDN, we recommend to keep the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute set:
+If you request React from a CDN, we recommend to keep the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute set:
 
 ```html
 <script crossorigin src="..."></script>


### PR DESCRIPTION
The snippet refers to someone fetching from the CDN, not hosting it.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
