### PR TITLE
remove a reference to fbjs from codebase overview

### DIFF
--- a/content/docs/codebase-overview.md
+++ b/content/docs/codebase-overview.md
@@ -19,8 +19,6 @@ We don't necessarily recommend any of these conventions in React apps. Many of t
 
 React has almost no external dependencies. Usually, a `require()` points to a file in React's own codebase. However, there are a few relatively rare exceptions.
 
-The [fbjs repository](https://github.com/facebook/fbjs) exists because React shares some small utilities with libraries like [Relay](https://github.com/facebook/relay), and we keep them in sync. We don't depend on equivalent small modules in the Node ecosystem because we want Facebook engineers to be able to make changes to them whenever necessary. None of the utilities inside fbjs are considered to be public API, and they are only intended for use by Facebook projects such as React.
-
 ### Top-Level Folders {#top-level-folders}
 
 After cloning the [React repository](https://github.com/facebook/react), you will see a few top-level folders in it:

--- a/content/docs/codebase-overview.md
+++ b/content/docs/codebase-overview.md
@@ -15,10 +15,6 @@ If you want to [contribute to React](/docs/how-to-contribute.html) we hope that 
 
 We don't necessarily recommend any of these conventions in React apps. Many of them exist for historical reasons and might change with time.
 
-### External Dependencies {#external-dependencies}
-
-React has almost no external dependencies. Usually, a `require()` points to a file in React's own codebase. However, there are a few relatively rare exceptions.
-
 ### Top-Level Folders {#top-level-folders}
 
 After cloning the [React repository](https://github.com/facebook/react), you will see a few top-level folders in it:


### PR DESCRIPTION
We can remove this sentence because React no longer has `fbjs` as its dependencies.


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
