### PR TITLE
Hide horizontal scrollbar in header and tweak breakpoitns

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -45,16 +45,17 @@ class DocSearch extends Component<{}, State> {
           paddingLeft: '0.25rem',
           paddingRight: '0.25rem',
 
-          [media.lessThan('mediumSearch')]: {
+          [media.lessThan('expandedSearch')]: {
             justifyContent: 'flex-end',
             marginRight: 10,
           },
-          [media.between('mediumSearch', 'largerSearch')]: {
-            width: 'calc(100% / 8)',
-          },
-          [media.greaterThan('largerSearch')]: {
+          // TODO: Something like this could show the full search box in more cases
+          // but it currently breaks its expanding animation.
+          // [media.between('mediumSearch', 'largerSearch')]: {
+          //   width: 'calc(100% / 8)',
+          // },
+          [media.greaterThan('expandedSearch')]: {
             minWidth: 100,
-            width: 'auto',
           },
         }}>
         <input
@@ -81,7 +82,7 @@ class DocSearch extends Component<{}, State> {
               borderRadius: '0.25rem',
             },
 
-            [media.lessThan('mediumSearch')]: {
+            [media.lessThan('expandedSearch')]: {
               fontSize: 16,
               width: '16px',
               transition: 'width 0.2s ease, padding 0.2s ease',

--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -45,15 +45,16 @@ class DocSearch extends Component<{}, State> {
           paddingLeft: '0.25rem',
           paddingRight: '0.25rem',
 
-          [media.lessThan('large')]: {
+          [media.lessThan('mediumSearch')]: {
             justifyContent: 'flex-end',
             marginRight: 10,
           },
-          [media.between('medium', 'xlarge')]: {
-            //width: 'calc(100% / 6)',
+          [media.between('mediumSearch', 'largerSearch')]: {
+            width: 'calc(100% / 8)',
           },
-          [media.greaterThan('large')]: {
+          [media.greaterThan('largerSearch')]: {
             minWidth: 100,
+            width: 'auto',
           },
         }}>
         <input
@@ -80,7 +81,7 @@ class DocSearch extends Component<{}, State> {
               borderRadius: '0.25rem',
             },
 
-            [media.lessThan('large')]: {
+            [media.lessThan('mediumSearch')]: {
               fontSize: 16,
               width: '16px',
               transition: 'width 0.2s ease, padding 0.2s ease',

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -101,6 +101,13 @@ const Header = ({location}: {location: Location}) => (
             WebkitOverflowScrolling: 'touch',
             height: '100%',
 
+            // Hide horizontal scrollbar
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
+            '::-webkit-scrollbar': {
+              display: 'none',
+            },
+
             [media.size('xsmall')]: {
               flexGrow: '1',
               width: 'auto',

--- a/src/theme.js
+++ b/src/theme.js
@@ -38,6 +38,10 @@ const SIZES = {
   // Sidebar/nav related tweakpoints
   largerSidebar: {min: 1100, max: 1339},
   sidebarFixed: {min: 2000, max: Infinity},
+
+  // Topbar related tweakpoints
+  mediumSearch: {min: 1040, max: 1179},
+  largerSearch: {min: 1180, max: Infinity},
 };
 
 type Size = $Keys<typeof SIZES>;

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,8 +40,7 @@ const SIZES = {
   sidebarFixed: {min: 2000, max: Infinity},
 
   // Topbar related tweakpoints
-  mediumSearch: {min: 1040, max: 1179},
-  largerSearch: {min: 1180, max: Infinity},
+  expandedSearch: {min: 1180, max: Infinity},
 };
 
 type Size = $Keys<typeof SIZES>;


### PR DESCRIPTION
Should fix this: https://mobile.twitter.com/_heavykj/status/1099628602193268736

I also tweaked the breakpoints to leave more space for Search. It was obscuring the menu due to the space lost to Languages with some widths. Should be fine now. 

This means full Search is visible only on larger screens now. I tried to make it more gradual (see commit history) but that messed with the expanding animation and I couldn't figure out how to fix it.