### PR TITLE
Changed binding naming convention for less confusion

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -66,11 +66,11 @@ class Toggle extends React.Component {
     super(props);
     this.state = {isToggleOn: true};
 
-    // This binding is necessary to make `this` work in the callback
-    this.handleClick = this.handleClick.bind(this);
+    // This binding is necessary to make `this` work in the callback    
+    this.handleClick = this.handleClickFunction.bind(this);
   }
 
-  handleClick() {
+  handleClickFunction() {
     this.setState(state => ({
       isToggleOn: !state.isToggleOn
     }));


### PR DESCRIPTION
So the reader will be less confused, he can now know the difference between what is referring to the function and what is to be binded to the button.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
