### PR TITLE
Rename App class component to Counter

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -53,7 +53,7 @@ To prepare a component for assertions, wrap the code rendering it and performing
 For example, let's say we have this `Counter` component:
 
 ```js
-class App extends React.Component {
+class Counter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {count: 0};


### PR DESCRIPTION
Sorry if this was intentional, it confused me at first since I thought `App` rendered a `Counter` component.