### PR TITLE
`--dev` option is deprecated

### DIFF
--- a/content/blog/2019-08-15-new-react-devtools.md
+++ b/content/blog/2019-08-15-new-react-devtools.md
@@ -49,7 +49,7 @@ Host nodes (e.g. HTML `<div>`, React Native `<View>`) are *hidden by default*, b
 If you are working with React Native version 60 (or older) you can install the previous release of DevTools from NPM:
 
 ```shell
-npm install --dev react-devtools@^3
+npm install --only=dev react-devtools@^3
 ```
 
 For older versions of React DOM (v0.14 or earlier) you will need to build the extension from source:


### PR DESCRIPTION
> Usage of the `--dev` option is deprecated. Use `--only=dev` instead.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
