### PR TITLE
Fix broken webpack production guide link in "Optimizing Performance" page.

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -153,7 +153,7 @@ new webpack.DefinePlugin({
 new webpack.optimize.UglifyJsPlugin()
 ```
 
-You can learn more about this in [webpack documentation](https://webpack.js.org/guides/production-build/).
+You can learn more about this in [webpack documentation](https://webpack.js.org/guides/production/).
 
 Remember that you only need to do this for production builds. You shouldn't apply `UglifyJsPlugin` or `DefinePlugin` with `'production'` value in development because they will hide useful React warnings, and make the builds much slower.
 


### PR DESCRIPTION
**Before**

[The link to the webpack production build guide](https://reactjs.org/docs/optimizing-performance.html#webpack) went to https://webpack.js.org/guides/production-build/ which results in a 404 Error.

![image](https://user-images.githubusercontent.com/7445205/57966703-f261db00-7998-11e9-8e94-534a8591adcf.png)

**After**

The link now directs to https://webpack.js.org/guides/production/ which is the correct URL.

![image](https://user-images.githubusercontent.com/7445205/57966723-348b1c80-7999-11e9-9680-126608e92551.png)
