### PR TITLE
Some fixes to the Accessibility guide

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -248,7 +248,7 @@ This is typically implemented by attaching a `click` event to the `window` objec
 
 ```javascript{12-14,26-30}
 class OuterClickExample extends React.Component {
-constructor(props) {
+  constructor(props) {
     super(props);
 
     this.state = { isOpen: false };
@@ -299,7 +299,7 @@ This may work fine for users with pointer devices, such as a mouse, but operatin
 
 <img src="../images/docs/outerclick-with-keyboard.gif" alt="A toggle button opening a popover list implemented with the click outside pattern and operated with the keyboard showing the popover not being closed on blur and it obscuring other screen elements." />
 
-The same functionality can be achieved by using an appropriate event handlers instead, such as `onBlur` and `onFocus`:
+The same functionality can be achieved by using appropriate event handlers instead, such as `onBlur` and `onFocus`:
 
 ```javascript{19-29,31-34,37-38,40-41}
 class BlurExample extends React.Component {


### PR DESCRIPTION
In the "Accessibility" guide,

* Added missing code indentation
* Removed an extra "an" determiner in a sentence.