### PR TITLE
Change const to var in test renderer

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -10,7 +10,7 @@ category: Reference
 
 ```javascript
 import TestRenderer from 'react-test-renderer'; // ES6
-const TestRenderer = require('react-test-renderer'); // ES5 with npm
+var TestRenderer = require('react-test-renderer'); // ES5 with npm
 ```
 
 ## Overview {#overview}


### PR DESCRIPTION
Change `const` to `var` in Test Renderer like mentioned in guidelines for code examples. 

> **Use `const` where possible, otherwise `let`. Don't use `var`.**
>
> Ignore this if you're specifically writing about ES5.
 