### PR TITLE
Removed hyperlink from 'a'

### DIFF
--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -111,4 +111,4 @@ Error boundaries preserve the declarative nature of React, and behave as you wou
 
 React 15 included a very limited support for error boundaries under a different method name: `unstable_handleError`. This method no longer works, and you will need to change it to `componentDidCatch` in your code starting from the first 16 beta release.
 
-For this change, we’ve provided [a codemod](https://github.com/reactjs/react-codemod#error-boundaries) to automatically migrate your code.
+For this change, we’ve provided a [codemod](https://github.com/reactjs/react-codemod#error-boundaries) to automatically migrate your code.


### PR DESCRIPTION
The sentence in line114 - "For this change, we’ve provided a [codemod](https://github.com/reactjs/react-codemod#error-boundaries) to automatically migrate your code" had hyperlink added to [a codemod] instead of only to [codemod]. Updated this.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
