### PR TITLE
Fixing incorrect value for eslint rule

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -41,7 +41,7 @@ npm install eslint-plugin-react-hooks
   "rules": {
     // ...
     "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
-    "react-hooks/exhaustive-deps": "warning" // Checks effect dependencies
+    "react-hooks/exhaustive-deps": "warn" // Checks effect dependencies
   }
 }
 ```


### PR DESCRIPTION
The name for the "warning" level in ESLint is `warn` not `warning` (https://eslint.org/docs/user-guide/configuring#configuring-rules)
