### PR TITLE
Devtools Docs: Add step to checkout the correct branch

### DIFF
--- a/content/blog/2019-08-15-new-react-devtools.md
+++ b/content/blog/2019-08-15-new-react-devtools.md
@@ -60,6 +60,9 @@ git clone https://github.com/facebook/react-devtools
 
 cd react-devtools
 
+# Checkout the previous release branch
+git checkout v3
+
 # Install dependencies and build the unpacked extension
 yarn install
 yarn build:extension


### PR DESCRIPTION
Include step to checkout v3 branch before building the old devtools extension. The current docs don't specify which branch to checkout before building the old extension.
It is specified in the README at https://github.com/facebook/react-devtools but should probably be specified here too.

https://github.com/reactjs/reactjs.org/blob/master/content/blog/2019-08-15-new-react-devtools.md#how-do-i-get-the-old-version-back

![Screenshot 2019-08-20 at 10 59 05](https://user-images.githubusercontent.com/7782211/63337966-d6742980-c339-11e9-8667-25cf73f139ee.png)

