### PR TITLE
Add General Assembly to Courses

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -47,3 +47,5 @@ permalink: community/courses.html
 - [Tyler McGinnis](https://tylermcginnis.com/courses) - Tyler McGinnis provides access to his courses for a monthly fee. Courses include "React Fundamentals" and "Universal React".
 
 - [Mastering React](https://codewithmosh.com/p/mastering-react/) - Build professional interactive apps with React.
+
+- [React Development at General Assembly](https://generalassemb.ly/education/react-development?where=online) - Learn to leverage React's power in this hands on, project-based course.


### PR DESCRIPTION
Simple markdown change: adding General Assembly's React Development course to Community > Courses.

![image](https://user-images.githubusercontent.com/4118615/62137996-e5286d00-b2b4-11e9-9d8a-e3846c64dfb3.png)
