### PR TITLE
Update languages page

### DIFF
--- a/content/languages.yml
+++ b/content/languages.yml
@@ -1,12 +1,11 @@
 # Status enums indicate what percentage of "core" content has been translated:
-# 0: Incomplete (0–49%)
-# 1: Partially complete (50–94%)
-# 2: Complete (95–100%)
+# 0: In progress (<100%)
+# 1: Complete (100%)
 
 - name: English
   translated_name: English
   code: en
-  status: 2
+  status: 1
 - name: Arabic
   translated_name: العربية
   code: ar
@@ -27,10 +26,14 @@
   translated_name: Deutsch
   code: de
   status: 0
+- name: Greek
+  translated_name: Ελληνικά
+  code: el
+  status: 0
 - name: Spanish
   translated_name: Español
   code: es
-  status: 2
+  status: 1
 - name: Persian
   translated_name: فارسی
   code: fa
@@ -38,6 +41,10 @@
 - name: French
   translated_name: Français
   code: fr
+  status: 0
+- name: Gujarati
+  translated_name: ગુજરાતી
+  code: gu
   status: 0
 - name: Hebrew
   translated_name: עברית
@@ -63,9 +70,21 @@
   translated_name: 日本語
   code: ja
   status: 1
+- name: Central Khmer
+  translated_name: ភាសាខ្មែរ
+  code: km
+  status: 0
 - name: Korean
   translated_name: 한국어
   code: ko
+  status: 0
+- name: Kurdish
+  translated_name: کوردی‎
+  code: ku
+  status: 0
+- name: Lithuanian
+  translated_name: Lietuvių kalba
+  code: lt
   status: 0
 - name: Malayalam
   translated_name: മലയാളം
@@ -86,7 +105,7 @@
 - name: Portuguese (Brazil)
   translated_name: Português do Brasil
   code: pt-br
-  status: 1
+  status: 0
 - name: Portuguese (Portugal)
   translated_name: Português europeu
   code: pt-pt
@@ -107,6 +126,10 @@
   translated_name: தமிழ்
   code: ta
   status: 0
+- name: Telugu
+  translated_name: తెలుగు
+  code: te
+  status: 0
 - name: Turkish
   translated_name: Türkçe
   code: tr
@@ -114,6 +137,10 @@
 - name: Ukrainian
   translated_name: Українська
   code: uk
+  status: 0
+- name: Urdu
+  translated_name: اردو
+  code: ur
   status: 0
 - name: Uzbek
   translated_name: Oʻzbekcha

--- a/content/languages.yml
+++ b/content/languages.yml
@@ -1,7 +1,7 @@
 # Status enums indicate what percentage of "core" content has been translated:
-# 0: In progress (<50%)
+# 0: Incomplete (0-49%)
 # 1: Partially complete (50-99%)
-# 1: Complete (100%)
+# 2: Complete (100%)
 
 - name: English
   translated_name: English

--- a/content/languages.yml
+++ b/content/languages.yml
@@ -1,11 +1,12 @@
 # Status enums indicate what percentage of "core" content has been translated:
-# 0: In progress (<100%)
+# 0: In progress (<50%)
+# 1: Partially complete (50-99%)
 # 1: Complete (100%)
 
 - name: English
   translated_name: English
   code: en
-  status: 1
+  status: 2
 - name: Arabic
   translated_name: العربية
   code: ar
@@ -33,7 +34,7 @@
 - name: Spanish
   translated_name: Español
   code: es
-  status: 1
+  status: 2
 - name: Persian
   translated_name: فارسی
   code: fa
@@ -41,7 +42,7 @@
 - name: French
   translated_name: Français
   code: fr
-  status: 0
+  status: 1
 - name: Gujarati
   translated_name: ગુજરાતી
   code: gu
@@ -69,7 +70,7 @@
 - name: Japanese
   translated_name: 日本語
   code: ja
-  status: 1
+  status: 2
 - name: Central Khmer
   translated_name: ភាសាខ្មែរ
   code: km
@@ -105,7 +106,7 @@
 - name: Portuguese (Brazil)
   translated_name: Português do Brasil
   code: pt-br
-  status: 0
+  status: 1
 - name: Portuguese (Portugal)
   translated_name: Português europeu
   code: pt-pt
