### PR TITLE
✏️Typo fix on getSnapshotBeforeUpdate docs

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -299,7 +299,7 @@ Note that this method is fired on *every* render, regardless of the cause. This 
 getSnapshotBeforeUpdate(prevProps, prevState)
 ```
 
-`getSnapshotBeforeUpdate()` is invoked right before the most recently rendered output is committed to e.g. the DOM. It enables your component to capture some information from the DOM (e.g. scroll position) before it is potentially changed. Any value returned by this lifecycle will be passed as a parameter to `componentDidUpdate()`.
+`getSnapshotBeforeUpdate()` is invoked right before the most recently rendered output is committed to the DOM. It enables your component to capture some information from the DOM (e.g. scroll position) before it is potentially changed. Any value returned by this lifecycle will be passed as a parameter to `componentDidUpdate()`.
 
 This use case is not common, but it may occur in UIs like a chat thread that need to handle scroll position in a special way.
 


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I'm making this PR because I noticed a typo in one of the documentation pages. I'm not sure if the wording was supposed to have something else that the `e.g.` was in reference to, but I removed it for clarity. If there are any other changes I should make in this PR, please let me know.
