### PR TITLE
Fix anchor link offset with fixed header

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -350,8 +350,8 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 90,
-        marginTop: -65,
+        paddingTop: 85,
+        marginTop: -60,
       },
 
       fontSize: 20,

--- a/src/theme.js
+++ b/src/theme.js
@@ -300,8 +300,8 @@ const sharedStyles = {
           content: ' ',
           display: 'block',
           borderBottom: 0,
-          marginTop: -80,
           paddingTop: 40,
+          marginTop: -80,
         },
       },
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -341,8 +341,16 @@ const sharedStyles = {
       fontSize: 20,
       color: colors.subtle,
       lineHeight: 1.3,
-      marginTop: 50,
+      paddingTop: 65,
       fontWeight: 400,
+
+      [media.between('small', 'large')]: {
+        paddingTop: 55,
+      },
+
+      [media.lessThan('small')]: {
+        paddingTop: 45,
+      },
     },
 
     '& h4 + p': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -285,7 +285,7 @@ const sharedStyles = {
     },
 
     '& h2': {
-      '&::before': {
+      '::before': {
         content: ' ',
         display: 'block',
         borderBottom: `1px solid ${colors.divider}`,
@@ -296,9 +296,13 @@ const sharedStyles = {
       lineHeight: 1.2,
 
       ':first-child': {
-        borderTop: 0,
-        marginTop: 0,
-        paddingTop: 0,
+        '::before': {
+          content: ' ',
+          display: 'block',
+          borderBottom: 0,
+          marginTop: -80,
+          paddingTop: 40,
+        },
       },
 
       [media.lessThan('large')]: {
@@ -315,11 +319,11 @@ const sharedStyles = {
     },
 
     '& h3': {
-      '&::before': {
+      '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 60,
-        marginTop: -15,
+        paddingTop: 90,
+        marginTop: -45,
       },
 
       [media.lessThan('small')]: {
@@ -334,15 +338,20 @@ const sharedStyles = {
     },
 
     '& h2 + h3, & h2 + h3:first-of-type': {
-      paddingTop: 30,
-    },
-
-    '& h4': {
-      '&::before': {
+      '::before': {
         content: ' ',
         display: 'block',
         paddingTop: 60,
-        marginTop: -10,
+        marginTop: -30,
+      },
+    },
+
+    '& h4': {
+      '::before': {
+        content: ' ',
+        display: 'block',
+        paddingTop: 100,
+        marginTop: -50,
       },
 
       fontSize: 20,

--- a/src/theme.js
+++ b/src/theme.js
@@ -341,8 +341,8 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 90,
-        marginTop: -60,
+        paddingTop: 60,
+        marginTop: -30,
       },
     },
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -286,14 +286,23 @@ const sharedStyles = {
 
     '& h2': {
       borderTop: `1px solid ${colors.divider}`,
-      marginTop: 44,
-      paddingTop: 40,
+      marginTop: 64,
+      paddingTop: 60,
       lineHeight: 1.2,
 
       ':first-child': {
         borderTop: 0,
         marginTop: 0,
         paddingTop: 0,
+      },
+
+      [media.between('small', 'large')]: {
+        marginTop: 54,
+        paddingTop: 50,
+      },
+      [media.lessThan('small')]: {
+        marginTop: 44,
+        paddingTop: 40,
       },
 
       [media.lessThan('large')]: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -341,8 +341,8 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 60,
-        marginTop: -30,
+        paddingTop: 90,
+        marginTop: -60,
       },
     },
 
@@ -350,8 +350,8 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 100,
-        marginTop: -50,
+        paddingTop: 90,
+        marginTop: -65,
       },
 
       fontSize: 20,

--- a/src/theme.js
+++ b/src/theme.js
@@ -285,24 +285,20 @@ const sharedStyles = {
     },
 
     '& h2': {
-      borderTop: `1px solid ${colors.divider}`,
-      marginTop: 60,
-      paddingTop: 65,
+      '&::before': {
+        content: ' ',
+        display: 'block',
+        borderBottom: `1px solid ${colors.divider}`,
+        paddingTop: 44,
+        marginBottom: 40,
+      },
+
       lineHeight: 1.2,
 
       ':first-child': {
         borderTop: 0,
         marginTop: 0,
         paddingTop: 0,
-      },
-
-      [media.between('small', 'large')]: {
-        marginTop: 50,
-        paddingTop: 55,
-      },
-      [media.lessThan('small')]: {
-        marginTop: 40,
-        paddingTop: 45,
       },
 
       [media.lessThan('large')]: {
@@ -319,14 +315,14 @@ const sharedStyles = {
     },
 
     '& h3': {
-      paddingTop: 65,
-
-      [media.between('small', 'large')]: {
-        paddingTop: 55,
+      '&::before': {
+        content: ' ',
+        display: 'block',
+        paddingTop: 60,
+        marginTop: '-15px',
       },
 
       [media.lessThan('small')]: {
-        paddingTop: 45,
         overflowWrap: 'break-word',
         wordBreak: 'break-word',
       },
@@ -337,20 +333,22 @@ const sharedStyles = {
       },
     },
 
+    '& h2 + h3, & h2 + h3:first-of-type': {
+      paddingTop: 30,
+    },
+
     '& h4': {
+      '&::before': {
+        content: ' ',
+        display: 'block',
+        paddingTop: 60,
+        marginTop: '-10px',
+      },
+
       fontSize: 20,
       color: colors.subtle,
       lineHeight: 1.3,
-      paddingTop: 65,
       fontWeight: 400,
-
-      [media.between('small', 'large')]: {
-        paddingTop: 55,
-      },
-
-      [media.lessThan('small')]: {
-        paddingTop: 45,
-      },
     },
 
     '& h4 + p': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -286,8 +286,8 @@ const sharedStyles = {
 
     '& h2': {
       borderTop: `1px solid ${colors.divider}`,
-      marginTop: 64,
-      paddingTop: 60,
+      marginTop: 60,
+      paddingTop: 65,
       lineHeight: 1.2,
 
       ':first-child': {
@@ -297,12 +297,12 @@ const sharedStyles = {
       },
 
       [media.between('small', 'large')]: {
-        marginTop: 54,
-        paddingTop: 50,
+        marginTop: 50,
+        paddingTop: 55,
       },
       [media.lessThan('small')]: {
-        marginTop: 44,
-        paddingTop: 40,
+        marginTop: 40,
+        paddingTop: 45,
       },
 
       [media.lessThan('large')]: {
@@ -319,9 +319,14 @@ const sharedStyles = {
     },
 
     '& h3': {
-      paddingTop: 45,
+      paddingTop: 65,
+
+      [media.between('small', 'large')]: {
+        paddingTop: 55,
+      },
 
       [media.lessThan('small')]: {
+        paddingTop: 45,
         overflowWrap: 'break-word',
         wordBreak: 'break-word',
       },
@@ -330,10 +335,6 @@ const sharedStyles = {
         fontSize: 25,
         lineHeight: 1.3,
       },
-    },
-
-    '& h2 + h3, & h2 + h3:first-of-type': {
-      paddingTop: 30,
     },
 
     '& h4': {

--- a/src/theme.js
+++ b/src/theme.js
@@ -319,7 +319,7 @@ const sharedStyles = {
         content: ' ',
         display: 'block',
         paddingTop: 60,
-        marginTop: '-15px',
+        marginTop: -15,
       },
 
       [media.lessThan('small')]: {
@@ -342,7 +342,7 @@ const sharedStyles = {
         content: ' ',
         display: 'block',
         paddingTop: 60,
-        marginTop: '-10px',
+        marginTop: -10,
       },
 
       fontSize: 20,

--- a/src/theme.js
+++ b/src/theme.js
@@ -350,8 +350,8 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 85,
-        marginTop: -60,
+        paddingTop: 100,
+        marginTop: -50,
       },
 
       fontSize: 20,
@@ -438,6 +438,15 @@ const sharedStyles = {
 
     '& .gatsby-highlight + blockquote': {
       marginTop: 40,
+    },
+
+    '& .gatsby-highlight + h4': {
+      '::before': {
+        content: ' ',
+        display: 'block',
+        paddingTop: 85,
+        marginTop: -60,
+      },
     },
   },
 };


### PR DESCRIPTION
Anchor links overlaps behind the fixed header on all viewport except `small`. I fixed it by matching `paddingTop` with [the header height on different viewport](https://github.com/reactjs/reactjs.org/blob/bab2a3491a18e7074799272d60c8a159473bb7f5/src/components/LayoutHeader/Header.js#L36-L42).

Open [this URL](https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers) for example in a new tab/window to see the issue.

<img width="1680" alt="reactorg" src="https://user-images.githubusercontent.com/4334778/55901840-7969a980-5bca-11e9-96f4-3b66fd2d34fa.png">
