### PR TITLE
Fix useCallback example snippet to match useMemo equivalence clause

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -273,12 +273,7 @@ If you return the same value from a Reducer Hook as the current state, React wil
 ### `useCallback` {#usecallback}
 
 ```js
-const memoizedCallback = useCallback(
-  () => {
-    doSomething(a, b);
-  },
-  [a, b],
-);
+const memoizedCallback = useCallback(doSomething, [a, b]);
 ```
 
 Returns a [memoized](https://en.wikipedia.org/wiki/Memoization) callback.


### PR DESCRIPTION
Based on the line: https://github.com/reactjs/reactjs.org/blob/486dac1c6786de0b4b670c4d4b14123283974f97/content/docs/hooks-reference.md#L288

I get the impression that the `useCallback` example code should be of the form `useCallback(fn, inputs)`.