### PR TITLE
docs: reorder past conference

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -89,289 +89,288 @@ December 6, 2019 in Berlin, Germany
 
 ## Past Conferences {#past-conferences}
 
-### React.js Conf 2015 {#reactjs-conf-2015}
-January 28 & 29 in Facebook HQ, CA
+[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
 
-[Website](http://conf2015.reactjs.org/) - [Schedule](http://conf2015.reactjs.org/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr)
-
-<iframe title="React.js Conf 2015 Keynote" width="650" height="315" src="//www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>
-
-### ReactEurope 2015 {#reacteurope-2015}
-July 2 & 3 in Paris, France
-
-[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
-
-### Reactive 2015 {#reactive-2015}
-November 2-4 in Bratislava, Slovakia
-
-[Website](https://reactive2015.com/) - [Schedule](https://reactive2015.com/schedule_speakers.html#schedule)
-
-### React.js Conf 2016 {#reactjs-conf-2016}
-February 22 & 23 in San Francisco, CA
-
-[Website](http://conf.reactjs.com/) - [Schedule](http://conf.reactjs.com/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS0M8Q95RIc2lOM6nc77q1IY)
-
-### React Amsterdam 2016 {#react-amsterdam-2016}
-April 16 in Amsterdam, The Netherlands
-
-[Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
-
-### ReactEurope 2016 {#reacteurope-2016}
-June 2 & 3 in Paris, France
-
-[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
-
-### ReactRally 2016 {#reactrally-2016}
-August 25-26 in Salt Lake City, UT
-
-[Website](http://www.reactrally.com/) - [Schedule](http://www.reactrally.com/#/schedule) - [Videos](https://www.youtube.com/playlist?list=PLUD4kD-wL_zYSfU3tIYsb4WqfFQzO_EjQ)
-
-### ReactNext 2016 {#reactnext-2016}
-September 15 in Tel Aviv, Israel
-
-[Website](http://react-next.com/) - [Schedule](http://react-next.com/#schedule) - [Videos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
-
-### ReactNL 2016 {#reactnl-2016}
-October 13 in Amsterdam, The Netherlands - [Schedule](http://reactnl.org/#program)
-
-[Website](http://reactnl.org/)
-
-### Reactive 2016 {#reactive-2016}
-October 26-28 in Bratislava, Slovakia
-
-[Website](https://reactiveconf.com/)
-
-### React Remote Conf 2016 {#react-remote-conf-2016}
-October 26-28 online
-
-[Website](https://allremoteconfs.com/react-2016) - [Schedule](https://allremoteconfs.com/react-2016#schedule)
-
-### Agent Conference 2017 {#agent-conference-2017}
-January 20-21 in Dornbirn, Austria
-
-[Website](http://agent.sh/)
-
-### React Conf 2017 {#react-conf-2017}
-March 13-14 in Santa Clara, CA
-
-[Website](http://conf.reactjs.org/) - [Videos](https://www.youtube.com/watch?v=7HSd1sk07uU&list=PLb0IAmt7-GS3fZ46IGFirdqKTIxlws7e0)
-
-### React London 2017 {#react-london-2017}
-March 28th at the [QEII Centre, London](http://qeiicentre.london/)
-
-[Website](http://react.london/) - [Videos](https://www.youtube.com/watch?v=2j9rSur_mnk&list=PLW6ORi0XZU0CFjdoYeC0f5QReBG-NeNKJ)
-
-### React Amsterdam 2017 {#react-amsterdam-2017}
-April 21st in Amsterdam, The Netherlands
-
-[Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
-
-### ReactEurope 2017 {#reacteurope-2017}
-May 18th & 19th in Paris, France
-
-[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
-
-### Chain React 2017 {#chain-react-2017}
-July 10-11 in Portland, Oregon USA
-
-[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf) - [Videos](https://www.youtube.com/watch?v=cz5BzwgATpc&list=PLFHvL21g9bk3RxJ1Ut5nR_uTZFVOxu522)
-
-### React Rally 2017 {#react-rally-2017}
-August 24-25 in Salt Lake City, Utah USA
-
-[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally) - [Videos](https://www.youtube.com/watch?v=f4KnHNCZcH4&list=PLUD4kD-wL_zZUhvAIHJjueJDPr6qHvkni)
-
-### React Native EU 2017 {#react-native-eu-2017}
-September 6-7 in Wroclaw, Poland
-
-[Website](http://react-native.eu/) - [Videos](https://www.youtube.com/watch?v=453oKJAqfy0&list=PLzUKC1ci01h_hkn7_KoFA-Au0DXLAQZR7)
-
-### ReactNext 2017 {#reactnext-2017}
-September 8-10 in Tel Aviv, Israel
-
-[Website](http://react-next.com/) - [Twitter](https://twitter.com/ReactNext) - [Videos (Hall A)](https://www.youtube.com/watch?v=eKXQw5kR86c&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z), [Videos (Hall B)](https://www.youtube.com/watch?v=1InokWxYGnE&list=PLMYVq3z1QxSqCZmaqgTXLsrcJ8mZmBF7T)
-
-### ReactFoo 2017 {#reactfoo-2017}
-September 14 in Bangalore, India
-
-[Website](https://reactfoo.in/2017/) - [Videos](https://www.youtube.com/watch?v=3G6tMg29Wnw&list=PL279M8GbNsespKKm1L0NAzYLO6gU5LvfH)
-
-### React Boston 2017 {#react-boston-2017}
-September 23-24 in Boston, Massachusetts USA
-
-[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston) - [Videos](https://www.youtube.com/watch?v=2iPE5l3cl_s&list=PL-fCkV3wv4ub8zJMIhmrrLcQqSR5XPlIT)
-
-### React Alicante 2017 {#react-alicante-2017}
-September 28-30 in Alicante, Spain
-
-[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante) - [Videos](https://www.youtube.com/watch?v=UMZvRCWo6Dw&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM)
-
-### ReactJS Day 2017 {#reactjs-day-2017}
-October 6 in Verona, Italy
-
-[Website](http://2017.reactjsday.it) - [Twitter](https://twitter.com/reactjsday) - [Videos](https://www.youtube.com/watch?v=bUqqJPIgjNU&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9)
-
-### React Conf Brasil 2017 {#react-conf-brasil-2017}
-October 7 in Sao Paulo, Brazil
-
-[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf/)
-
-### State.js Conference 2017 {#statejs-conference-2017}
-October 13 in Stockholm, Sweden
-
-[Website](https://statejs.com/)
-
-### React Summit 2017 {#react-summit-2017}
-October 21 in Lagos, Nigeria
-
-[Website](https://reactsummit2017.splashthat.com/) - [Twitter](https://twitter.com/DevCircleLagos/) - [Facebook](https://www.facebook.com/groups/DevCLagos/)
-
-### ReactiveConf 2017 {#reactiveconf-2017}
-October 25–27, Bratislava, Slovakia
-
-[Website](https://reactiveconf.com) - [Videos](https://www.youtube.com/watch?v=BOKxSFB2hOE&list=PLa2ZZ09WYepMB-I7AiDjDYR8TjO8uoNjs)
-
-### React Seoul 2017 {#react-seoul-2017}
-November 4 in Seoul, South Korea
-
-[Website](http://seoul.reactjs.kr/en)
-
-### React Day Berlin 2017 {#react-day-berlin-2017}
-December 2, Berlin, Germany
-
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/watch?v=UnNLJvHKfSY&list=PL-3BrJ5CiIx5GoXci54-VsrO6GwLhSHEK)
-
-### ReactFoo Pune {#reactfoo-pune}
-January 19-20, Pune, India
-
-[Website](https://reactfoo.in/2018-pune/) - [Twitter](https://twitter.com/ReactFoo)
-
-### AgentConf 2018 {#agentconf-2018}
-January 25-28 in Dornbirn, Austria
-
-[Website](http://agent.sh/)
-
-### ReactFest 2018 {#reactfest-2018}
-March 8-9 in London, UK
-
-[Website](https://reactfest.uk/) - [Twitter](https://twitter.com/ReactFest) - [Videos](https://www.youtube.com/watch?v=YOCrJ5vRCnw&list=PLRgweB8YtNRt-Sf-A0y446wTJNUaAAmle)
-
-### Reactathon 2018 {#reactathon-2018}
-March 20-22 in San Francisco, USA
-
-[Website](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon) - [Videos (fundamentals)](https://www.youtube.com/watch?v=knn364bssQU&list=PLRvKvw42Rc7OWK5s-YGGFSmByDzzgC0HP), [Videos (advanced day1)](https://www.youtube.com/watch?v=57hmk4GvJpk&list=PLRvKvw42Rc7N0QpX2Rc5CdrqGuxzwD_0H), [Videos (advanced day2)](https://www.youtube.com/watch?v=1hvQ8p8q0a0&list=PLRvKvw42Rc7Ne46QAjWNWFo1Jf0mQdnIW)
-
-### React Native Camp UA 2018 {#react-native-camp-ua-2018}
-March 31 in Kiev, Ukraine
-
-[Website](http://reactnative.com.ua/) - [Twitter](https://twitter.com/reactnativecamp) - [Facebook](https://www.facebook.com/reactnativecamp/)
-
-### React Amsterdam 2018 {#react-amsterdam-2018}
-April 13 in Amsterdam, The Netherlands
-
-[Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Facebook](https://www.facebook.com/reactamsterdam)
-
-### React Finland 2018 {#react-finland-2018}
-April 24-26 in Helsinki, Finland
-
-[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
-
-### <React.NotAConf /> 2018 {#reactnotaconf--2018}
-April 28 in Sofia, Bulgaria
-
-[Website](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/groups/1614950305478021/)
-
-### ReactEurope 2018 {#reacteurope-2018}
-May 17-18 in Paris, France
-
-[Website](https://www.react-europe.org) - [Twitter](https://twitter.com/ReactEurope) - [Facebook](https://www.facebook.com/ReactEurope)
-
-### ReactFoo Mumbai {#reactfoo-mumbai}
-May 26 in Mumbai, India
-
-[Website](https://reactfoo.in/2018-mumbai/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
-
-### Chain React 2018 {#chain-react-2018}
-July 11-13 in Portland, Oregon USA
-
-[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf)
-
-### React Rally {#react-rally}
-August 16-17 in Salt Lake City, Utah USA
-
-[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
-
-### React DEV Conf China {#react-dev-conf-china}
-August 18 in Guangzhou, China
-
-[Website](https://react.w3ctech.com)
-
-### ReactFoo Delhi {#reactfoo-delhi}
-August 18 in Delhi, India
-
-[Website](https://reactfoo.in/2018-delhi/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
-
-### Byteconf React 2018 {#byteconf-react-2018}
-August 31 streamed online, via Twitch
-
-[Website](https://byteconf.com) - [Twitch](https://twitch.tv/byteconf) - [Twitter](https://twitter.com/byteconf)
-
-### React Native EU 2018 {#react-native-eu-2018}
-September 5-6 in Wrocław, Poland
-
-[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
-
-### React Alicante 2018 {#react-alicante-2018}
-September 13-15 in Alicante, Spain
-
-[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante)
-
-### React Boston 2018 {#react-boston-2018}
-September 29-30 in Boston, Massachusetts USA
-
-[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston)
-
-### ReactJS Day 2018 {#reactjs-day-2018}
-October 5 in Verona, Italy
-
-[Website](http://2018.reactjsday.it) - [Twitter](https://twitter.com/reactjsday)
-
-### React Conf Brasil 2018 {#react-conf-brasil-2018}
-October 20 in Sao Paulo, Brazil
-
-[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf)
-
-### React Conf 2018 {#react-conf-2018}
-October 25-26 in Henderson, Nevada USA
-
-[Website](https://conf.reactjs.org/)
-
-### ReactNext 2018 {#reactnext-2018}
-November 4 in Tel Aviv, Israel
-
-[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Facebook](https://facebook.com/ReactNext2016)
-
-### React Day Berlin 2018 {#react-day-berlin-2018}
-November 30, Berlin, Germany
-
-[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/channel/UC1EYHmQYBUJjkmL6OtK4rlw)
-
-### React Iran 2019 {#react-iran-2019}
-January 31, 2019 in Tehran, Iran
-
-[Website](http://reactiran.com) - [Instagram](https://www.instagram.com/reactiran/)
-
-### Reactathon 2019 {#reactathon-2019}
-March 30-31, 2019 in San Francisco, USA
+### React Amsterdam 2019 {#react-amsterdam-2019}
+April 12, 2019 in Amsterdam, The Netherlands
 
 [Website](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon)
 
 ### App.js Conf 2019 {#appjs-conf-2019}
 April 4-5, 2019 in Kraków, Poland
 
-[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
+[Website](http://reactiran.com) - [Instagram](https://www.instagram.com/reactiran/)
 
-### React Amsterdam 2019 {#react-amsterdam-2019}
-April 12, 2019 in Amsterdam, The Netherlands
+### Reactathon 2019 {#reactathon-2019}
+March 30-31, 2019 in San Francisco, USA
+
+### React Iran 2019 {#react-iran-2019}
+January 31, 2019 in Tehran, Iran
+
+### React Day Berlin 2018 {#react-day-berlin-2018}
+November 30, Berlin, Germany
+
+[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/channel/UC1EYHmQYBUJjkmL6OtK4rlw)
+
+### ReactNext 2018 {#reactnext-2018}
+November 4 in Tel Aviv, Israel
+
+[Website](https://react-next.com) - [Twitter](https://twitter.com/ReactNext) - [Facebook](https://facebook.com/ReactNext2016)
+
+### React Conf 2018 {#react-conf-2018}
+October 25-26 in Henderson, Nevada USA
+
+[Website](https://conf.reactjs.org/)
+
+### React Conf Brasil 2018 {#react-conf-brasil-2018}
+October 20 in Sao Paulo, Brazil
+
+[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf)
+
+### ReactJS Day 2018 {#reactjs-day-2018}
+October 5 in Verona, Italy
+
+[Website](http://2018.reactjsday.it) - [Twitter](https://twitter.com/reactjsday)
+
+### React Boston 2018 {#react-boston-2018}
+September 29-30 in Boston, Massachusetts USA
+
+[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston)
+
+### React Alicante 2018 {#react-alicante-2018}
+September 13-15 in Alicante, Spain
+
+[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante)
+
+### React Native EU 2018 {#react-native-eu-2018}
+September 5-6 in Wrocław, Poland
+
+[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+
+### Byteconf React 2018 {#byteconf-react-2018}
+August 31 streamed online, via Twitch
+
+[Website](https://byteconf.com) - [Twitch](https://twitch.tv/byteconf) - [Twitter](https://twitter.com/byteconf)
+
+### ReactFoo Delhi {#reactfoo-delhi}
+August 18 in Delhi, India
+
+[Website](https://reactfoo.in/2018-delhi/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
+
+### React DEV Conf China {#react-dev-conf-china}
+August 18 in Guangzhou, China
+
+[Website](https://react.w3ctech.com)
+
+### React Rally {#react-rally}
+August 16-17 in Salt Lake City, Utah USA
+
+[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
+
+### Chain React 2018 {#chain-react-2018}
+July 11-13 in Portland, Oregon USA
+
+[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf)
+
+### ReactFoo Mumbai {#reactfoo-mumbai}
+May 26 in Mumbai, India
+
+[Website](https://reactfoo.in/2018-mumbai/) - [Twitter](https://twitter.com/reactfoo) - [Past talks](https://hasgeek.tv)
+
+### ReactEurope 2018 {#reacteurope-2018}
+May 17-18 in Paris, France
+
+[Website](https://www.react-europe.org) - [Twitter](https://twitter.com/ReactEurope) - [Facebook](https://www.facebook.com/ReactEurope)
+
+### <React.NotAConf /> 2018 {#reactnotaconf--2018}
+April 28 in Sofia, Bulgaria
+
+[Website](http://react-not-a-conf.com/) - [Twitter](https://twitter.com/reactnotaconf) - [Facebook](https://www.facebook.com/groups/1614950305478021/)
+
+### React Finland 2018 {#react-finland-2018}
+April 24-26 in Helsinki, Finland
+
+[Website](https://react-finland.fi/) - [Twitter](https://twitter.com/ReactFinland)
+
+### React Amsterdam 2018 {#react-amsterdam-2018}
+April 13 in Amsterdam, The Netherlands
+
+[Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Facebook](https://www.facebook.com/reactamsterdam)
+
+### React Native Camp UA 2018 {#react-native-camp-ua-2018}
+March 31 in Kiev, Ukraine
+
+[Website](http://reactnative.com.ua/) - [Twitter](https://twitter.com/reactnativecamp) - [Facebook](https://www.facebook.com/reactnativecamp/)
+
+### Reactathon 2018 {#reactathon-2018}
+March 20-22 in San Francisco, USA
+
+[Website](https://www.reactathon.com/) - [Twitter](https://twitter.com/reactathon) - [Videos (fundamentals)](https://www.youtube.com/watch?v=knn364bssQU&list=PLRvKvw42Rc7OWK5s-YGGFSmByDzzgC0HP), [Videos (advanced day1)](https://www.youtube.com/watch?v=57hmk4GvJpk&list=PLRvKvw42Rc7N0QpX2Rc5CdrqGuxzwD_0H), [Videos (advanced day2)](https://www.youtube.com/watch?v=1hvQ8p8q0a0&list=PLRvKvw42Rc7Ne46QAjWNWFo1Jf0mQdnIW)
+
+### ReactFest 2018 {#reactfest-2018}
+March 8-9 in London, UK
+
+[Website](https://reactfest.uk/) - [Twitter](https://twitter.com/ReactFest) - [Videos](https://www.youtube.com/watch?v=YOCrJ5vRCnw&list=PLRgweB8YtNRt-Sf-A0y446wTJNUaAAmle)
+
+### AgentConf 2018 {#agentconf-2018}
+January 25-28 in Dornbirn, Austria
+
+[Website](http://agent.sh/)
+
+### ReactFoo Pune {#reactfoo-pune}
+January 19-20, Pune, India
+
+[Website](https://reactfoo.in/2018-pune/) - [Twitter](https://twitter.com/ReactFoo)
+
+### React Day Berlin 2017 {#react-day-berlin-2017}
+December 2, Berlin, Germany
+
+[Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/watch?v=UnNLJvHKfSY&list=PL-3BrJ5CiIx5GoXci54-VsrO6GwLhSHEK)
+
+### React Seoul 2017 {#react-seoul-2017}
+November 4 in Seoul, South Korea
+
+[Website](http://seoul.reactjs.kr/en)
+
+### ReactiveConf 2017 {#reactiveconf-2017}
+October 25–27, Bratislava, Slovakia
+
+[Website](https://reactiveconf.com) - [Videos](https://www.youtube.com/watch?v=BOKxSFB2hOE&list=PLa2ZZ09WYepMB-I7AiDjDYR8TjO8uoNjs)
+
+### React Summit 2017 {#react-summit-2017}
+October 21 in Lagos, Nigeria
+
+[Website](https://reactsummit2017.splashthat.com/) - [Twitter](https://twitter.com/DevCircleLagos/) - [Facebook](https://www.facebook.com/groups/DevCLagos/)
+
+### State.js Conference 2017 {#statejs-conference-2017}
+October 13 in Stockholm, Sweden
+
+[Website](https://statejs.com/)
+
+### React Conf Brasil 2017 {#react-conf-brasil-2017}
+October 7 in Sao Paulo, Brazil
+
+[Website](http://reactconfbr.com.br) - [Twitter](https://twitter.com/reactconfbr) - [Facebook](https://www.facebook.com/reactconf/)
+
+### ReactJS Day 2017 {#reactjs-day-2017}
+October 6 in Verona, Italy
+
+[Website](http://2017.reactjsday.it) - [Twitter](https://twitter.com/reactjsday) - [Videos](https://www.youtube.com/watch?v=bUqqJPIgjNU&list=PLWK9j6ps_unl293VhhN4RYMCISxye3xH9)
+
+### React Alicante 2017 {#react-alicante-2017}
+September 28-30 in Alicante, Spain
+
+[Website](http://reactalicante.es) - [Twitter](https://twitter.com/ReactAlicante) - [Videos](https://www.youtube.com/watch?v=UMZvRCWo6Dw&list=PLd7nkr8mN0sWvBH_s0foCE6eZTX8BmLUM)
+
+### React Boston 2017 {#react-boston-2017}
+September 23-24 in Boston, Massachusetts USA
+
+[Website](http://www.reactboston.com/) - [Twitter](https://twitter.com/ReactBoston) - [Videos](https://www.youtube.com/watch?v=2iPE5l3cl_s&list=PL-fCkV3wv4ub8zJMIhmrrLcQqSR5XPlIT)
+
+### ReactFoo 2017 {#reactfoo-2017}
+September 14 in Bangalore, India
+
+[Website](https://reactfoo.in/2017/) - [Videos](https://www.youtube.com/watch?v=3G6tMg29Wnw&list=PL279M8GbNsespKKm1L0NAzYLO6gU5LvfH)
+
+### ReactNext 2017 {#reactnext-2017}
+September 8-10 in Tel Aviv, Israel
+
+[Website](http://react-next.com/) - [Twitter](https://twitter.com/ReactNext) - [Videos (Hall A)](https://www.youtube.com/watch?v=eKXQw5kR86c&list=PLMYVq3z1QxSqq6D7jxVdqttOX7H_Brq8Z), [Videos (Hall B)](https://www.youtube.com/watch?v=1InokWxYGnE&list=PLMYVq3z1QxSqCZmaqgTXLsrcJ8mZmBF7T)
+
+### React Native EU 2017 {#react-native-eu-2017}
+September 6-7 in Wroclaw, Poland
+
+[Website](http://react-native.eu/) - [Videos](https://www.youtube.com/watch?v=453oKJAqfy0&list=PLzUKC1ci01h_hkn7_KoFA-Au0DXLAQZR7)
+
+### React Rally 2017 {#react-rally-2017}
+August 24-25 in Salt Lake City, Utah USA
+
+[Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally) - [Videos](https://www.youtube.com/watch?v=f4KnHNCZcH4&list=PLUD4kD-wL_zZUhvAIHJjueJDPr6qHvkni)
+
+### Chain React 2017 {#chain-react-2017}
+July 10-11 in Portland, Oregon USA
+
+[Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/chainreactconf) - [Videos](https://www.youtube.com/watch?v=cz5BzwgATpc&list=PLFHvL21g9bk3RxJ1Ut5nR_uTZFVOxu522)
+
+### ReactEurope 2017 {#reacteurope-2017}
+May 18th & 19th in Paris, France
+
+[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
+
+### React Amsterdam 2017 {#react-amsterdam-2017}
+April 21st in Amsterdam, The Netherlands
+
+[Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+
+### React London 2017 {#react-london-2017}
+March 28th at the [QEII Centre, London](http://qeiicentre.london/)
+
+[Website](http://react.london/) - [Videos](https://www.youtube.com/watch?v=2j9rSur_mnk&list=PLW6ORi0XZU0CFjdoYeC0f5QReBG-NeNKJ)
+
+### React Conf 2017 {#react-conf-2017}
+March 13-14 in Santa Clara, CA
+
+[Website](http://conf.reactjs.org/) - [Videos](https://www.youtube.com/watch?v=7HSd1sk07uU&list=PLb0IAmt7-GS3fZ46IGFirdqKTIxlws7e0)
+
+### Agent Conference 2017 {#agent-conference-2017}
+January 20-21 in Dornbirn, Austria
+
+[Website](http://agent.sh/)
+
+
+### React Remote Conf 2016 {#react-remote-conf-2016}
+October 26-28 online
+
+[Website](https://allremoteconfs.com/react-2016) - [Schedule](https://allremoteconfs.com/react-2016#schedule)
+
+### Reactive 2016 {#reactive-2016}
+October 26-28 in Bratislava, Slovakia
+
+[Website](https://reactiveconf.com/)
+
+### ReactNL 2016 {#reactnl-2016}
+October 13 in Amsterdam, The Netherlands - [Schedule](http://reactnl.org/#program)
+
+[Website](http://reactnl.org/)
+
+### ReactNext 2016 {#reactnext-2016}
+September 15 in Tel Aviv, Israel
+
+[Website](http://react-next.com/) - [Schedule](http://react-next.com/#schedule) - [Videos](https://www.youtube.com/channel/UC3BT8hh3yTTYxbLQy_wbk2w)
+
+### ReactRally 2016 {#reactrally-2016}
+August 25-26 in Salt Lake City, UT
+
+[Website](http://www.reactrally.com/) - [Schedule](http://www.reactrally.com/#/schedule) - [Videos](https://www.youtube.com/playlist?list=PLUD4kD-wL_zYSfU3tIYsb4WqfFQzO_EjQ)
+
+### ReactEurope 2016 {#reacteurope-2016}
+June 2 & 3 in Paris, France
+
+[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
+
+### React Amsterdam 2016 {#react-amsterdam-2016}
+April 16 in Amsterdam, The Netherlands
 
 [Website](https://react.amsterdam) - [Twitter](https://twitter.com/reactamsterdam) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+
+### React.js Conf 2016 {#reactjs-conf-2016}
+February 22 & 23 in San Francisco, CA
+
+[Website](http://conf.reactjs.com/) - [Schedule](http://conf.reactjs.com/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS0M8Q95RIc2lOM6nc77q1IY)
+
+### Reactive 2015 {#reactive-2015}
+November 2-4 in Bratislava, Slovakia
+
+[Website](https://reactive2015.com/) - [Schedule](https://reactive2015.com/schedule_speakers.html#schedule)
+
+### ReactEurope 2015 {#reacteurope-2015}
+July 2 & 3 in Paris, France
+
+[Website](http://www.react-europe.org/) - [Schedule](http://www.react-europe.org/#schedule) - [Videos](https://www.youtube.com/channel/UCorlLn2oZfgOJ-FUcF2eZ1A/playlists)
+
+### React.js Conf 2015 {#reactjs-conf-2015}
+January 28 & 29 in Facebook HQ, CA
+
+[Website](http://conf2015.reactjs.org/) - [Schedule](http://conf2015.reactjs.org/schedule.html) - [Videos](https://www.youtube.com/playlist?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr)
+
+<iframe title="React.js Conf 2015 Keynote" width="650" height="315" src="//www.youtube-nocookie.com/embed/KVZ-P-ZI6W4?list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
It makes sense to have ascending order for future conferences, but for past conferences, the latest it would be more relevant since it has more updated content and topics that interest the community.