### PR TITLE
Removed unnecessary wrapper component

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -86,10 +86,10 @@ class Mouse extends React.Component {
 class MouseTracker extends React.Component {
   render() {
     return (
-      <div>
+      <>
         <h1>Move the mouse around!</h1>
         <Mouse />
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Removed Unnecessary wrapper component. While copy-pasting this e.g. to local create-react-app, I had to do this change

(Apart from adding following to index.css:)
```css
html,
body {
  height: 100%;
}
 #root {
  height: 100%;
} 
```