### PR TITLE
Change variable declaration of ‘newState’ in CodeEditor.js

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -270,7 +270,7 @@ class CodeEditor extends Component {
 
   _updateState(code, showJSX = true) {
     try {
-      let newState = {
+      const newState = {
         compiled: compileES5(code),
         error: null,
       };


### PR DESCRIPTION
I used 'const' instead of 'let' because it was not reassigning a variable 'newState'.

Thank you!