### PR TITLE
Add a Scrimba course to list of free courses

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -22,6 +22,8 @@ permalink: community/courses.html
 
 - [Free React Bootcamp](https://tylermcginnis.com/free-react-bootcamp/) - Recordings from three days of a free online React bootcamp.
 
+- [Scrimba: Learn React for free](https://scrimba.com/g/glearnreact) - A comprehensive beginners course that lets you interact with the code inside the screencasts.
+
 ## Paid Courses {#paid-courses}
 
 - [Egghead.io](https://egghead.io/browse/frameworks/react) - Short instructional videos on React and many other topics.


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Hi, I'm proposing this course for the docs as it'll make React more accessible to people in low-bandwidth areas (point 1 below), and easier to learn (point 2 below).

### 1. Makes React more accessible to people in low-bandwidth areas
Scrimba screencasts require less than 1% of the bandwidth of traditional videos, so it's accessible to people with slow internet access (typically developing countries). Right now, all the video courses you're linking to has been made with traditional video technology, so adding this one would make your docs more accessible.


### 2. Beginners often say that this course _finally_ made them understand React
This is in large because of Scrimba's functionality, where you're able to interact with the code inside the videos. No other React course online offers this.

Some examples of how students react on this course:

https://twitter.com/edgarnigel/status/1097438500692078592

https://twitter.com/StephonBee/status/1091033903283036160

https://twitter.com/lesleyrazz/status/1115413847261761536

Another factor is the amazing instructor Bob Ziroll, Director of Education at [V School](https://vschool.io/). 

Over 50K students have enrolled in the course, and it does not require any email signup.

Thanks,
Per Harald Borgen
Co-founder of Scrimba