### PR TITLE
Avoid horizontal scrolling in header for mobile devices

### DIFF
--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -30,6 +30,11 @@ const Container = ({children}: {children: Node}) => (
       [media.size('xxlarge')]: {
         maxWidth: 1260,
       },
+
+      [media.lessThan('small')]: {
+        paddingLeft: 8,
+        paddingRight: 8,
+      },
     }}>
     {children}
   </div>

--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -45,14 +45,11 @@ class DocSearch extends Component<{}, State> {
           paddingLeft: '0.25rem',
           paddingRight: '0.25rem',
 
-          [media.lessThan('large')]: {
+          [media.lessThan('xlarge')]: {
             justifyContent: 'flex-end',
             marginRight: 10,
           },
-          [media.between('medium', 'xlarge')]: {
-            //width: 'calc(100% / 6)',
-          },
-          [media.greaterThan('large')]: {
+          [media.greaterThan('xlarge')]: {
             minWidth: 100,
           },
         }}>
@@ -80,7 +77,7 @@ class DocSearch extends Component<{}, State> {
               borderRadius: '0.25rem',
             },
 
-            [media.lessThan('large')]: {
+            [media.lessThan('xlarge')]: {
               fontSize: 16,
               width: '16px',
               transition: 'width 0.2s ease, padding 0.2s ease',

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -33,18 +33,12 @@ const Header = ({location}: {location: Location}) => (
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
-          height: 60,
-          [media.between('small', 'large')]: {
-            height: 50,
-          },
-          [media.lessThan('small')]: {
-            height: 40,
-          },
         }}>
         <Link
           css={{
             display: 'flex',
-            marginRight: 10,
+            flex: '0 0 auto',
+            marginRight: 8,
             height: '100%',
             alignItems: 'center',
             color: colors.brand,
@@ -52,13 +46,6 @@ const Header = ({location}: {location: Location}) => (
             ':focus': {
               outline: 0,
               color: colors.white,
-            },
-
-            [media.greaterThan('small')]: {
-              width: 'calc(100% / 6)',
-            },
-            [media.lessThan('small')]: {
-              flex: '0 0 auto',
             },
           }}
           to="/">
@@ -102,15 +89,12 @@ const Header = ({location}: {location: Location}) => (
             height: '100%',
 
             [media.size('xsmall')]: {
+              flexWrap: 'wrap',
               flexGrow: '1',
               width: 'auto',
             },
             [media.greaterThan('xlarge')]: {
               width: null,
-            },
-            [media.lessThan('small')]: {
-              maskImage:
-                'linear-gradient(to right, transparent, black 20px, black 90%, transparent)',
             },
           }}>
           <HeaderLink
@@ -143,17 +127,10 @@ const Header = ({location}: {location: Location}) => (
             alignItems: 'center',
             justifyContent: 'flex-end',
             width: 'auto',
-
-            //[media.lessThan('medium')]: {
-            //width: 'auto',
-            //},
-            //[media.greaterThan('large')]: {
-            //width: 'calc(100% / 4)',
-            //},
           }}>
           <Link
             css={{
-              padding: '5px 10px',
+              padding: '5px 8px',
               whiteSpace: 'nowrap',
               ...fonts.small,
 
@@ -178,7 +155,7 @@ const Header = ({location}: {location: Location}) => (
             css={{
               display: 'flex',
               alignItems: 'center',
-              padding: '5px 10px',
+              padding: '5px 8px',
               whiteSpace: 'nowrap',
               ...fonts.small,
 
@@ -207,8 +184,8 @@ const Header = ({location}: {location: Location}) => (
           </Link>
           <a
             css={{
-              padding: '5px 10px',
-              marginLeft: 10,
+              padding: '5px 8px',
+              marginLeft: 8,
               whiteSpace: 'nowrap',
               ...fonts.small,
 

--- a/src/components/LayoutHeader/HeaderLink.js
+++ b/src/components/LayoutHeader/HeaderLink.js
@@ -28,9 +28,15 @@ const style = {
   alignItems: 'center',
   color: colors.white,
   transition: 'color 0.2s ease-out',
-  paddingLeft: 15,
-  paddingRight: 15,
+  padding: '0 15px',
   fontWeight: 300,
+  minHeight: 60,
+  [media.between('small', 'large')]: {
+    minHeight: 50,
+  },
+  [media.lessThan('small')]: {
+    minHeight: 40,
+  },
 
   ':focus': {
     outline: 0,
@@ -39,18 +45,16 @@ const style = {
   },
 
   [media.size('xsmall')]: {
-    paddingLeft: 8,
-    paddingRight: 8,
+    padding: '0 8px',
+    fontSize: 14,
   },
 
   [media.between('small', 'medium')]: {
-    paddingLeft: 10,
-    paddingRight: 10,
+    padding: '0 10px',
   },
 
   [media.greaterThan('xlarge')]: {
-    paddingLeft: 20,
-    paddingRight: 20,
+    padding: '0 20px',
     fontSize: 18,
 
     ':hover:not(:focus)': {


### PR DESCRIPTION
Wouldn't it be nice if the header didn't require horizontal scrolling on smaller devices? Here's one possible take.

cc @joecritch 

# Screenshots at various sizes
<img width="1920" alt="screen shot 2019-02-24 at 6 13 28 pm" src="https://user-images.githubusercontent.com/29597/53310213-cedb3880-3860-11e9-97c2-86b7c8e23057.png">
<img width="1257" alt="screen shot 2019-02-24 at 6 13 40 pm" src="https://user-images.githubusercontent.com/29597/53310214-cedb3880-3860-11e9-898e-3bd5cc7074e3.png">
<img width="965" alt="screen shot 2019-02-24 at 6 14 00 pm" src="https://user-images.githubusercontent.com/29597/53310215-cedb3880-3860-11e9-8275-356cbabbc384.png">
<img width="766" alt="screen shot 2019-02-24 at 6 14 14 pm" src="https://user-images.githubusercontent.com/29597/53310216-cedb3880-3860-11e9-94a9-a220c29f37d8.png">
<img width="595" alt="screen shot 2019-02-24 at 6 14 24 pm" src="https://user-images.githubusercontent.com/29597/53310217-cedb3880-3860-11e9-8757-bfa1292eea03.png">
<img width="335" alt="screen shot 2019-02-24 at 6 14 30 pm" src="https://user-images.githubusercontent.com/29597/53310218-cf73cf00-3860-11e9-9bfe-2d1f8bae3967.png">

# Possible pro (or con)?
![header](https://user-images.githubusercontent.com/29597/53310234-ddc1eb00-3860-11e9-8a84-1b6736041c74.gif)
