### PR TITLE
Fix shallow renderer link on test utils page

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -139,7 +139,7 @@ Pass a mocked component module to this method to augment it with useful methods 
 
 > Note:
 >
-> `mockComponent()` is a legacy API. We recommend using [shallow rendering](/docs/test-utils.html#shallow-rendering) or [`jest.mock()`](https://facebook.github.io/jest/docs/en/tutorial-react-native.html#mock-native-modules-using-jestmock) instead.
+> `mockComponent()` is a legacy API. We recommend using [shallow rendering](/docs/shallow-renderer.html) or [`jest.mock()`](https://facebook.github.io/jest/docs/en/tutorial-react-native.html#mock-native-modules-using-jestmock) instead.
 
 * * *
 


### PR DESCRIPTION
Hello all,

In [the Test Utils doc](https://reactjs.org/docs/test-utils.html#mockcomponent), there is a broken link (a wrong anchor to be correct) in the "Note" block:

> We recommend using shallow rendering

which points to https://reactjs.org/docs/test-utils.html#shallow-rendering

This PR fixes the link to the correct page (https://reactjs.org/docs/shallow-renderer.html).

Thanks.