### PR TITLE
Add React Conf to list of community conferences

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -52,6 +52,11 @@ September 26-28, 2019 in Alicante, Spain
 
 [Website](http://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante)
 
+### React Conf 2019 {#react-conf-2019}
+October 25-26, 2019 in Henderson, Nevada USA
+
+[Website](https://conf.reactjs.org/) - [Twitter](https://twitter.com/reactjs)
+
 ### React Advanced 2019 {#react-advanced-2019}
 October 25, 2019 in London, UK
 

--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -53,7 +53,7 @@ September 26-28, 2019 in Alicante, Spain
 [Website](http://reactalicante.es/) - [Twitter](https://twitter.com/reactalicante) - [Facebook](https://www.facebook.com/ReactAlicante)
 
 ### React Conf 2019 {#react-conf-2019}
-October 25-26, 2019 in Henderson, Nevada USA
+October 24-25, 2019 in Henderson, Nevada USA
 
 [Website](https://conf.reactjs.org/) - [Twitter](https://twitter.com/reactjs)
 


### PR DESCRIPTION
I noticed React Conf wasn't on the list of community conferences. Should it be? I added it here, but it's also not quite a community conference. What do you folks think?