### PR TITLE
Add lang and hreflang to language pages for screen reader UX

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -149,8 +149,7 @@ Only ever use CSS that removes this outline, for example by setting `outline: 0`
 
 Provide a mechanism to allow users to skip past navigation sections in your application as this assists and speeds up keyboard navigation.
 
-Skiplinks or Skip Navigation Links are hidden navigation links that only become visible when keyboard users interact with the page. They are very easy to implement with
-internal page anchors and some styling:
+Skiplinks or Skip Navigation Links are hidden navigation links that only become visible when keyboard users interact with the page. They are very easy to implement with internal page anchors and some styling:
 
 - [WebAIM - Skip Navigation Links](https://webaim.org/techniques/skipnav/)
 
@@ -162,8 +161,7 @@ Read more about the use of these elements to enhance accessibility here:
 
 ### Programmatically managing focus {#programmatically-managing-focus}
 
-Our React applications continuously modify the HTML DOM during runtime, sometimes leading to keyboard focus being lost or set to an unexpected element. In order to repair this,
-we need to programmatically nudge the keyboard focus in the right direction. For example, by resetting keyboard focus to a button that opened a modal window after that modal window is closed.
+Our React applications continuously modify the HTML DOM during runtime, sometimes leading to keyboard focus being lost or set to an unexpected element. In order to repair this, we need to programmatically nudge the keyboard focus in the right direction. For example, by resetting keyboard focus to a button that opened a modal window after that modal window is closed.
 
 MDN Web Docs takes a look at this and describes how we can build [keyboard-navigable JavaScript widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets).
 
@@ -201,8 +199,7 @@ Then we can focus it elsewhere in our component when needed:
  }
  ```
 
-Sometimes a parent component needs to set focus to an element in a child component. We can do this by [exposing DOM refs to parent components](/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components)
-through a special prop on the child component that forwards the parent's ref to the child's DOM node.
+Sometimes a parent component needs to set focus to an element in a child component. We can do this by [exposing DOM refs to parent components](/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components) through a special prop on the child component that forwards the parent's ref to the child's DOM node.
 
 ```javascript{4,12,16}
 function CustomTextInput(props) {
@@ -229,12 +226,10 @@ class Parent extends React.Component {
 this.inputElement.current.focus();
 ```
 
-When using a HOC to extend components, it is recommended to [forward the ref](/docs/forwarding-refs.html) to the wrapped component using the `forwardRef` function of React. If a third party HOC
-does not implement ref forwarding, the above pattern can still be used as a fallback.
+When using a HOC to extend components, it is recommended to [forward the ref](/docs/forwarding-refs.html) to the wrapped component using the `forwardRef` function of React. If a third party HOC does not implement ref forwarding, the above pattern can still be used as a fallback.
 
 A great focus management example is the [react-aria-modal](https://github.com/davidtheclark/react-aria-modal). This is a relatively rare example of a fully accessible modal window. Not only does it set initial focus on
-the cancel button (preventing the keyboard user from accidentally activating the success action) and trap keyboard focus inside the modal, it also resets focus back to the element that
-initially triggered the modal.
+the cancel button (preventing the keyboard user from accidentally activating the success action) and trap keyboard focus inside the modal, it also resets focus back to the element that initially triggered the modal.
 
 >Note:
 >
@@ -243,8 +238,7 @@ initially triggered the modal.
 
 ## Mouse and pointer events {#mouse-and-pointer-events}
 
-Ensure that all functionality exposed through a mouse or pointer event can also be accessed using the keyboard alone. Depending only on the pointer device will lead to many cases where
-keyboard users cannot use your application.
+Ensure that all functionality exposed through a mouse or pointer event can also be accessed using the keyboard alone. Depending only on the pointer device will lead to many cases where keyboard users cannot use your application.
 
 To illustrate this, let's look at a prolific example of broken accessibility caused by click events. This is the outside click pattern, where a user can disable an opened popover by clicking outside the element.
 
@@ -301,8 +295,7 @@ constructor(props) {
 }
 ```
 
-This may work fine for users with pointer devices, such as a mouse, but operating this with the keyboard alone leads to broken functionality when tabbing to the next element
-as the `window` object never receives a `click` event. This can lead to obscured functionality which blocks users from using your application.
+This may work fine for users with pointer devices, such as a mouse, but operating this with the keyboard alone leads to broken functionality when tabbing to the next element as the `window` object never receives a `click` event. This can lead to obscured functionality which blocks users from using your application.
 
 <img src="../images/docs/outerclick-with-keyboard.gif" alt="A toggle button opening a popover list implemented with the click outside pattern and operated with the keyboard showing the popover not being closed on blur and it obscuring other screen elements." />
 
@@ -368,18 +361,15 @@ class BlurExample extends React.Component {
 }
 ```
 
-This code exposes the functionality to both pointer device and keyboard users. Also note the added `aria-*` props to support screen-reader users. For simplicity's sake
-the keyboard events to enable `arrow key` interaction of the popover options have not been implemented.
+This code exposes the functionality to both pointer device and keyboard users. Also note the added `aria-*` props to support screen-reader users. For simplicity's sake the keyboard events to enable `arrow key` interaction of the popover options have not been implemented.
 
 <img src="../images/docs/blur-popover-close.gif" alt="A popover list correctly closing for both mouse and keyboard users." />
 
-This is one example of many cases where depending on only pointer and mouse events will break functionality for keyboard users. Always testing with the keyboard will immediately
-highlight the problem areas which can then be fixed by using keyboard aware event handlers.
+This is one example of many cases where depending on only pointer and mouse events will break functionality for keyboard users. Always testing with the keyboard will immediately highlight the problem areas which can then be fixed by using keyboard aware event handlers.
 
 ## More Complex Widgets {#more-complex-widgets}
 
-A more complex user experience should not mean a less accessible one. Whereas accessibility is most easily achieved by coding as close to HTML as possible,
-even the most complex widget can be coded accessibly.
+A more complex user experience should not mean a less accessible one. Whereas accessibility is most easily achieved by coding as close to HTML as possible, even the most complex widget can be coded accessibly.
 
 Here we require knowledge of [ARIA Roles](https://www.w3.org/TR/wai-aria/#roles) as well as [ARIA States and Properties](https://www.w3.org/TR/wai-aria/#states_and_properties).
 These are toolboxes filled with HTML attributes that are fully supported in JSX and enable us to construct fully accessible, highly functional React components.
@@ -438,16 +428,13 @@ By far the easiest and also one of the most important checks is to test if your 
 
 ### Development assistance {#development-assistance}
 
-We can check some accessibility features directly in our JSX code. Often intellisense checks are already provided in JSX aware IDE's for the ARIA roles, states and properties. We also
-have access to the following tool:
+We can check some accessibility features directly in our JSX code. Often intellisense checks are already provided in JSX aware IDE's for the ARIA roles, states and properties. We also have access to the following tool:
 
 #### eslint-plugin-jsx-a11y {#eslint-plugin-jsx-a11y}
 
-The [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) plugin for ESLint provides AST linting feedback regarding accessibility issues in your JSX. Many
-IDE's allow you to integrate these findings directly into code analysis and source code windows.
+The [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) plugin for ESLint provides AST linting feedback regarding accessibility issues in your JSX. Many IDE's allow you to integrate these findings directly into code analysis and source code windows.
 
-[Create React App](https://github.com/facebookincubator/create-react-app) has this plugin with a subset of rules activated. If you want to enable even more accessibility rules,
-you can create an `.eslintrc` file in the root of your project with this content:
+[Create React App](https://github.com/facebookincubator/create-react-app) has this plugin with a subset of rules activated. If you want to enable even more accessibility rules, you can create an `.eslintrc` file in the root of your project with this content:
 
   ```json
   {

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -29,7 +29,7 @@ const alternatePages = canonicalUrl => {
   const pages = languagesToLinkTo.map(language => (
     <link
       rel="alternate"
-      hreflang={language.code}
+      hreflang={language.code === 'en' ? 'x-default' : language.code}
       href={canonicalUrl.replace(
         urlRoot,
         `https://${

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -28,8 +28,9 @@ const completeLanguages = languages.filter(language => {
 const alternatePages = canonicalUrl => {
   return completeLanguages.map(language => (
     <link
+      key={('alt-', language.code)}
       rel="alternate"
-      hreflang={language.code === 'en' ? 'x-default' : language.code}
+      hreflang={language.code}
       href={canonicalUrl.replace(
         urlRoot,
         `https://${
@@ -38,6 +39,10 @@ const alternatePages = canonicalUrl => {
       )}
     />
   ));
+};
+
+const defaultPage = canonicalUrl => {
+  return canonicalUrl.replace(urlRoot, 'https://reactjs.org');
 };
 
 const TitleAndMetaTags = ({title, ogDescription, canonicalUrl}: Props) => {
@@ -53,6 +58,13 @@ const TitleAndMetaTags = ({title, ogDescription, canonicalUrl}: Props) => {
       />
       <meta property="fb:app_id" content="623268441017527" />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {canonicalUrl && (
+        <link
+          rel="alternate"
+          href={defaultPage(canonicalUrl)}
+          hreflang="x-default"
+        />
+      )}
       {canonicalUrl && alternatePages(canonicalUrl)}
     </Helmet>
   );

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -7,6 +7,9 @@
 
 import Helmet from 'react-helmet';
 import React from 'react';
+import {urlRoot} from 'site-constants';
+// $FlowFixMe This is a valid path
+import languages from '../../../content/languages.yml';
 
 const defaultDescription = 'A JavaScript library for building user interfaces';
 
@@ -14,6 +17,28 @@ type Props = {
   title: string,
   ogDescription: string,
   canonicalUrl: string,
+};
+
+// only provide alternate links to pages in languages where 95-100% of core content has been translated
+// which is determined by status enum of 2
+const languagesToLinkTo = languages.filter(language => {
+  return language.status == 2;
+});
+
+const alternatePages = canonicalUrl => {
+  const pages = languagesToLinkTo.map(language => (
+    <link
+      rel="alternate"
+      hreflang={language.code}
+      href={canonicalUrl.replace(
+        urlRoot,
+        `https://${
+          language.code === 'en' ? '' : `${language.code}.`
+        }reactjs.org`,
+      )}
+    />
+  ));
+  return pages;
 };
 
 const TitleAndMetaTags = ({title, ogDescription, canonicalUrl}: Props) => {
@@ -29,6 +54,7 @@ const TitleAndMetaTags = ({title, ogDescription, canonicalUrl}: Props) => {
       />
       <meta property="fb:app_id" content="623268441017527" />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {canonicalUrl && alternatePages(canonicalUrl)}
     </Helmet>
   );
 };

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -152,7 +152,10 @@ const Language = ({code, name, status, translatedName}) => {
           }}
           href={`https://github.com/reactjs/${prefix}reactjs.org/`}
           target="_blank"
-          rel="noopener">
+          rel="noopener"
+          lang={prefix}
+          hreflang={prefix}
+>
           Contribute
         </a>
       </div>

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -106,6 +106,7 @@ const LanguagesGrid = ({languages}) => (
 
 const Language = ({code, name, status, translatedName}) => {
   const prefix = code === 'en' ? '' : `${code}.`;
+  const hrefLang = code === 'en' ? 'x-default' : code;
 
   return (
     <li
@@ -144,7 +145,7 @@ const Language = ({code, name, status, translatedName}) => {
             href={`https://${prefix}reactjs.org/`}
             rel="nofollow"
             lang={code}
-            hrefLang={code}>
+            hrefLang={hrefLang}>
             {translatedName}
           </a>
         )}

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -106,7 +106,6 @@ const LanguagesGrid = ({languages}) => (
 
 const Language = ({code, name, status, translatedName}) => {
   const prefix = code === 'en' ? '' : `${code}.`;
-  const hrefLang = code === 'en' ? 'x-default' : code;
 
   return (
     <li
@@ -145,7 +144,7 @@ const Language = ({code, name, status, translatedName}) => {
             href={`https://${prefix}reactjs.org/`}
             rel="nofollow"
             lang={code}
-            hrefLang={hrefLang}>
+            hrefLang={code}>
             {translatedName}
           </a>
         )}

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -140,7 +140,11 @@ const Language = ({code, name, status, translatedName}) => {
         }}>
         {status === 0 && translatedName}
         {status > 0 && (
-          <a href={`https://${prefix}reactjs.org/`} rel="nofollow">
+          <a
+            href={`https://${prefix}reactjs.org/`}
+            rel="nofollow"
+            lang={code}
+            hrefLang={code}>
             {translatedName}
           </a>
         )}
@@ -152,10 +156,7 @@ const Language = ({code, name, status, translatedName}) => {
           }}
           href={`https://github.com/reactjs/${prefix}reactjs.org/`}
           target="_blank"
-          rel="noopener"
-          lang={prefix}
-          hreflang={prefix}
->
+          rel="noopener">
           Contribute
         </a>
       </div>


### PR DESCRIPTION
Previous HTML
`<a href="https://fr.reactjs.org/" rel="nofollow">Français</a>`
Updated HTML
`<a href="https://fr.reactjs.org/" rel="nofollow" lang="fr" hreflang="fr">Français</a>`

I wanted to add `lang` and `hreflang` to the link element for translated languages at https://reactjs.org/languages.  `Lang` is used by screen readers to switch language profiles to provide the correct accent and pronunciation and `hreflang` seems to help with SEO

>If you have multiple versions of a page for different languages or regions, tell Google about these different variations. Doing so will help Google Search point users to the most appropriate version of your page by language or region.
> Note that even without taking action, Google might still find alternate language versions of your page, but it is usually best for you to explicitly indicate your language- or region-specific pages.

Source: https://support.google.com/webmasters/answer/189077?hl=en



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
