### PR TITLE
Documentation error

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -323,7 +323,7 @@ function useWindowPosition() {
 
 Note how we were able to move the `useState` call for the `position` state variable and the related effect into a custom Hook without changing their code. If all state was in a single object, extracting it would be more difficult.
 
-Both putting all state in a single `useState` call, and having a `useState` call per each field can work. Components tend to be most readable when you find a balance between these two extremes, and group related state into a few independent state variables. If the state logic becomes complex, we recommend [managing it with a reducer](/docs/hooks-reference.html#usereducer) or a custom Hook.
+Both: putting all state in a single `useState` call, and having a `useState` call per each field can work. Components tend to be most readable when you find a balance between these two extremes, and group related state into a few independent state variables. If the state logic becomes complex, we recommend [managing it with a reducer](/docs/hooks-reference.html#usereducer) or a custom Hook.
 
 ### Can I run an effect only on updates? {#can-i-run-an-effect-only-on-updates}
 


### PR DESCRIPTION
Line 326 - "Both putting all state in a single useState call, and having a useState call per each field can work. "
updated to 
"Both: putting all state in a single useState call, and having a useState call per each field can work. " as there should be  a line-break after 'both'.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
