### PR TITLE
Add Chain React to conferences list

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -52,6 +52,11 @@ June 21, 2019 Chicago, Illinois USA
 
 [Website](https://reactloop.com) - [Twitter](https://twitter.com/ReactLoop)
 
+### Chain React 2019
+July 11-12, 2019. Portland, OR, USA.
+
+[Website](https://infinite.red/ChainReactConf)
+
 ### React Rally 2019
 August 22-23, 2019. Salt Lake City, USA.
 
@@ -59,6 +64,7 @@ August 22-23, 2019. Salt Lake City, USA.
 
 ### ComponentsConf 2019 {#componentsconf-2019}
 September 6, 2019 in Melbourne, Australia
+
 [Website](https://www.componentsconf.com.au/) - [Twitter](https://twitter.com/componentsconf)
 
 ### React Native EU 2019 {#react-native-eu-2019}


### PR DESCRIPTION
Chain React is a React Native focused conference put on yearly. This will be the 3rd year it has been held.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
