### PR TITLE
Remove duplication in react-test-renderer docs

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -149,7 +149,7 @@ Return an object representing the rendered tree. This tree only contains the pla
 testRenderer.toTree()
 ```
 
-Return an object representing the rendered tree. Unlike `toJSON()`, the representation is more detailed than the one provided by `toJSON()`, and includes the user-written components. You probably don't need this method unless you're writing your own assertion library on top of the test renderer.
+Return an object representing the rendered tree. The representation is more detailed than the one provided by `toJSON()`, and includes the user-written components. You probably don't need this method unless you're writing your own assertion library on top of the test renderer.
 
 ### `testRenderer.update()` {#testrendererupdate}
 


### PR DESCRIPTION
This PR removes some minor duplication in the react-test-renderer documentation.

I unfortunately got a typo into the commit message 😑 . Will fix when I get a chance.
