### PR TITLE
Update testing-recipes.md with English correction.

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -393,7 +393,7 @@ it("changes value when clicked", () => {
     render(<Toggle onChange={onChange} />, container);
   });
 
-  // get a hold of the button element, and trigger some clicks on it
+  // get ahold of the button element, and trigger some clicks on it
   const button = document.querySelector("[data-testid=toggle]");
   expect(button.innerHTML).toBe("Turn off");
 


### PR DESCRIPTION
"Get a hold" should be the phrasal verb "get ahold". See https://www.quickanddirtytips.com/education/grammar/a-hold-or-ahold?page=1



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
