### PR TITLE
Fix overflowing headers on small screens

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -89,6 +89,11 @@ const fonts = {
     lineHeight: '65px',
     fontWeight: 700,
 
+    [media.lessThan('small')]: {
+      overflowWrap: 'break-word',
+      wordBreak: 'break-word',
+    },
+
     [media.lessThan('medium')]: {
       fontSize: 40,
       lineHeight: '45px',


### PR DESCRIPTION
Long words in headers will overflow and break the layout on mobile screens (e.g. [https://reactjs.org/acknowledgements.html](https://reactjs.org/acknowledgements.html)). This fix allows them to break on small screens. 

Before:
<img width="160" alt="reactjs org_(iPhone 5_SE)" src="https://user-images.githubusercontent.com/10158587/54423823-d9774800-4711-11e9-826e-c9ccd010a18e.png">

After:
<img width="160" alt="0 0 0 0_8001_(iPhone 5_SE)" src="https://user-images.githubusercontent.com/10158587/54423830-de3bfc00-4711-11e9-80ac-11d5eff29f54.png">

Tested on mobile Safari, Chrome & Firefox
