### PR TITLE
Fix explanation of the `useState` example in 'Hooks API Reference' page

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -67,7 +67,7 @@ function Counter({initialCount}) {
 }
 ```
 
-The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to 0.
+The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to initial value.
 
 > Note
 >

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -67,7 +67,7 @@ function Counter({initialCount}) {
 }
 ```
 
-The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to initial value.
+The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to the initial value.
 
 > Note
 >


### PR DESCRIPTION
Hello 👋 

I'm working on Polish translations of the docs and I have found an error in original docs. 

In the counter example when there is an event handler that sets state value back to the value from `props`, while the explanation suggests it's always 0.