### PR TITLE
Broken anchor link in Advanced Concepts.

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -99,7 +99,7 @@ Sometimes people find third-party books and video courses more helpful than the 
 
 ### Advanced Concepts {#advanced-concepts}
 
-Once you're comfortable with the [main concepts](#main-concepts) and played with React a little bit, you might be interested in more advanced topics. This section will introduce you to the powerful, but less commonly used React features like [context](/docs/context.html) and [refs](/docs/refs-and-the-dom.html).
+Once you're comfortable with the [main concepts](/docs/hello-world.html) and played with React a little bit, you might be interested in more advanced topics. This section will introduce you to the powerful, but less commonly used React features like [context](/docs/context.html) and [refs](/docs/refs-and-the-dom.html).
 
 ### API Reference {#api-reference}
 


### PR DESCRIPTION
The link should probably either go to directly to the beginning of main concepts (which is what my proposes change does), or to the anchor  -tag of "Step-by-Step Guide" (#step-by-step-guide). There is no other link in the article which refers to another anchor-tag, that's why I chose to directly link to the main-concepts.
