### PR TITLE
Add link to `yarn` in how-to-contribute guide

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -79,7 +79,7 @@ The core team is monitoring for pull requests. We will review your pull request 
 **Before submitting a pull request,** please make sure the following is done:
 
 1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
-2. Run `yarn` in the repository root.
+2. Run [`yarn`](https://yarnpkg.com/) in the repository root.
 3. If you've fixed a bug or added code that should be tested, add tests!
 4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
 5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.


### PR DESCRIPTION
I did not have `yarn` installed on my machine and had to go to yarnpkg.com to install it. Having a direct link would hopefully remove confusion for future contributors.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
