### PR TITLE
Added 'the' before Best Practices

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -18,7 +18,7 @@ Stack Overflow is a popular forum to ask code-level questions or if you're stuck
 
 ## Popular Discussion Forums {#popular-discussion-forums}
 
-There are many online forums which are a great place for discussion about best practices and application architecture as well as the future of React. If you have an answerable code-level question, Stack Overflow is usually a better fit.
+There are many online forums which provide a great place for discussion about the best practices and application architecture as well as the future of React. If you have an answerable code-level question, Stack Overflow is usually a better fit.
 
 Each community consists of many thousands of React users.
 


### PR DESCRIPTION
Added 'provided' instead of  'are ' and added 'the' before 'best practices' as it is written in superlative. 

There are many online forums which "provide" a great place for discussion about "the" best practices and application architecture as well as the future of React.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
