### PR TITLE
Update ESLint Plugin installation command

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -28,7 +28,7 @@ By following this rule, you ensure that all stateful logic in a component is cle
 We released an ESLint plugin called [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) that enforces these two rules. You can add this plugin to your project if you'd like to try it:
 
 ```bash
-npm install eslint-plugin-react-hooks
+npm install eslint-plugin-react-hooks --save-dev
 ```
 
 ```js


### PR DESCRIPTION
This PR changes the installation command to match the instructions in the plugin page on npm (https://www.npmjs.com/package/eslint-plugin-react-hooks), which installs the plugin as a dev dependency (which is probably the expected use case for most people).
