### PR TITLE
useMemo wording regarding usage in useEffect dependency list

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -322,7 +322,7 @@ Remember that the function passed to `useMemo` runs during rendering. Don't do a
 
 If no array is provided, a new value will be computed on every render.
 
-**You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without `useMemo` — and then add it to optimize performance.
+**You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components.
 
 > Note
 >

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -322,7 +322,7 @@ Remember that the function passed to `useMemo` runs during rendering. Don't do a
 
 If no array is provided, a new value will be computed on every render.
 
-**You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components.
+**You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. This means that a value from `useMemo` in a `useEffect` dependency list may trigger the effect without any "real" changes. However, if an additional run of that effect does not break your component, you should feel free to use it in that regard.
 
 > Note
 >


### PR DESCRIPTION
While answering a stackoverflow question (https://stackoverflow.com/questions/55196774/skipping-effects-does-not-work-for-array-of-dynamic-urls) I suggested that the asker should use `useMemo` to avoid a re-trigger of `useEffect`. I noticed that Dan Abramov suggests such a use case: https://github.com/facebook/react/issues/14476#issuecomment-471199055. 

The wording "Write your code so that it still works without `useMemo` — and then add it to optimize performance." suggests that you may not use it to any logic whatsoever, which is not true. I think this is a reasonable wording which should get the point across, which in turn would have decreased my doubts while reading. 