### PR TITLE
Fix previous article on hooks-effect.md

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -3,7 +3,7 @@ id: hooks-state
 title: Using the Effect Hook
 permalink: docs/hooks-effect.html
 next: hooks-rules.html
-prev: hooks-intro.html
+prev: hooks-state.html
 ---
 
 *Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.


### PR DESCRIPTION
Hi! :wave: 

This PR only fixes the `Previous article` link on [this page](https://reactjs.org/docs/hooks-effect.html).

Once this get merged, do I need to open a similar PR in each one of the translation repos?