### PR TITLE
Use hooks on front page

### DIFF
--- a/content/home/examples/a-component-using-external-plugins.js
+++ b/content/home/examples/a-component-using-external-plugins.js
@@ -1,39 +1,33 @@
-class MarkdownEditor extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-    this.state = { value: 'Hello, **world**!' };
+function MarkdownEditor() {
+  const [value, setValue] = React.useState('Hello, **world**');
+
+  function handleChange(event) {
+    setValue(event.target.value);
   }
 
-  handleChange(e) {
-    this.setState({ value: e.target.value });
-  }
-
-  getRawMarkup() {
+  function getRawMarkup() {
     const md = new Remarkable();
-    return { __html: md.render(this.state.value) };
+    return { __html: md.render(value) };
   }
 
-  render() {
-    return (
-      <div className="MarkdownEditor">
-        <h3>Input</h3>
-        <label htmlFor="markdown-content">
-          Enter some markdown
-        </label>
-        <textarea
-          id="markdown-content"
-          onChange={this.handleChange}
-          defaultValue={this.state.value}
-        />
-        <h3>Output</h3>
-        <div
-          className="content"
-          dangerouslySetInnerHTML={this.getRawMarkup()}
-        />
-      </div>
-    );
-  }
+  return (
+    <div className="MarkdownEditor">
+      <h3>Input</h3>
+      <label htmlFor="markdown-content">
+        Enter some markdown
+      </label>
+      <textarea
+        id="markdown-content"
+        onChange={handleChange}
+        defaultValue={value}
+      />
+      <h3>Output</h3>
+      <div
+        className="content"
+        dangerouslySetInnerHTML={getRawMarkup()}
+      />
+    </div>
+  );
 }
 
 ReactDOM.render(

--- a/content/home/examples/a-simple-component.js
+++ b/content/home/examples/a-simple-component.js
@@ -1,11 +1,9 @@
-class HelloMessage extends React.Component {
-  render() {
-    return (
-      <div>
-        Hello {this.props.name}
-      </div>
-    );
-  }
+function HelloMessage(props) {
+  return (
+    <div>
+      Hello {props.name}
+    </div>
+  );
 }
 
 ReactDOM.render(

--- a/content/home/examples/a-simple-component.md
+++ b/content/home/examples/a-simple-component.md
@@ -4,6 +4,6 @@ order: 0
 domid: hello-example
 ---
 
-React components implement a `render()` method that takes input data and returns what to display. This example uses an XML-like syntax called JSX. Input data that is passed into the component can be accessed by `render()` via `this.props`.
+React components are functions that take input data and return what to display. This example uses an XML-like syntax called JSX. Input data that is passed into the component can be accessed `props`.
 
 **JSX is optional and not required to use React.** Try the [Babel REPL](babel://es5-syntax-example) to see the raw JavaScript code produced by the JSX compilation step.

--- a/content/home/examples/a-stateful-component.js
+++ b/content/home/examples/a-stateful-component.js
@@ -1,20 +1,15 @@
-function Timer(props) {
+function Timer() {
   const [seconds, setSeconds] = React.useState(0);
+
   React.useEffect(() => {
     const id = setInterval(
       () => setSeconds(currentSeconds => currentSeconds + 1),
-      1000
+      1000,
     );
     return () => clearInterval(id);
   }, []);
-  return (
-    <div>
-      Seconds: {seconds}
-    </div>
-  )
+
+  return <div>Seconds: {seconds}</div>;
 }
 
-ReactDOM.render(
-  <Timer />,
-  document.getElementById('timer-example')
-);
+ReactDOM.render(<Timer />, document.getElementById('timer-example'));

--- a/content/home/examples/a-stateful-component.js
+++ b/content/home/examples/a-stateful-component.js
@@ -1,30 +1,17 @@
-class Timer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { seconds: 0 };
-  }
-
-  tick() {
-    this.setState(state => ({
-      seconds: state.seconds + 1
-    }));
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => this.tick(), 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    return (
-      <div>
-        Seconds: {this.state.seconds}
-      </div>
+function Timer(props) {
+  const [seconds, setSeconds] = React.useState(0);
+  React.useEffect(() => {
+    const id = setInterval(
+      () => setSeconds(currentSeconds => currentSeconds + 1),
+      1000
     );
-  }
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div>
+      Seconds: {seconds}
+    </div>
+  )
 }
 
 ReactDOM.render(

--- a/content/home/examples/a-stateful-component.md
+++ b/content/home/examples/a-stateful-component.md
@@ -4,4 +4,4 @@ order: 1
 domid: timer-example
 ---
 
-In addition to taking input data (accessed via `this.props`), a component can maintain internal state data (accessed via `this.state`). When a component's state data changes, the rendered markup will be updated by re-invoking `render()`.
+In addition to taking input data (accessed via `props`), a component can maintain internal state data by using a "hook". When a component's state data changes, the rendered markup will be updated by re-invoking the function.

--- a/content/home/examples/an-application.js
+++ b/content/home/examples/an-application.js
@@ -1,63 +1,52 @@
-class TodoApp extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { items: [], text: '' };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
+function TodoApp() {
+  const [items, setItems] = React.useState([]);
+  const [text, setText] = React.useState(text);
 
-  render() {
-    return (
-      <div>
-        <h3>TODO</h3>
-        <TodoList items={this.state.items} />
-        <form onSubmit={this.handleSubmit}>
-          <label htmlFor="new-todo">
-            What needs to be done?
-          </label>
-          <input
-            id="new-todo"
-            onChange={this.handleChange}
-            value={this.state.text}
-          />
-          <button>
-            Add #{this.state.items.length + 1}
-          </button>
-        </form>
-      </div>
-    );
+  function handleChange(event) {
+    setText(event.target.value);
   }
-
-  handleChange(e) {
-    this.setState({ text: e.target.value });
-  }
-
-  handleSubmit(e) {
-    e.preventDefault();
-    if (!this.state.text.length) {
+  function handleSubmit(event) {
+    event.preventDefault();
+    if (!text.length) {
       return;
     }
     const newItem = {
-      text: this.state.text,
+      text: text,
       id: Date.now()
     };
-    this.setState(state => ({
-      items: state.items.concat(newItem),
-      text: ''
-    }));
+
+    setItems(currentItems => currentItems.concat(newItem));
   }
+
+  return (
+    <div>
+      <h3>TODO</h3>
+      <TodoList items={items} />
+      <form onSubmit={handleSubmit}>
+        <label htmlFor="new-todo">
+          What needs to be done?
+        </label>
+        <input
+          id="new-todo"
+          onChange={handleChange}
+          value={text}
+        />
+        <button>
+          Add #{items.length + 1}
+        </button>
+      </form>
+    </div>
+  );
 }
 
-class TodoList extends React.Component {
-  render() {
-    return (
-      <ul>
-        {this.props.items.map(item => (
-          <li key={item.id}>{item.text}</li>
-        ))}
-      </ul>
-    );
-  }
+function TodoList(props) {
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>{item.text}</li>
+      ))}
+    </ul>
+  );
 }
 
 ReactDOM.render(

--- a/content/home/examples/an-application.js
+++ b/content/home/examples/an-application.js
@@ -1,6 +1,6 @@
 function TodoApp() {
   const [items, setItems] = React.useState([]);
-  const [text, setText] = React.useState(text);
+  const [text, setText] = React.useState('');
 
   function handleChange(event) {
     setText(event.target.value);
@@ -12,10 +12,11 @@ function TodoApp() {
     }
     const newItem = {
       text: text,
-      id: Date.now()
+      id: Date.now(),
     };
 
     setItems(currentItems => currentItems.concat(newItem));
+    setText('');
   }
 
   return (
@@ -23,17 +24,9 @@ function TodoApp() {
       <h3>TODO</h3>
       <TodoList items={items} />
       <form onSubmit={handleSubmit}>
-        <label htmlFor="new-todo">
-          What needs to be done?
-        </label>
-        <input
-          id="new-todo"
-          onChange={handleChange}
-          value={text}
-        />
-        <button>
-          Add #{items.length + 1}
-        </button>
+        <label htmlFor="new-todo">What needs to be done?</label>
+        <input id="new-todo" onChange={handleChange} value={text} />
+        <button>Add #{items.length + 1}</button>
       </form>
     </div>
   );
@@ -49,7 +42,4 @@ function TodoList(props) {
   );
 }
 
-ReactDOM.render(
-  <TodoApp />,
-  document.getElementById('todos-example')
-);
+ReactDOM.render(<TodoApp />, document.getElementById('todos-example'));


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This pull request refactors the examples on the home page to be function components using hooks, instead of class components.

Hooks are inherently easier to understand than the concept of classes and lifecycles at first glance - so I think it makes sense to show people the easiest-to-grasp version first.

I'm sure this could've been discussed in an issue first, sorry for just barging in with a PR like this. It didn't take a lot of time though!

I think we might want to re-consider the second example, however, since it introduces the concept of useEffect - a slightly harder to grok piece of functionality. Perhaps a simple counter example would suffice?