### PR TITLE
Add reference to persist to SyntheticEvent's API

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -26,6 +26,7 @@ void preventDefault()
 boolean isDefaultPrevented()
 void stopPropagation()
 boolean isPropagationStopped()
+void persist()
 DOMEventTarget target
 number timeStamp
 string type


### PR DESCRIPTION
Since persist() is referred to in the doc as a method for disabling event pooling, that must mean it's part of the SyntheticEvent API.

I'm proposing to state it more explicitly so that there's no doubt for newcomers like me whether it is the SyntheticEvent or the actual JS event that has the method.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
