### PR TITLE
Documentation correction

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -287,7 +287,7 @@ Now let's say we want to write some logic that changes `left` and `top` when the
 
 This is because when we update a state variable, we *replace* its value. This is different from `this.setState` in a class, which *merges* the updated fields into the object.
 
-If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. However, instead **we recommend to split state into multiple state variables based on which values tend to change together.**
+If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. However, **we recommend to split state into multiple state variables based on which values tend to change together.**
 
 For example, we could split our component state into `position` and `size` objects, and always replace the `position` with no need for merging:
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -287,7 +287,7 @@ Now let's say we want to write some logic that changes `left` and `top` when the
 
 This is because when we update a state variable, we *replace* its value. This is different from `this.setState` in a class, which *merges* the updated fields into the object.
 
-If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. Instead, **we recommend to split state into multiple state variables based on which values tend to change together.**
+If you miss automatic merging, you could write a custom `useLegacyState` Hook that merges object state updates. However, **we recommend to split state into multiple state variables based on which values tend to change together.**
 
 For example, we could split our component state into `position` and `size` objects, and always replace the `position` with no need for merging:
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -287,7 +287,7 @@ Now let's say we want to write some logic that changes `left` and `top` when the
 
 This is because when we update a state variable, we *replace* its value. This is different from `this.setState` in a class, which *merges* the updated fields into the object.
 
-If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. However, **we recommend to split state into multiple state variables based on which values tend to change together.**
+If you miss automatic merging, you can write a custom `useLegacyState` Hook that merges object state updates. Instead, **we recommend to split state into multiple state variables based on which values tend to change together.**
 
 For example, we could split our component state into `position` and `size` objects, and always replace the `position` with no need for merging:
 


### PR DESCRIPTION
Line 290 - ". However, instead we recommend to split state into multiple state variables based on which values tend to change together."
Both 'however' and 'instead' are contrasting words and only one of them should be used. 
Either "Instead we recommend to split state into multiple state variables based on which values tend to change together." OR "However, we recommend to split state into multiple state variables based on which values tend to change together."
Updated the sentence.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