@@ -117,7 +118,7 @@
 - name: Russian
   translated_name: Русский
   code: ru
-  status: 0
+  status: 1
 - name: Sinhala
   translated_name: සිංහල
   code: si
@@ -137,7 +138,7 @@
 - name: Ukrainian
   translated_name: Українська
   code: uk
-  status: 0
+  status: 1
 - name: Urdu
   translated_name: اردو
   code: ur
@@ -153,7 +154,7 @@
 - name: Simplified Chinese
   translated_name: 简体中文
   code: zh-hans
-  status: 0
+  status: 1
 - name: Traditional Chinese
   translated_name: 繁體中文
   code: zh-hant

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -16,25 +16,21 @@ import {media, sharedStyles} from 'theme';
 import languages from '../../content/languages.yml';
 
 // Status enums indicate what percentage of "core" content has been translated:
-// 0: Incomplete (0–49%)
-// 1: Partially complete (50–94%)
-// 2: Complete (95–100%)
-const {complete, incomplete, partial} = languages.reduce(
+// 0: In progress (<100%)
+// 1: Complete (100%)
+const {complete, inProgress} = languages.reduce(
   (reduced, language) => {
     switch (language.status) {
       case 0:
-        reduced.incomplete.push(language);
+        reduced.inProgress.push(language);
         break;
       case 1:
-        reduced.partial.push(language);
-        break;
-      case 2:
         reduced.complete.push(language);
         break;
     }
     return reduced;
   },
-  {complete: [], incomplete: [], partial: []},
+  {complete: [], inProgress: []},
 );
 
 type Props = {
@@ -57,10 +53,13 @@ const Languages = ({location}: Props) => (
             <LanguagesGrid languages={complete} />
 
             <h2>In Progress</h2>
-            <LanguagesGrid languages={partial} />
 
-            <h2>Needs Contributors</h2>
-            <LanguagesGrid languages={incomplete} />
+            <p>
+              Translations for the following languages are in progress and need
+              additional contributors:
+            </p>
+
+            <LanguagesGrid languages={inProgress} />
 
             <p>
               Don't see your language above?{' '}

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -16,21 +16,25 @@ import {media, sharedStyles} from 'theme';
 import languages from '../../content/languages.yml';
 
 // Status enums indicate what percentage of "core" content has been translated:
-// 0: In progress (<100%)
-// 1: Complete (100%)
-const {complete, inProgress} = languages.reduce(
+// 0: Incomplete (0–49%)
+// 1: Partially complete (50–94%)
+// 2: Complete (95–100%)
+const {complete, incomplete, partial} = languages.reduce(
   (reduced, language) => {
     switch (language.status) {
       case 0:
-        reduced.inProgress.push(language);
+        reduced.incomplete.push(language);
         break;
       case 1:
+        reduced.partial.push(language);
+        break;
+      case 2:
         reduced.complete.push(language);
         break;
     }
     return reduced;
   },
-  {complete: [], inProgress: []},
+  {complete: [], incomplete: [], partial: []},
 );
 
 type Props = {
@@ -53,13 +57,10 @@ const Languages = ({location}: Props) => (
             <LanguagesGrid languages={complete} />
 
             <h2>In Progress</h2>
+            <LanguagesGrid languages={partial} />
 
-            <p>
-              Translations for the following languages are in progress and need
-              additional contributors:
-            </p>
-
-            <LanguagesGrid languages={inProgress} />
+            <h2>Needs Contributors</h2>
+            <LanguagesGrid languages={incomplete} />
 
             <p>
               Don't see your language above?{' '}


### PR DESCRIPTION
* Japanese is at 100%! おめでとう御座います！
<img width="338" alt="screen shot 2019-03-01 at 4 29 45 pm" src="https://user-images.githubusercontent.com/1278991/53674316-f441bb00-3c41-11e9-9076-218d0bef5412.png">

* Switch to just two categories: "complete" (100%) and "in progress" (<100%)
* Added new languages

Preview:
<img width="1278" alt="screen shot 2019-03-01 at 4 46 18 pm" src="https://user-images.githubusercontent.com/1278991/53674347-23582c80-3c42-11e9-9867-32b7c5439714.png">

The markdown styling feels a bit weird to me. Anyone have any ideas?