### PR TITLE
Update core-js import calls as per v3

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -11,8 +11,8 @@ React 16 depends on the collection types [Map](https://developer.mozilla.org/en-
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
-import 'core-js/es6/map';
-import 'core-js/es6/set';
+import 'core-js/es/map';
+import 'core-js/es/set';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
The documented import style with `core-js/es6/map` no longer works in `core-js@3.0.1` as the structure has changed to `core-js/es/map`.

From [core-js v3 docs](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#packages-entry-points-and-modules-names)

> In previous versions of core-js, modules with polyfills for stable ECMAScript features and ECMAScript proposals were prefixed with es6. and es7. respectively. It was a decision taken in 2014 when all the features which could be after ES6 were considered as ES7. In core-js@3 all stable ECMAScript features are prefixed with es., while ECMAScript proposals with esnext.