### PR TITLE
Add new routing framework

### DIFF
--- a/content/community/tools-routing.md
+++ b/content/community/tools-routing.md
@@ -10,6 +10,7 @@ permalink: community/routing.html
 * **[component-router](https://github.com/in-flux/component-router):** Flux-based routing solution for components
 * **[Director](https://github.com/flatiron/director)** - A tiny and isomorphic URL router for JavaScript.
 * **[Finch](http://stoodder.github.io/finchjs/)** - A simple, yet powerful, javascript route handling library.
+* **[hookrouter](https://github.com/Paratron/hookrouter)** A small, easily nestable router based on hooks.
 * **[mvc-router](https://github.com/rajeev-k/mvc-router)** Use the Model-View-Controller (MVC) pattern to build React applications.
 * **[Reach Router](https://reach.tech/router)** An Accessible Router for React
 * **[react-mini-router](https://github.com/larrymyers/react-mini-router)** A minimal URL router mixin.


### PR DESCRIPTION
This adds the `hookrouter` routing framework to the list of known community routing frameworks.

I happened to come across this framework while looking at alternatives. It's quite small and simple
to use.

/cc @Paratron
