### PR TITLE
Fix broken link in community roundup 26 post

### DIFF
--- a/content/blog/2015-03-30-community-roundup-26.md
+++ b/content/blog/2015-03-30-community-roundup-26.md
@@ -27,9 +27,9 @@ Colin also [blogged about his experience using React Native](http://blog.scottlo
 
 ## The Changelog {#the-changelog}
 
-Spencer Ahrens and I had the great pleasure to talk about React Native on [The Changelog](https://thechangelog.com/149/) podcast. It was really fun to chat for an hour, I hope that you'll enjoy listening to it. :)
+Spencer Ahrens and I had the great pleasure to talk about React Native on [The Changelog](https://changelog.com/podcast/149) podcast. It was really fun to chat for an hour, I hope that you'll enjoy listening to it. :)
 
-<audio src="http://fdlyr.co/d/changelog/cdn.5by5.tv/audio/broadcasts/changelog/2015/changelog-149.mp3" controls="controls" style="width: 100%"></audio>
+<audio src="https://cdn.changelog.com/uploads/podcast/149/the-changelog-149.mp3" controls="controls" style="width: 100%"></audio>
 
 
 ## Hacker News {#hacker-news}


### PR DESCRIPTION
Hi, everyone 👋Glad to be here.

I'm working on reactjs.org Localization. 
When I set up Netlify auto preview, the HTTP link in this post will let the check failed.

<img width="813" alt="screen shot 2019-02-16 at 3 35 26 am" src="https://user-images.githubusercontent.com/5573816/52880155-2a8c2e80-319c-11e9-9a25-7ee646d341f9.png">

So I update the link and audio URL to the lastest version. Please take a look. 
Thank you! 👍