### PR TITLE
React Native will ship hooks in its 0.59 release.

### DIFF
--- a/content/blog/2019-02-06-react-v16.8.0.md
+++ b/content/blog/2019-02-06-react-v16.8.0.md
@@ -34,7 +34,7 @@ Yes! Starting with 16.8.0, React includes a stable implementation of React Hooks
 
 Note that **to enable Hooks, all React packages need to be 16.8.0 or higher**. Hooks won't work if you forget to update, for example, React DOM.
 
-**React Native will support Hooks in the [0.60 release](https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-457735214).**
+**React Native will support Hooks in the [0.59 release](https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-457735214).**
 
 ## Tooling Support
 

--- a/content/warnings/invalid-hook-call-warning.md
+++ b/content/warnings/invalid-hook-call-warning.md
@@ -18,7 +18,7 @@ Let's look at each of these cases.
 
 ## Mismatching Versions of React and React DOM
 
-You might be using a version of `react-dom` (< 16.8.0) or `react-native` (< 0.60) that doesn't yet support Hooks. You can run `npm ls react-dom` or `npm ls react-native` in your application folder to check which version you're using. If you find more than one of them, this might also create problems (more on that below).
+You might be using a version of `react-dom` (< 16.8.0) or `react-native` (< 0.59) that doesn't yet support Hooks. You can run `npm ls react-dom` or `npm ls react-native` in your application folder to check which version you're using. If you find more than one of them, this might also create problems (more on that below).
 
 ## Breaking the Rules of Hooks
 


### PR DESCRIPTION
I was made aware by @grabbou that the plan is for hooks to ship in React Native's 0.59 release.