### PR TITLE
Add lang and hreflang to language pages for screen reader UX

### DIFF
--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -152,7 +152,10 @@ const Language = ({code, name, status, translatedName}) => {
           }}
           href={`https://github.com/reactjs/${prefix}reactjs.org/`}
           target="_blank"
-          rel="noopener">
+          rel="noopener"
+          lang={prefix}
+          hreflang={prefix}
+>
           Contribute
         </a>
       </div>


### PR DESCRIPTION
I wanted to add `lang` and `hreflang` to the link element for translated languages.  `Lang` is used by screen readers to switch language profiles to provide the correct accent and pronunciation.

>If you have multiple versions of a page for different languages or regions, tell Google about these different variations. Doing so will help Google Search point users to the most appropriate version of your page by language or region.
> Note that even without taking action, Google might still find alternate language versions of your page, but it is usually best for you to explicitly indicate your language- or region-specific pages.

Source: https://support.google.com/webmasters/answer/189077?hl=en



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
