### PR TITLE
Adding Immer as a library for immutable table

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -430,6 +430,6 @@ x === z; // true
 
 In this case, since a new reference is returned when mutating `x`, we can use a reference equality check `(x === y)` to verify that the new value stored in `y` is different than the original value stored in `x`.
 
-Two other libraries that can help use immutable data are [seamless-immutable](https://github.com/rtfeldman/seamless-immutable) and [immutability-helper](https://github.com/kolodny/immutability-helper).
+Three other libraries that can help use immutable data are [seamless-immutable](https://github.com/rtfeldman/seamless-immutable), [immutability-helper](https://github.com/kolodny/immutability-helper) and [immer](https://github.com/mweststrate/immer)
 
 Immutable data structures provide you with a cheap way to track changes on objects, which is all we need to implement `shouldComponentUpdate`. This can often provide you with a nice performance boost.


### PR DESCRIPTION
Since immer is a library which can be used with both vanilla react state and redux state as well it's a really great choice for making the state immutable



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
