### PR TITLE
Update podcasts.md

### DIFF
--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -12,7 +12,7 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 - [The React Podcast](https://reactpodcast.simplecast.fm/) - The podcast about everything React.js, hosted by [React Training](https://reacttraining.com)
 
-- [JavaScript Air](https://javascriptair.com/) - All about JavaScript (currently not producing new episodes)
+- [React Round Up](https://devchat.tv/react-round-up/) - A Devchat.tv general podcast and weekly discussion among ReactJS developers. 
 
 - [React 30](https://react30.com/) - A 30-minute podcast all about React (moved to [The React Podcast](https://reactpodcast.simplecast.fm/)).
 
@@ -20,7 +20,111 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 ## Episodes {#episodes}
 
-- [CodeWinds Episode 4](https://codewinds.com/podcast/004.html) - Pete Hunt talks with Jeff Barczewski about React.
+- [JavaScript Air #005](https://javascriptair.com/episodes/2016-01-13/) - Firefox DevTools, React, and Redux
 
+- [JavaScript Air #011](https://javascriptair.com/episodes/2016-02-23/) - Live at React Conf
 
-- [JavaScript Jabber 73](https://devchat.tv/js-jabber/073-jsj-react-with-pete-hunt-and-jordan-walke) - Pete Hunt and Jordan Walke talk about React.
+- [JavaScript Air #037](https://javascriptair.com/episodes/2016-08-25/) - On-site at React Rally
+
+- [JavaScript Air #046](https://javascriptair.com/episodes/2016-10-26/) - React Native
+
+- [Future of Coding #011](https://futureofcoding.org/episodes/011) - How ReactJS was created - with Pete Hunt
+
+- [CodeWinds #004](https://codewinds.com/podcast/004.html) - Pete Hunt, Software Engineer for Facebook, discussing Facebook's open source js UI framework, React
+
+- [CodePen Radio #095](https://blog.codepen.io/2016/06/21/095-react/) - React
+
+- [CodePen Radio #125](https://blog.codepen.io/2017/04/11/125-building-projects-react/) - Building Projects with React
+
+- [Toolsday Developer Podcast #090](https://podtail.com/en/podcast/toolsday/90-react-hooks/) - React Hooks
+
+- [JavaScript Jabber #073](https://devchat.tv/js-jabber/073-jsj-react-with-pete-hunt-and-jordan-walke) - Pete Hunt and Jordan Walke talk about React.
+
+- [JavaScript Jabber #146](https://devchat.tv/js-jabber/146-jsj-react-with-christopher-chedeau-and-jordan-walke/) - React with Christopher Chedeau and Jordan Walke
+
+- [JavaScript Jabber #157](https://devchat.tv/js-jabber/157-moving-your-rendering-engine-to-react-with-amit-kaufman-and-avi-marcus/) - Moving Your Rendering Engine to React with Amit Kaufman and Avi Marcus
+
+- [JavaScript Jabber #179](https://devchat.tv/js-jabber/179-jsj-redux-and-react-with-dan-abramov/) - redux and React with Dan Abramov
+
+- [JavaScript Jabber #227](https://devchat.tv/js-jabber/227-jsj-fostering-community-through-react-with-benjamin-dunphy-berkeley-martinez-and-ian-sinnott/) - Fostering Community Through React with Benjamin Dunphy, Berkeley Martinez, and Ian Sinnott
+
+- [JavaScript Jabber #237](https://devchat.tv/js-jabber/237-jsj-clls-ember-angular-and-react-with-tracy-lee/) - Ember Angular and React with Tracy Lee
+
+- [JavaScript Jabber #245](https://devchat.tv/js-jabber/jsj-245-styled-components-and-react-boilerplate-with-max-stoiber/) - Styled Components and React-Boilerplate with Max Stoiber
+
+- [JavaScript Jabber #269](https://devchat.tv/js-jabber/jsj-269-reusable-react-javascript-components-cory-house/) - Reusable React and JavaScript Components with Cory House
+
+- [JavaScript Jabber #296](https://devchat.tv/js-jabber/jsj-296-changes-react-license-azat-mardan/) - Pete Hunt and Jordan Walke talk about React.
+
+- [JavaScript Jabber #304](https://devchat.tv/js-jabber/jsj-304-react-the-big-picture/) - React: The Big Picture
+
+- [ShopTalk Show Episode #369](https://shoptalkshow.com/episodes/369/) - Chris and Dave talk about jamstack, React and what it means to call someone a fullstack developer.
+
+- [ShopTalk Show Episode #302](https://shoptalkshow.com/episodes/302/) - React Drama with guest Michael Jackson
+
+- [ShopTalk Show Episode #327](https://shoptalkshow.com/episodes/327/) - Changes in React and the license with Azat Mardan
+
+- [Syntax.fm Episode #001](https://syntax.fm/show/001/react-tools) - React Tools
+
+- [Syntax.fm Episode #066](https://syntax.fm/show/066/the-react-episode) - The React Episode
+
+- [Syntax.fm Episode #092](https://syntax.fm/show/092/react-hooks) - React Hooks
+
+- [Syntax.fm Episode #127](https://syntax.fm/show/127/hasty-treat-react-suspense) - React Suspense
+
+- [Syntax.fm Episode #134](https://syntax.fm/show/134/syntax-live-react-edition) - Syntax Live React Edition
+
+- [Full Stack Radio #079](http://www.fullstackradio.com/79) - Kent C. Dodds - Building Reusable React Components with Render Props
+
+- [Full Stack Radio #099](http://www.fullstackradio.com/99) - Tim Neutkens - Building React Apps with Next.js
+
+- [Full Stack Radio #114](http://www.fullstackradio.com/114) - Sebastian De Deyne - React for Vue Developers
+
+- [Full Stack Radio #115](http://www.fullstackradio.com/115) - Jason Lengstorf - Gatsby for Skeptics
+
+- [Software Engineering Daily (July 27, 2015)](https://softwareengineeringdaily.com/2015/07/27/react-js-with-sebastian-markbage-and-christopher-chedeau/) - React.js with Sebastian Markbage and Christopher Chedeau
+
+- [Software Engineering Daily (September 16, 2015)](https://softwareengineeringdaily.com/2015/09/16/react-router-flux-and-web-debates-with-michael-jackson/) - React Router, Flux, and Web Debates with Michael Jackson
+
+- [Software Engineering Daily (September 17, 2015)](https://softwareengineeringdaily.com/2015/09/17/react-at-facebook-with-ben-alpert/) - React at Facebook with Ben Alpert
+
+- [Software Engineering Daily (September 18, 2015)](https://softwareengineeringdaily.com/2015/09/18/flux-redux-and-react-hot-loader-with-dan-abramov/) - Flux, Redux, and React Hot Loader with Dan Abramov
+
+- [Software Engineering Daily (December 3, 2015)](https://softwareengineeringdaily.com/2015/12/03/the-future-of-react-with-christopher-chedeau/) - The Future of React with Christopher Chedeau
+
+- [Software Engineering Daily (February 22, 2016)](https://softwareengineeringdaily.com/2016/02/22/react-js-conf-with-brent-vatne/) - React.js Conf with Brent Vatne
+
+- [Software Engineering Daily (May 9, 2016)](https://softwareengineeringdaily.com/2016/05/09/react-data-flow-jared-forsyth/) - React Data Flow with Jared Forsyth
+
+- [Software Engineering Daily (January 19, 2017)](https://softwareengineeringdaily.com/2017/01/19/inferno-with-dominic-gannaway/) - Inferno and React with Dominic Gannaway
+
+- [Software Engineering Daily (April 14, 2017)](https://softwareengineeringdaily.com/2017/04/14/facebook-open-source-with-tom-occhino/) - Facebook Open Source with Tom Occhino
+
+- [Software Engineering Daily (May 24, 2017)](https://softwareengineeringdaily.com/2017/05/24/relay-modern-with-lee-byron-and-joe-savona/) - Relay Modern with Lee Byron and Joe Savona
+
+- [Software Engineering Daily (October 2, 2017)](https://softwareengineeringdaily.com/2017/10/02/reactvr-with-andrew-imm/) - ReactVR with Andrew Imm
+
+- [Software Engineering Daily (November 30, 2017)](https://softwareengineeringdaily.com/2017/11/30/react-and-graphql-at-new-york-times/) - React and GraphQL at New York Times
+
+- [Software Engineering Daily (December 21, 2017)](https://softwareengineeringdaily.com/2017/12/21/react-components-with-max-stoiber/) - React Components with Max Stoiber
+
+- [Software Engineering Daily (April 19, 2018)](https://softwareengineeringdaily.com/2018/04/19/react-stack-with-g2i-team/) - React Stack with G2i Team
+
+- [Software Engineering Daily (December 14, 2018)](https://softwareengineeringdaily.com/2018/12/14/full-stack-javascript-with-wes-bos/) - Full Stack JavaScript with Wes Bos
+
+- [Software Engineering Daily (December 20, 2018)](https://softwareengineeringdaily.com/2018/12/20/modern-front-end-react-graphql-vr-webassembly-with-adam-conrad/) - Modern Front End: React, GraphQL, VR, WebAssembly with Adam Conrad
+
+- [Software Engineering Daily (January 23, 2019)](https://softwareengineeringdaily.com/2019/01/23/storybook-ui-engineering-with-zoltan-olah/) - Storybook: UI Engineering with Zoltan Olah
+
+- [Software Engineering Daily (May 16, 2019)](https://softwareengineeringdaily.com/2019/05/16/facebook-react-with-dan-abramov/) - Facebook React with Dan Abramov
+
+- [Software Engineering Daily (July 18, 2019)](https://softwareengineeringdaily.com/2019/07/18/facebook-open-source-management-with-tom-occhino/) - 
+Facebook Open Source Management with Tom Occhino
+
+- [DotNetRocks #1258](https://dotnetrocks.com/?show=1258) - Reusable React with Chris Canal
+
+- [DotNetRocks #1341](https://dotnetrocks.com/?show=1341) - React for Windows with Matthew Podwysocki and Eric Rozell
+
+- [Eat Sleep Code Podcast](https://www.telerik.com/blogs/react-redux-retrospectives) - React Redux and Retrospectives with Margaret James
+
+- [Eat Sleep Code Podcast](https://www.telerik.com/blogs/podcast-we-discuss-reactjs) - We discuss ReactJS with Cory House


### PR DESCRIPTION
Add an exhaustive list of historical ReactJS related episodes from major JS podcasts
Remove JavaScript Air from dedicated podcast link and highlight only the shows that deal with ReactJS