### PR TITLE
Remove implicit boolean conversion from homepage example

### DIFF
--- a/content/home/examples/an-application.js
+++ b/content/home/examples/an-application.js
@@ -34,7 +34,7 @@ class TodoApp extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    if (!this.state.text.length) {
+    if (this.state.text.length === 0) {
       return;
     }
     const newItem = {


### PR DESCRIPTION
We shouldn't be encouraging this pattern which requires good understanding of JS quirks and can lead to bugs in other instances.