### PR TITLE
Update in the Avatar component

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -161,11 +161,11 @@ This component can be tricky to change because of all the nesting, and it is als
 First, we will extract `Avatar`:
 
 ```js{3-6}
-function Avatar(props) {
+function Avatar(user) {
   return (
     <img className="Avatar"
-      src={props.user.avatarUrl}
-      alt={props.user.name}
+      src={user.avatarUrl}
+      alt={user.name}
     />
   );
 }


### PR DESCRIPTION
It seems wrong to have both props and user in it. In the next step we already pass in the component props.author, which have name and avatarUrl attributes. So the user must be instead of props, isn't it?



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
