### PR TITLE
previous page link not linking to previous page, but to the second last.

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -8,7 +8,7 @@ prev: hooks-overview.html
 
 *Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
 
-The [previous page](/docs/hooks-intro.html) introduced Hooks with this example:
+The [introduction page](/docs/hooks-intro.html) used this example to introduce Hooks:
 
 ```js{4-5}
 import React, { useState } from 'react';

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -8,7 +8,7 @@ prev: hooks-overview.html
 
 *Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class.
 
-The [introduction page](/docs/hooks-intro.html) used this example to introduce Hooks:
+The [introduction page](/docs/hooks-intro.html) used this example to get familiar with Hooks:
 
 ```js{4-5}
 import React, { useState } from 'react';


### PR DESCRIPTION
The example code is on both, the `Introducing Hooks` as well as `Hooks at a Glance` page, but the linked page is the `Introducing Hooks` and I think that's the right one. The `Hooks at a Glance` page probably got added later?

Not sure about the phrasing so, having "introduce" twice in one sentence ...



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
