### PR TITLE
Don't recommend shallow rendering inside TestUtils docs

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -139,7 +139,7 @@ Pass a mocked component module to this method to augment it with useful methods 
 
 > Note:
 >
-> `mockComponent()` is a legacy API. We recommend using [shallow rendering](/docs/shallow-renderer.html) or [`jest.mock()`](https://facebook.github.io/jest/docs/en/tutorial-react-native.html#mock-native-modules-using-jestmock) instead.
+> `mockComponent()` is a legacy API. We recommend using [`jest.mock()`](https://facebook.github.io/jest/docs/en/tutorial-react-native.html#mock-native-modules-using-jestmock) instead.
 
 * * *
 


### PR DESCRIPTION
They're already using react-dom, so shallow rendering is a drastic change to their setup. `jest.mock` is more suitable in this scenario. 

(should I mention "or your framework's mocking helpers" to not be jest specific?)