### PR TITLE
Fix navigation mobile mask

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -110,7 +110,7 @@ const Header = ({location}: {location: Location}) => (
             },
             [media.lessThan('small')]: {
               maskImage:
-                'linear-gradient(to right, transparent, black 20px, black 90%, transparent)',
+                'linear-gradient(to right, transparent, black 10px, black 90%, transparent)',
             },
           }}>
           <HeaderLink


### PR DESCRIPTION
Fix navigation mobile mask so that it does not overlay first item when no scrolling is done

Fix this:
![localhost_8000_ iphone 6_7_8](https://user-images.githubusercontent.com/13827786/52525285-dcfd5680-2caf-11e9-9336-df6038c12e97.png)

After the fix:
![localhost_8000_ iphone 6_7_8 -fix](https://user-images.githubusercontent.com/13827786/52525263-9b6cab80-2caf-11e9-9aad-48a1704920d1.png)
![localhost_8000_ iphone 6_7_8 -fix2](https://user-images.githubusercontent.com/13827786/52525264-9d366f00-2caf-11e9-8c6f-e5c3cecc217d.png)
