### PR TITLE
Update Single Responsibility Principle Definition in thinking-in-react.md

### DIFF
--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -35,7 +35,7 @@ Our JSON API returns some data that looks like this:
 
 The first thing you'll want to do is to draw boxes around every component (and subcomponent) in the mock and give them all names. If you're working with a designer, they may have already done this, so go talk to them! Their Photoshop layer names may end up being the names of your React components!
 
-But how do you know what should be its own component? Just use the same techniques for deciding if you should create a new function or object. One such technique is the [single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle), that is, a component should ideally only do one thing. If it ends up growing, it should be decomposed into smaller subcomponents.
+But how do you know what should be its own component? Just use the same techniques for deciding if you should create a new function or object. One such technique is the [single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle), that is, a component should ideally have only one reason to change. If it ends up having more than one reason to change, it should be decomposed into smaller subcomponents.
 
 Since you're often displaying a JSON data model to a user, you'll find that if your model was built correctly, your UI (and therefore your component structure) will map nicely. That's because UI and data models tend to adhere to the same *information architecture*, which means the work of separating your UI into components is often trivial. Just break it up into components that represent exactly one piece of your data model.
 


### PR DESCRIPTION
_Single Responsibility Principle_ definition is misleading here. It does _not_ mean that every single container (_modules, classes, functions_ in the terms of _OOP_; _Components_ in the terms of _React_) should be modularized to have a single functionality. It means every container should have only one reason to change and should be modularized according to that.

_Single Responsibility Principle_ is defined as "a class should have one reason to change" [by its founder](butunclebob.com/ArticleS.UncleBob.PrinciplesOfOod). And there is a reason for using the word "change" instead of "exist". He published another [article](https://blog.cleancoder.com/uncle-bob/2014/05/08/SingleReponsibilityPrinciple.html) in 2014 in order to explain it in depth.

> We want to increase the cohesion between things that change for the same reasons, and we want to decrease the coupling between those things that change for different reasons.

If it is thought in the terms of modularizing for each functionality, ending up with single method classes is very likely in _OOP_ world.

Either React should have its own _Modularize Everything For Each Functionality_ principle and should not mention _Single Responsibility Principle_, or should correct the definition in the terms of reason to change which is the correct definition of _Single Responsibility Principle_.