### PR TITLE
[docs] Updated required node and npm versions to match CRA docs in 'docs/create-a-new-react-app.html'

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -39,7 +39,7 @@ The React team primarily recommends these solutions:
 
 [Create React App](https://github.com/facebookincubator/create-react-app) is a comfortable environment for **learning React**, and is the best way to start building **a new [single-page](/docs/glossary.html#single-page-application) application** in React.
 
-It sets up your development environment so that you can use the latest JavaScript features, provides a nice developer experience, and optimizes your app for production. You’ll need to have Node >= 6 and npm >= 5.2 on your machine. To create a project, run:
+It sets up your development environment so that you can use the latest JavaScript features, provides a nice developer experience, and optimizes your app for production. You’ll need to have Node >= 8.10 and npm >= 5.6 on your machine. To create a project, run:
 
 ```bash
 npx create-react-app my-app


### PR DESCRIPTION
Updated 'Node >= 6' to 'Node >= 8.10' and 'NPM >= 5.2' to 'NPM >= 5.6'

This change brings the docs into alignment with the create-react-app getting started guide for the current version (v3.0.1) as well as the console error message when running `npx create-react-app my-app` on a Node version below 8.10. See: https://facebook.github.io/create-react-app/docs/getting-started