### PR TITLE
Amend React.Children.map/forEach fns signatures

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -223,7 +223,7 @@ Verifies the object is a React element. Returns `true` or `false`.
 #### `React.Children.map` {#reactchildrenmap}
 
 ```javascript
-React.Children.map(children, function[(thisArg)])
+React.Children.map(children, callback(child[, index])[, thisArg])
 ```
 
 Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is an array it will be traversed and the function will be called for each child in the array. If children is `null` or `undefined`, this method will return `null` or `undefined` rather than an array.
@@ -235,7 +235,7 @@ Invokes a function on every immediate child contained within `children` with `th
 #### `React.Children.forEach` {#reactchildrenforeach}
 
 ```javascript
-React.Children.forEach(children, function[(thisArg)])
+React.Children.forEach(children, callback(child[, index])[, thisArg])
 ```
 
 Like [`React.Children.map()`](#reactchildrenmap) but does not return an array.


### PR DESCRIPTION
Changed function signatures of `React.Children.map` and `React.Children.forEach` so that they express explicitly how to pass `thisArg`.