### PR TITLE
[Documentation] Fix: Update link to Chrome Accessibility Inspector documentation

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -468,7 +468,7 @@ to assistive technology, such as screen readers.
 In some browsers we can easily view the accessibility information for each element in the accessibility tree:
 
 - [Using the Accessibility Inspector in Firefox](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector)
-- [Activate the Accessibility Inspector in Chrome](https://gist.github.com/marcysutton/0a42f815878c159517a55e6652e3b23a)
+- [Using the Accessibility Inspector in Chrome](https://developers.google.com/web/tools/chrome-devtools/accessibility/reference#pane)
 - [Using the Accessibility Inspector in OS X Safari](https://developer.apple.com/library/content/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html)
 
 ### Screen readers {#screen-readers}


### PR DESCRIPTION
This PR updates the Chrome Accessibility Inspector link to [the Chrome Dev Tools documentation](https://developers.google.com/web/tools/chrome-devtools/accessibility/reference#pane).

The change reflects that the Accessibility Pane is no longer an Experimental Feature in Chrome.