### PR TITLE
Define hooks in positive terms to avoid confusion about classes

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -6,7 +6,7 @@ next: hooks-reference.html
 prev: hooks-rules.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 Building your own Hooks lets you extract component logic into reusable functions.
 

--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -6,7 +6,7 @@ next: hooks-reference.html
 prev: hooks-rules.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 Building your own Hooks lets you extract component logic into reusable functions.
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -6,7 +6,7 @@ next: hooks-rules.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 The *Effect Hook* lets you perform side effects in function components:
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -6,7 +6,7 @@ next: hooks-rules.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 The *Effect Hook* lets you perform side effects in function components:
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-faq.html
 prev: hooks-reference.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 This page answers some of the frequently asked questions about [Hooks](/docs/hooks-overview.html).
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-faq.html
 prev: hooks-reference.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 This page answers some of the frequently asked questions about [Hooks](/docs/hooks-overview.html).
 

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-intro.html
 next: hooks-overview.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 ```js{4,5}
 import React, { useState } from 'react';

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -5,7 +5,7 @@ permalink: docs/hooks-intro.html
 next: hooks-overview.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 ```js{4,5}
 import React, { useState } from 'react';

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -6,7 +6,7 @@ next: hooks-state.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). This page provides an overview of Hooks for experienced React users. This is a fast-paced overview. If you get confused, look for a yellow box like this:
 

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -6,7 +6,7 @@ next: hooks-state.html
 prev: hooks-intro.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). This page provides an overview of Hooks for experienced React users. This is a fast-paced overview. If you get confused, look for a yellow box like this:
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -6,7 +6,7 @@ prev: hooks-custom.html
 next: hooks-faq.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 This page describes the APIs for the built-in Hooks in React.
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -6,7 +6,7 @@ prev: hooks-custom.html
 next: hooks-faq.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 This page describes the APIs for the built-in Hooks in React.
 

--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -6,7 +6,7 @@ next: hooks-custom.html
 prev: hooks-effect.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 Hooks are JavaScript functions, but you need to follow two rules when using them. We provide a [linter plugin](https://www.npmjs.com/package/eslint-plugin-react-hooks) to enforce these rules automatically:
 

--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -6,7 +6,7 @@ next: hooks-custom.html
 prev: hooks-effect.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 Hooks are JavaScript functions, but you need to follow two rules when using them. We provide a [linter plugin](https://www.npmjs.com/package/eslint-plugin-react-hooks) to enforce these rules automatically:
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -6,7 +6,7 @@ next: hooks-effect.html
 prev: hooks-overview.html
 ---
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic.
 
 The [previous page](/docs/hooks-intro.html) introduced Hooks with this example:
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -6,7 +6,7 @@ next: hooks-effect.html
 prev: hooks-overview.html
 ---
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic.
 
 The [previous page](/docs/hooks-intro.html) introduced Hooks with this example:
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -67,7 +67,7 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
 
 ### Hooks {#hooks}
 
-*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic. Hooks have a [dedicated docs section](/docs/hooks-intro.html) and a separate API reference:
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React component, allowing you to compose state and other React features into sharable logic. Hooks have a [dedicated docs section](/docs/hooks-intro.html) and a separate API reference:
 
 - [Basic Hooks](/docs/hooks-reference.html#basic-hooks)
   - [`useState`](/docs/hooks-reference.html#usestate)

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -67,7 +67,7 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
 
 ### Hooks {#hooks}
 
-*Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class. Hooks have a [dedicated docs section](/docs/hooks-intro.html) and a separate API reference:
+*Hooks* are a new addition in React 16.8. They are the fundamental building blocks of a React app, allowing you to compose state and other React features into sharable logic. Hooks have a [dedicated docs section](/docs/hooks-intro.html) and a separate API reference:
 
 - [Basic Hooks](/docs/hooks-reference.html#basic-hooks)
   - [`useState`](/docs/hooks-reference.html#usestate)


### PR DESCRIPTION
In response to confusion over whether classes are "bad" or "being deprecated" we should define hooks by what they are not by what they're not (classes).

This PR changes the verbiage of the intro text that appears in every hooks section.


Spawned from the following thread/conversation:
<a href="https://twitter.com/dan_abramov/status/1098147803480670209"><img alt="A tweet from dan: I think it’s unfortunate that people see Hooks as a statement against JavaScript classes. I’ll happily continue using classes for cases where I want an object factory with some methods. React components seem a bit different to me, that’s all." src="https://user-images.githubusercontent.com/1127238/53114394-8803e080-34f8-11e9-91ca-617be77a1c8f.png" width="380"></a>

See preview of changes [here](https://github.com/reactjs/reactjs.org/pull/1718#issuecomment-465701116) or see the netlify build.