### PR TITLE
Replacing incorrect link - Forms documentation

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -198,7 +198,7 @@ In HTML, an `<input type="file">` lets the user choose one or more files from th
 <input type="file" />
 ```
 
-Because its value is read-only, it is an **uncontrolled** component in React. It is discussed together with other uncontrolled components [later in the documentation](/docs/uncontrolled-components.html#the-file-input-tag).
+Because its value is read-only, it is an **uncontrolled** component in React. It is discussed together with other uncontrolled components [later in the documentation](/docs/uncontrolled-components.html#alternatives-to-controlled-components).
 
 ## Handling Multiple Inputs {#handling-multiple-inputs}
 


### PR DESCRIPTION
A link was redirecting to the same section it was in.

Now it properly forwards to the right part of the documentation, uncontrolled components. 
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
