### PR TITLE
Put Blog in top bar before Community

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -124,14 +124,14 @@ const Header = ({location}: {location: Location}) => (
             to="/tutorial/tutorial.html"
           />
           <HeaderLink
-            isActive={location.pathname.includes('/community/')}
-            title="Community"
-            to="/community/support.html"
-          />
-          <HeaderLink
             isActive={location.pathname.includes('/blog')}
             title="Blog"
             to="/blog/"
+          />
+          <HeaderLink
+            isActive={location.pathname.includes('/community/')}
+            title="Community"
+            to="/community/support.html"
           />
         </nav>
 


### PR DESCRIPTION
This way it isn't completely obscured on iPhone 7 due to language picker. (Instead, "Community" doesn't quite fit but it's more obviously scrollable.)

It's also official so seems fitting to emphasize it.