### PR TITLE
Update CodeSplitting to clarify that lazy() must be used with Suspense

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -124,37 +124,21 @@ The `React.lazy` function lets you render a dynamic import as a regular componen
 
 ```js
 import OtherComponent from './OtherComponent';
-
-function MyComponent() {
-  return (
-    <div>
-      <OtherComponent />
-    </div>
-  );
-}
 ```
 
 **After:**
 
 ```js
 const OtherComponent = React.lazy(() => import('./OtherComponent'));
-
-function MyComponent() {
-  return (
-    <div>
-      <OtherComponent />
-    </div>
-  );
-}
 ```
 
-This will automatically load the bundle containing the `OtherComponent` when this component gets rendered.
+This will automatically load the bundle containing the `OtherComponent` when this component is first rendered.
 
 `React.lazy` takes a function that must call a dynamic `import()`. This must return a `Promise` which resolves to a module with a `default` export containing a React component.
 
 ### Suspense {#suspense}
 
-If the module containing the `OtherComponent` is not yet loaded by the time `MyComponent` renders, we must show some fallback content while we're waiting for it to load - such as a loading indicator. This is done using the `Suspense` component.
+The lazy component should then be rendered inside a `Suspense` component, which allows us to show some fallback content (such as a loading indicator) while we're waiting for the lazy component to load.
 
 ```js
 const OtherComponent = React.lazy(() => import('./OtherComponent'));

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -136,8 +136,6 @@ This will automatically load the bundle containing the `OtherComponent` when thi
 
 `React.lazy` takes a function that must call a dynamic `import()`. This must return a `Promise` which resolves to a module with a `default` export containing a React component.
 
-### Suspense {#suspense}
-
 The lazy component should then be rendered inside a `Suspense` component, which allows us to show some fallback content (such as a loading indicator) while we're waiting for the lazy component to load.
 
 ```js


### PR DESCRIPTION
It seems that a `React.lazy()` **must** be wrapped in a `<Suspense>`. Update the wording of the documentation to clarify this (and remove a confusing example which shows the lazy component being rendered without any Suspense around it).