### PR TITLE
Add React Knowledgeable (Singapore) to meetups

### DIFF
--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -107,6 +107,9 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 ## Scotland (UK) {#scotland-uk}
 * [Edinburgh](https://www.meetup.com/React-Scotland/)
 
+## Singapore {#singapore}
+* [Singapore - React Knowledgeable](https://reactknowledgeable.org/)
+
 ## Spain {#spain}
 * [Barcelona](https://www.meetup.com/ReactJS-Barcelona/)
 


### PR DESCRIPTION
What does this PR do?
---
This PR adds a Singapore based meetup [React Knowledgeable](https://reactknowledgeable.org/) to the meetups page in the doc.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
