### PR TITLE
adding --save-dev to eslint-plugin-react-hooks bash command so it will ins…

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -28,7 +28,7 @@ By following this rule, you ensure that all stateful logic in a component is cle
 We released an ESLint plugin called [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) that enforces these two rules. You can add this plugin to your project if you'd like to try it:
 
 ```bash
-npm install eslint-plugin-react-hooks
+npm install eslint-plugin-react-hooks --save-dev
 ```
 
 ```js


### PR DESCRIPTION
…talled as devDependency

eslint plugins should be installed as devDependencies instead of dependencies.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
