### PR TITLE
links Get started and Take the Tutorial have been relocated in mobile…

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -62,7 +62,7 @@ class Home extends Component {
             <div
               css={{
                 paddingTop: 45,
-                paddingBottom: 20,
+                paddingBottom: 10,
 
                 [media.greaterThan('small')]: {
                   paddingTop: 60,
@@ -137,8 +137,11 @@ class Home extends Component {
                   </p>
                   <Flex
                     valign="center"
+                    halign="center"
                     css={{
                       paddingTop: 40,
+                      flexWrap: 'wrap',
+                      justifyContent: 'center',
 
                       [media.greaterThan('xlarge')]: {
                         paddingTop: 65,
@@ -279,10 +282,16 @@ class Home extends Component {
               background: colors.dark,
               color: colors.white,
               paddingTop: 45,
-              paddingBottom: 45,
+              paddingBottom: 25,
             }}>
             <Container>
-              <Flex valign="center">
+              <Flex
+                valign="center"
+                halign="center"
+                css={{
+                  flexWrap: 'wrap',
+                  justifyContent: 'center',
+                }}>
                 <CtaItem>
                   <ButtonLink to="/docs/getting-started.html" type="primary">
                     Get Started
@@ -312,8 +321,6 @@ Home.propTypes = {
 const CtaItem = ({children, primary = false}) => (
   <div
     css={{
-      width: '50%',
-
       [media.between('small', 'large')]: {
         paddingLeft: 20,
       },
@@ -324,12 +331,21 @@ const CtaItem = ({children, primary = false}) => (
 
       '&:first-child': {
         textAlign: 'right',
-        paddingRight: 15,
+        paddingRight: 7,
+        paddingLeft: 7,
+        [media.lessThan('small')]: {
+          marginBottom: 10,
+        },
       },
 
       '&:nth-child(2)': {
+        paddingRight: 7,
+        paddingLeft: 7,
         [media.greaterThan('small')]: {
           paddingLeft: 15,
+        },
+        [media.lessThan('small')]: {
+          marginBottom: 10,
         },
       },
     }}>


### PR DESCRIPTION
According to the [issue](https://github.com/reactjs/ru.reactjs.org/issues/253) (RUS), the design has been changed  on mobile version as on this version long text (for example in oher languages) is not fully depicted. If there is a need to change styles I'll correct it.
AFTER
![afterFixEng](https://user-images.githubusercontent.com/12746043/54866218-dadfea80-4d79-11e9-9aec-497e79bb342d.png)
![afterFixRUS](https://user-images.githubusercontent.com/12746043/54866219-dadfea80-4d79-11e9-8436-95e4a7991558.png)
BEFORE
![beforeFixRUS](https://user-images.githubusercontent.com/12746043/54866226-e9c69d00-4d79-11e9-8de8-68b199f24dcd.png)
![beforeFixENG](https://user-images.githubusercontent.com/12746043/54866228-ef23e780-4d79-11e9-95f7-75d2528f22ef.png)


