### PR TITLE
Fix ref creation in CustomTextInput component

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -168,7 +168,7 @@ You can, however, **use the `ref` attribute inside a function component** as lon
 ```javascript{2,3,6,13}
 function CustomTextInput(props) {
   // textInput must be declared here so the ref can refer to it
-  let textInput = React.createRef();
+  let textInput = useRef(null);
 
   function handleClick() {
     textInput.current.focus();


### PR DESCRIPTION
Change React.createRef() to useRef(null)



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
