### PR TITLE
Document the [deps] argument to useEffect()

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -102,7 +102,7 @@ Note that React may still need to render that specific component again before ba
 ### `useEffect` {#useeffect}
 
 ```js
-useEffect(didUpdate);
+useEffect(didUpdate, [deps]);
 ```
 
 Accepts a function that contains imperative, possibly effectful code.


### PR DESCRIPTION
This PR treads similar ground as #1342, but is much more constrained and is a straightforward clarification rather than a jumping-off point. It fixes #1825.

This documents the optional `[deps]` second argument to `useEffect()` the same way that it is documented for `useImperativeHandle`.