### PR TITLE
Fix typo in React v16.9.0 blog post

### DIFF
--- a/content/blog/2019-08-08-react-v16.9.0.md
+++ b/content/blog/2019-08-08-react-v16.9.0.md
@@ -66,7 +66,7 @@ function FactoryComponent() {
 
 This pattern is confusing because it looks too much like a function component — but it isn't one. (A function component would just return the `<div />` in the above example.)
 
-This pattern was almost never used in the wild, and supporting it causes React to be slightly larger and slower than necessary. So we are deprecating this pattern in 16.9 and logging a warning if it's enountered. If you rely on it, adding `FactoryComponent.prototype = React.Component.prototype` can serve as a workaround. Alternatively, you can convert it to either a class or a function component.
+This pattern was almost never used in the wild, and supporting it causes React to be slightly larger and slower than necessary. So we are deprecating this pattern in 16.9 and logging a warning if it's encountered. If you rely on it, adding `FactoryComponent.prototype = React.Component.prototype` can serve as a workaround. Alternatively, you can convert it to either a class or a function component.
 
 We don't expect most codebases to be affected by this.
 


### PR DESCRIPTION
"enountered" -> "encountered"