### PR TITLE
fix docs word error

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -106,7 +106,7 @@ class BlogPost extends React.Component {
 - Inside the listener, call `setState` whenever the data source changes.
 - On unmount, remove the change listener.
 
-You can imagine that in a large app, this same pattern of subscribing to `DataSource` and calling `setState` will occur over and over again. We want an abstraction that allows us to define this logic in a single place and share it across many components. This is where higher-order components excel.
+You can imagine that in a large app, this same pattern of subscribing to `DataSource` and calling `setState` will occur over and over again. We want an abstraction that allows us to define this logic in a single place and share it across many components. This is where higher-order components exist.
 
 We can write a function that creates components, like `CommentList` and `BlogPost`, that subscribe to `DataSource`. The function will accept as one of its arguments a child component that receives the subscribed data as a prop. Let's call the function `withSubscription`:
 


### PR DESCRIPTION
In "This is where higher-order components excel" of the higher-order-components.html, "excel" should be "exist"



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
