### PR TITLE
fix(Blog): Post title updated to correct word for yes word in Spanish

### DIFF
--- a/content/blog/2019-02-23-is-react-translated-yet.md
+++ b/content/blog/2019-02-23-is-react-translated-yet.md
@@ -1,5 +1,5 @@
 ---
-title: "Is React Translated Yet? ¡Sí! Sim! はい！"
+title: "Is React Translated Yet? ¡Sí! Sím! はい！"
 author: [tesseralis]
 ---
 


### PR DESCRIPTION
The blog title is currently having **`¡Sí! Sim!`** meaning **`Yes! Sim!`** as per Google translate. The correct string for **`Yes! Yes!`** should be **`¡Sí! Sím!`**