### PR TITLE
Update docs about an existence of .elementType

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -57,6 +57,9 @@ MyComponent.propTypes = {
   // A React element.
   optionalElement: PropTypes.element,
 
+  // A React element type (ie. MyComponent).
+  optionalElementType: PropTypes.elementType,
+  
   // You can also declare that a prop is an instance of a class. This uses
   // JS's instanceof operator.
   optionalMessage: PropTypes.instanceOf(Message),


### PR DESCRIPTION
Hi, I've met the same issue on [here](https://github.com/facebook/prop-types/issues/200) at storybook and found the following [PR](https://github.com/facebook/prop-types/pull/211) that adds the `elementType` feature. It could find the doc on [npm](https://www.npmjs.com/package/prop-types), but not the official react site.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
