### PR TITLE
Stop calling function components stateless

### DIFF
--- a/content/docs/legacy-context.md
+++ b/content/docs/legacy-context.md
@@ -152,11 +152,11 @@ If `contextTypes` is defined within a component, the following [lifecycle method
 >
 > As of React 16, `componentDidUpdate` no longer receives `prevContext`.
 
-### Referencing Context in Stateless Function Components {#referencing-context-in-stateless-function-components}
+### Referencing Context in Function Components {#referencing-context-in-stateless-function-components}
 
 > This section documents a legacy API. See the [new API](/docs/context.html).
 
-Stateless function components are also able to reference `context` if `contextTypes` is defined as a property of the function. The following code shows a `Button` component written as a stateless function component.
+Function components are also able to reference `context` if `contextTypes` is defined as a property of the function. The following code shows a `Button` component written as a function component.
 
 ```javascript
 import PropTypes from 'prop-types';


### PR DESCRIPTION
These docs still refer to function components as "stateless function components" despite the fact that function components aren't necessarily stateless (anymore). The docs shouldn't use this outdated terminology anymore. 

I left the "stateless" in the link to avoid breaking existing links to these docs but can remove if keeping links valid isn't a priority.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
