### PR TITLE
Fix useReducer example

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -226,7 +226,7 @@ function reducer(state, action) {
   }
 }
 
-function Counter({initialState}) {
+function Counter() {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <>


### PR DESCRIPTION
The `useReducer` [example](https://reactjs.org/docs/hooks-reference.html#usereducer) is broken, here is a before and after codesandbox of the code example change included with this PR.

[current useReducer example](https://codesandbox.io/s/m53mnlylny?fontsize=14)
[useReducer example after fix in PR](https://codesandbox.io/s/21jz3q8n1r?fontsize=14)

