### PR TITLE
Revert "fix(Blog): Post title updated to correct word for yes word in…

### DIFF
--- a/content/blog/2019-02-23-is-react-translated-yet.md
+++ b/content/blog/2019-02-23-is-react-translated-yet.md
@@ -1,5 +1,5 @@
 ---
-title: "Is React Translated Yet? ¡Sí! Sím! はい！"
+title: "Is React Translated Yet? ¡Sí! Sim! はい！"
 author: [tesseralis]
 ---
 


### PR DESCRIPTION
This revert the misspelling added by #2122

The problem is that the word in question is not in Spanish, but Portuguese.

This reverts commit 06a029d53d7ee7e5e717dd39450ac6af1ff554e5.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
