### PR TITLE
Corrected grammar in hooks API reference

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -199,7 +199,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialCount}) {
+function Counter({initialState}) {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
Currently in the https://reactjs.org/docs/hooks-reference.html#usereducer section is taking wrong param in `Counter` function.

```diff
- function Counter({initialCount}) {
+ function Counter({initialState}) {
```