### PR TITLE
Fixed broken link to discuss.react.org

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -50,7 +50,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 ### How to Get in Touch {#how-to-get-in-touch}
 
 * IRC: [#reactjs on freenode](https://webchat.freenode.net/?channels=reactjs)
-* [Discussion Forums](https://reactjs.org/community/support.html#popular-discussion-forums)
+* [Discussion forums](https://reactjs.org/community/support.html#popular-discussion-forums)
 
 There is also [an active community of React users on the Discord chat platform](https://www.reactiflux.com/) in case you need help with React.
 

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -50,7 +50,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 ### How to Get in Touch {#how-to-get-in-touch}
 
 * IRC: [#reactjs on freenode](https://webchat.freenode.net/?channels=reactjs)
-* Discussion forum: [discuss.reactjs.org](https://discuss.reactjs.org/)
+* [Discussion Forums](https://reactjs.org/community/support.html#popular-discussion-forums)
 
 There is also [an active community of React users on the Discord chat platform](https://www.reactiflux.com/) in case you need help with React.
 


### PR DESCRIPTION
Potential fix for #2080 

When navigating to https://reactjs.org/docs/how-to-contribute.html#how-to-get-in-touch you will realize that the `discuss.reactjs.org` (https://discuss.reactjs.org/) link times out.
![image](https://user-images.githubusercontent.com/17889671/60379353-b3935c00-99ff-11e9-8d7a-b6cede634358.png)

I'm proposing to simply link to https://reactjs.org/community/support.html#popular-discussion-forums as a workaround.

Quick test link: https://deploy-preview-2107--reactjs.netlify.com/docs/how-to-contribute.html#how-to-get-in-touch