### PR TITLE
useMemo docs state that value will be computed when a new functions instance is passed which is not true

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -303,7 +303,7 @@ Pass a "create" function and an array of inputs. `useMemo` will only recompute t
 
 Remember that the function passed to `useMemo` runs during rendering. Don't do anything there that you wouldn't normally do while rendering. For example, side effects belong in `useEffect`, not `useMemo`.
 
-If no array is provided, a new value will be computed whenever a new function instance is passed as the first argument. (With an inline function, on every render.)
+If no array is provided, a new value will be computed on every render.
 
 **You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without `useMemo` — and then add it to optimize performance.
 


### PR DESCRIPTION
The docs say that 

> a new value will be computed whenever a **new function instance** is passed as the first argument

The following code shows otherwise. The function instance is always the same, however a new value for `n` is computed on every render because no array is passed.

```javascript
import React, { useMemo, useState } from "react";
import ReactDOM from "react-dom";

class RandomNumberContainer {
  number = Math.random();
}

function createRandomNumberContainer() {
  return new RandomNumberContainer();
}

function App() {
  const [i, setI] = useState(0);
  const n = useMemo(createRandomNumberContainer);
  const n2 = useMemo(createRandomNumberContainer, []);

  return (
    <div className="App">
      <p>i: {i}</p>
      <p>number: {n.number}</p>
      <p>number2: {n2.number}</p>
      <button onClick={() => setI(i + 1)} />
    </div>
  );
}

const rootElement = document.getElementById("root");
ReactDOM.render(<App />, rootElement);
```

Here's an example sandbox: https://codesandbox.io/s/4x68k8nrw
