### PR TITLE
docs: document prod vs dev behavior difference in componentDidCatch

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -413,6 +413,12 @@ class ErrorBoundary extends React.Component {
 }
 ```
 
+Production and development builds of React slightly differ in the way `componentDidCatch()` handles errors.
+
+On development, the errors will bubble up to `window`, this means that any `window.onerror` or `window.addEventListener('error', callback)` will intercept the errors that have been caught by `componentDidCatch()`.
+
+On production, instead, the errors will not bubble up, which means any ancestor error handler will only receive errors not explictly caught by `componentDidCatch()`.
+
 > Note
 > 
 > In the event of an error, you can render a fallback UI with `componentDidCatch()` by calling `setState`, but this will be deprecated in a future release.


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This PR aims to document the `componentDidCatch()` behavior described by @gaearon in [this comment](https://github.com/facebook/react/issues/12897#issuecomment-410036991).

I may use some help with the wording of this new paragraph.