### PR TITLE
Clarify return value of ReactDOM.render

### DIFF
--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -36,7 +36,10 @@ React supports all popular browsers, including Internet Explorer 9 and above, al
 ReactDOM.render(element, container[, callback])
 ```
 
-Render a React element into the DOM in the supplied `container` and return a [reference](/docs/more-about-refs.html) to the component (or returns `null` for [stateless components](/docs/components-and-props.html#functional-and-class-components)).
+Render a React element into the DOM in the supplied `container` and return a [reference](/docs/more-about-refs.html) to:
+*   the underlying DOM element for built-in components (like `<div>` or `<span>`),
+*   the instance of the component for [class components](/docs/components-and-props.html#functional-and-class-components),
+*   `null` for [function components](/docs/components-and-props.html#functional-and-class-components).
 
 If the React element was previously rendered into `container`, this will perform an update on it and only mutate the DOM as necessary to reflect the latest React element.
 


### PR DESCRIPTION
*   changed `stateless components` to `function components`
*   added rule for built-in components
