### PR TITLE
Context docs: suggest memoization in caveat case

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -243,6 +243,8 @@ To get around this, lift the value into the parent's state:
 
 `embed:context/reference-caveats-solution.js`
 
+If you want to pass certain props as context, you don't need to use state. [Memoize instead](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization).
+
 ## Legacy API {#legacy-api}
 
 > Note


### PR DESCRIPTION
In the case where you want to pass certain props to context, suggest memoization instead of suggesting to use the local state to avoid re-renders.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
