### PR TITLE
forwarding-refs: concrete example for function name

### DIFF
--- a/content/docs/forwarding-refs.md
+++ b/content/docs/forwarding-refs.md
@@ -67,7 +67,7 @@ For example, the following component will appear as "*ForwardRef*" in the DevToo
 
 `embed:forwarding-refs/wrapped-component.js`
 
-If you name the render function, DevTools will also include its name (e.g. "*ForwardRef(myFunction)*"):
+If you name the render function, DevTools will also include its name (e.g. "*ForwardRef(Button)*"):
 
 `embed:forwarding-refs/wrapped-component-with-function-name.js`
 

--- a/examples/forwarding-refs/wrapped-component-with-function-name.js
+++ b/examples/forwarding-refs/wrapped-component-with-function-name.js
@@ -1,5 +1,9 @@
-const WrappedComponent = React.forwardRef(
-  function myFunction(props, ref) {
-    return <LogProps {...props} forwardedRef={ref} />;
+const FancyButton = React.forwardRef(
+  function Button(props, ref) {
+    return (
+      <button ref={ref} className="FancyButton">
+        {props.children}
+      </button>
+    );
   }
 );

--- a/examples/forwarding-refs/wrapped-component.js
+++ b/examples/forwarding-refs/wrapped-component.js
@@ -1,3 +1,7 @@
-const WrappedComponent = React.forwardRef((props, ref) => {
-  return <LogProps {...props} forwardedRef={ref} />;
+const FancyButton = React.forwardRef((props, ref) => {
+  return (
+    <button ref={ref} className="FancyButton">
+      {props.children}
+    </button>
+  );
 });


### PR DESCRIPTION
Followup on facebook/react#15100

The named render function example in the forwarding refs guide was using a very generic name. Hope this clarifies the use case.
