### PR TITLE
Restyle nav bar positioning to support translations

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -54,9 +54,6 @@ const Header = ({location}: {location: Location}) => (
               color: colors.white,
             },
 
-            [media.greaterThan('small')]: {
-              width: 'calc(100% / 6)',
-            },
             [media.lessThan('small')]: {
               flex: '0 0 auto',
             },
@@ -94,7 +91,6 @@ const Header = ({location}: {location: Location}) => (
           css={{
             flex: '1',
             display: 'flex',
-            flexDirection: 'row',
             alignItems: 'stretch',
             overflowX: 'auto',
             overflowY: 'hidden',
@@ -120,26 +116,34 @@ const Header = ({location}: {location: Location}) => (
                 'linear-gradient(to right, transparent, black 20px, black 90%, transparent)',
             },
           }}>
-          <HeaderLink
-            isActive={location.pathname.includes('/docs/')}
-            title="Docs"
-            to="/docs/getting-started.html"
-          />
-          <HeaderLink
-            isActive={location.pathname.includes('/tutorial/')}
-            title="Tutorial"
-            to="/tutorial/tutorial.html"
-          />
-          <HeaderLink
-            isActive={location.pathname.includes('/blog')}
-            title="Blog"
-            to="/blog/"
-          />
-          <HeaderLink
-            isActive={location.pathname.includes('/community/')}
-            title="Community"
-            to="/community/support.html"
-          />
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'row',
+              marginLeft: 'auto',
+              marginRight: 'auto',
+          }}>
+            <HeaderLink
+              isActive={location.pathname.includes('/docs/')}
+              title="Docs"
+              to="/docs/getting-started.html"
+            />
+            <HeaderLink
+              isActive={location.pathname.includes('/tutorial/')}
+              title="Tutorial"
+              to="/tutorial/tutorial.html"
+            />
+            <HeaderLink
+              isActive={location.pathname.includes('/blog')}
+              title="Blog"
+              to="/blog/"
+            />
+            <HeaderLink
+              isActive={location.pathname.includes('/community/')}
+              title="Community"
+              to="/community/support.html"
+            />
+          </div>
         </nav>
 
         <DocSearch />

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -122,7 +122,7 @@ const Header = ({location}: {location: Location}) => (
               flexDirection: 'row',
               marginLeft: 'auto',
               marginRight: 'auto',
-          }}>
+            }}>
             <HeaderLink
               isActive={location.pathname.includes('/docs/')}
               title="Docs"


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
### **About:**
This PR fixes #1817. 

Currently for Ukrainian translation, a hard-coded logo width is used to prevent nav bar cut offs w/ the search bar. 
The change in this PR centers the nav bar between the logo and search bar.

### **Visuals:**
**Before Changes:**
[uk.reactjs.org](https://uk.reactjs.org/):
<img width="1422" alt="Screen Shot 2019-03-24 at 10 03 58 PM" src="https://user-images.githubusercontent.com/15851351/54899069-dc013c80-4e8b-11e9-96e9-4865da4009a1.png">

**After Changes:**
<img width="1425" alt="Screen Shot 2019-03-24 at 11 03 40 PM" src="https://user-images.githubusercontent.com/15851351/54899080-e7546800-4e8b-11e9-9017-dfa01935177a.png">

(Decided to go for centering of nav bar so the style would fit with the default English translation)
[reactjs.org](https://reactjs.org/):
<img width="1425" alt="Screen Shot 2019-03-24 at 10 04 37 PM" src="https://user-images.githubusercontent.com/15851351/54899105-ffc48280-4e8b-11e9-8cc4-3cc33190a01e.png">

### **Other:**
Flexbox auto margins were used over `justify-content: center` so [scrolling of nav bar wouldn't be cut off in mobile display](https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container).