### PR TITLE
Changed unicode hyphen to normal hyphen

### DIFF
--- a/content/blog/2014-09-24-testing-flux-applications.md
+++ b/content/blog/2014-09-24-testing-flux-applications.md
@@ -17,7 +17,7 @@ The first steps toward working with Jest are as follows:
 
 1. Get the module dependencies for the application installed by running `npm install`.
 2. Create a directory `__tests__/` with a test file, in this case TodoStore-test.js
-3. Run `npm install jest-cli —save-dev`
+3. Run `npm install jest-cli --save-dev`
 4. Add the following to your package.json
 
 ```javascript


### PR DESCRIPTION
When copy and pasting `npm install jest-cli —save-dev` you get this error
`Invalid tag name "—save-dev": Tags may not have any characters that encodeURIComponent encodes`

I replaced the unicode characters '—' with ascii hypens '-'



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
