### PR TITLE
Unmount in tests to ensure Portals are cleaned up

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -99,6 +99,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
   document.body.removeChild(container);
   container = null;
 });


### PR DESCRIPTION
When following the example, my tests never cleaned up Portals that were
created by my components. To make sure that problem is bypassed all
together, make sure the component is unmounted via
`ReactDOM.unmountComponentAtNode` before removing the container from
the DOM.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
