### PR TITLE
Update example to display a meaningful error message

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -28,12 +28,12 @@ A class component becomes an error boundary if it defines either (or both) of th
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { error: null };
   }
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    return { error };
   }
 
   componentDidCatch(error, info) {
@@ -42,9 +42,9 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    if (this.state.hasError) {
+    if (this.state.error) {
       // You can render any custom fallback UI
-      return <h1>Something went wrong.</h1>;
+      return <h1>{this.state.error.message}</h1>;
     }
 
     return this.props.children; 


### PR DESCRIPTION
The ErrorBoundary example limits the error message to be a static string ("Something went wrong") by saving only a boolean in the state. The proposed change provides the flexibility to display a more meaningful message.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
