### PR TITLE
Remove warning

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -102,7 +102,6 @@ If calling `bind` annoys you, there are two ways you can get around this. If you
 ```js{2-6}
 class LoggingButton extends React.Component {
   // This syntax ensures `this` is bound within handleClick.
-  // Warning: this is *experimental* syntax.
   handleClick = () => {
     console.log('this is:', this);
   }


### PR DESCRIPTION
This syntax is no longer experimental, so the warning can be removed.