### PR TITLE
Fix command for initializing tsconfig

### DIFF
--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -220,13 +220,13 @@ The compiler is of no help to us until we tell it what to do. In TypeScript, the
 
 If you use [Yarn](https://yarnpkg.com/), run:
 
-```shell
+```bash
 yarn run tsc --init
 ```
 
 If you use [npm](https://www.npmjs.com/), run:
 
-```shell
+```bash
 npx tsc --init
 ```
 

--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -216,9 +216,17 @@ Congrats! You've installed the latest version of TypeScript into your project. I
 ```
 
 ### Configuring the TypeScript Compiler {#configuring-the-typescript-compiler}
-The compiler is of no help to us until we tell it what to do. In TypeScript, these rules are defined in a special file called `tsconfig.json`. To generate this file run:
+The compiler is of no help to us until we tell it what to do. In TypeScript, these rules are defined in a special file called `tsconfig.json`. To generate this file:
 
-```bash
+If you use [Yarn](https://yarnpkg.com/), run:
+
+```shell
+yarn run tsc --init
+```
+
+If you use [npm](https://www.npmjs.com/), run:
+
+```shell
 npx tsc --init
 ```
 

--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -219,7 +219,7 @@ Congrats! You've installed the latest version of TypeScript into your project. I
 The compiler is of no help to us until we tell it what to do. In TypeScript, these rules are defined in a special file called `tsconfig.json`. To generate this file run:
 
 ```bash
-tsc --init
+npx tsc --init
 ```
 
 Looking at the now generated `tsconfig.json`, you can see that there are many options you can use to configure the compiler. For a detailed description of all the options, check [here](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).


### PR DESCRIPTION
Project dependency doesn't add itself it global PATH. So call `tsc` will work either with globally installed typescript, or from npm/yarn script.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
