### PR TITLE
add the missing lang ..

### DIFF
--- a/content/languages.yml
+++ b/content/languages.yml
@@ -59,6 +59,10 @@
   translated_name: हिन्दी
   code: hi
   status: 0
+- name: Hungarian
+  translated_name: magyar
+  code: hu
+  status: 0
 - name: Armenian
   translated_name: Հայերեն
   code: hy


### PR DESCRIPTION
The Hungarian language is available at the [progress monitoring website](https://isreacttranslatedyet.com/): 

![image](https://user-images.githubusercontent.com/43971542/63631047-4af0e600-c622-11e9-89c5-98932ad91cdc.png)

But it's not exist in the [website](https://reactjs.org/languages) !!
