### PR TITLE
correct useMemo pseudocode

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -285,7 +285,7 @@ Returns a [memoized](https://en.wikipedia.org/wiki/Memoization) callback.
 
 Pass an inline callback and an array of inputs. `useCallback` will return a memoized version of the callback that only changes if one of the inputs has changed. This is useful when passing callbacks to optimized child components that rely on reference equality to prevent unnecessary renders (e.g. `shouldComponentUpdate`).
 
-`useCallback(fn, inputs)` is equivalent to `useMemo(() => fn, inputs)`.
+`useCallback(fn, inputs)` is equivalent to `useMemo(() => fn(), inputs)`.
 
 > Note
 >


### PR DESCRIPTION
useMemo need to return something, just like

```js
const memoizedValue = useMemo(() => computeExpensiveValue(a, b), [a, b]);
```



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
