### PR TITLE
Updated babel installation instructions for Flow

### DIFF
--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -88,13 +88,13 @@ If you manually configured Babel for your project, you will need to install a sp
 If you use Yarn, run:
 
 ```bash
-yarn add --dev babel-preset-flow
+yarn add --dev @babel/preset-flow
 ```
 
 If you use npm, run:
 
 ```bash
-npm install --save-dev babel-preset-flow
+npm install --save-dev @babel/preset-flow
 ```
 
 Then add the `flow` preset to your [Babel configuration](https://babeljs.io/docs/usage/babelrc/). For example, if you configure Babel through `.babelrc` file, it could look like this:
@@ -102,7 +102,7 @@ Then add the `flow` preset to your [Babel configuration](https://babeljs.io/docs
 ```js{3}
 {
   "presets": [
-    "flow",
+    "@babel/preset-flow",
     "react"
   ]
 }


### PR DESCRIPTION
updated how to install babel presets to use the newer namespace conventions that comes with newer versions of Babel, version 7.
My react app kept crashing when I tried installing Flow.
I have updated the docs on Flow's documentation, then I saw the same issue here.

Here is the PR on Flow's docs just in case - https://github.com/facebook/flow/pull/7856



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
