### PR TITLE
Update useReducer hook reference example

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -226,7 +226,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialState}) {
+function Counter() {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
The `initialState` prop that may be passed to the `Counter` component shadows the `initialState` constant declared at the top of the example. If the example code is run without passing `initialState` the code will fail with the error `Uncaught TypeError: Cannot read property 'count' of undefined`.

Before: https://codesandbox.io/s/jzm0k3o4y9
After: https://codesandbox.io/s/506v6j107k



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
