### PR TITLE
Add a relevant FAQ link in "Thinking In React"

### DIFF
--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -76,7 +76,7 @@ Refer to the [React docs](/docs/) if you need help executing this step.
 
 ### A Brief Interlude: Props vs State {#a-brief-interlude-props-vs-state}
 
-There are two types of "model" data in React: props and state. It's important to understand the distinction between the two; skim [the official React docs](/docs/interactivity-and-dynamic-uis.html) if you aren't sure what the difference is.
+There are two types of "model" data in React: props and state. It's important to understand the distinction between the two; skim [the official React docs](/docs/state-and-lifecycle.html) if you aren't sure what the difference is. See also [FAQ: What is the difference between state and props?](/docs/faq-state.html#what-is-the-difference-between-state-and-props)
 
 ## Step 3: Identify The Minimal (but complete) Representation Of UI State {#step-3-identify-the-minimal-but-complete-representation-of-ui-state}
 


### PR DESCRIPTION
I think this FAQ entry is more directly relevant to the question of props vs. state. The linked "State and Lifecycle" section (I updated the url from `/docs/interactivity-and-dynamic-uis.html`, which is a redirect, I assume from a previous name) has one sentence comparing them (*State is similar to props, but it is private and fully controlled by the component.*), but it's tucked away and easy to miss.