### PR TITLE
Typo fix 'Diffrent' ➡️ 'Different'

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -393,7 +393,7 @@ it("changes value when clicked", () => {
 });
 ```
 
-Diffrent DOM events and their properties are described in [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent). Note that you need to pass `{ bubbles: true }` in each event you create for it to reach the React listener because React automatically delegates events to the document.
+Different DOM events and their properties are described in [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent). Note that you need to pass `{ bubbles: true }` in each event you create for it to reach the React listener because React automatically delegates events to the document.
 
 > Note:
 >


### PR DESCRIPTION
Typo fix 'Diffrent' ➡️ 'Different'



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
