### PR TITLE
Fix broken link to recipes in Test Utilities document

### DIFF
--- a/content/docs/addons-test-utils.md
+++ b/content/docs/addons-test-utils.md
@@ -124,7 +124,7 @@ it('can render and update a counter', () => {
 
 - Don't forget that dispatching DOM events only works when the DOM container is added to the `document`. You can use a library like [React Testing Library](https://testing-library.com/react) to reduce the boilerplate code.
 
-- The [`recipes`](/docs/recipes.html) document contains more details on how `act()` behaves, with examples and usage.
+- The [`recipes`](/docs/testing-recipes.html) document contains more details on how `act()` behaves, with examples and usage.
 
 * * *
 


### PR DESCRIPTION
Closes #2234
This PR fixes a wrong link to Testing Recipes document.