### PR TITLE
[DOCS] Class components - updates?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Instead, **do** write this:
 
 ```js
 class MyComponent extends React.Component {
-  this.state = {value: ''};
+  state = {value: ''};
   
   handleChange(e) {
     this.setState({value: e.target.value});

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,11 +71,8 @@ Instead, **do** write this:
 
 ```js
 class MyComponent extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleChange = this.handleChange.bind(this);
-    this.state = {value: ''};
-  }
+  this.state = {value: ''};
+  
   handleChange(e) {
     this.setState({value: e.target.value});
   }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The documentation is divided into several sections with a different tone and pur
 
 ### Make the change
 
-1. Follow the "Running locally" instructions
+1. Follow the "[Running locally](#running-locally)" instructions
 1. Save the files and check in the browser
   1. Changes to React components in `src` will hot-reload
   1. Changes to markdown files in `content` will hot-reload


### PR DESCRIPTION
__Dont Merge I'm looking for some feedback / review__

copying issue #2031 content below: 👇 

There seems to be confusion on how to write class components in the docs. Using this as a starting point for other pages which may need to be updated.

There is a mixture of `function` declaration and `class` components in the docs which can be confusing as when someone may __want__ or __need__ to use either method. Since the release of hooks, the docs should have a new site version release (similar to how Babel has site versions) with the updated, preferred way to write components backed by the core team.

in [CONTRIBUTING.md](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#dont-use-features-that-arent-standardized-yet), it shows that you should write classes with a constructor, but the Blog post titled "[Update on Async Rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state)" seems to prefer the former method of writing components.

Can this be solidified and added to the docs where necessary? Will there be a need to have a new site version with focus on `function` declaration components?

🥇 
