### PR TITLE
[docs] Add missing events to docs/events page

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -74,8 +74,8 @@ The event handlers below are triggered by an event in the bubbling phase. To reg
 - [Composition Events](#composition-events)
 - [Keyboard Events](#keyboard-events)
 - [Focus Events](#focus-events)
-- [Form Events](#for
-m-events)
+- [Form Events](#form-events)
+- [Generic Events](#generic-events)
 - [Mouse Events](#mouse-events)
 - [Pointer Events](#pointer-events)
 - [Selection Events](#selection-events)

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -74,7 +74,8 @@ The event handlers below are triggered by an event in the bubbling phase. To reg
 - [Composition Events](#composition-events)
 - [Keyboard Events](#keyboard-events)
 - [Focus Events](#focus-events)
-- [Form Events](#form-events)
+- [Form Events](#for
+m-events)
 - [Mouse Events](#mouse-events)
 - [Pointer Events](#pointer-events)
 - [Selection Events](#selection-events)
@@ -176,10 +177,20 @@ DOMEventTarget relatedTarget
 Event names:
 
 ```
-onChange onInput onInvalid onSubmit
+onChange onInput onInvalid onReset onSubmit 
 ```
 
 For more information about the onChange event, see [Forms](/docs/forms.html).
+
+* * *
+
+### Generic Events {#generic-events}
+
+Event names:
+
+```
+onError onLoad
+```
 
 * * *
 


### PR DESCRIPTION
Added missing `onReset` event to Form Events –– (https://reactjs.org/docs/events.html#form-events)
Created Generic Events subsection, and added `onError` & `onLoad` events –– (https://reactjs.org/docs/events.html#generic-events)

Based on suggestion by @sophiebits  in following thread:
https://github.com/facebook/react/issues/1718#issuecomment-122622933



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
