### PR TITLE
Add Translatable component

### DIFF
--- a/content/strings.yml
+++ b/content/strings.yml
@@ -1,0 +1,6 @@
+"Babel could not be loaded": ""
+"This can be caused by an ad blocker. If you're using one, consider adding reactjs.org to the whitelist so the live code examples will work.": ""
+"Loading code example...": ""
+"When you encounter an error, you'll receive a link to this page for that specific error and we'll show you the full error text.": ""
+"The full text of the error you just encountered is:": ""
+"Edit this page": ""

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -10,6 +10,7 @@ import Remarkable from 'remarkable';
 import {LiveEditor, LiveProvider} from 'react-live';
 import {colors, media} from 'theme';
 import MetaTitle from 'templates/components/MetaTitle';
+import Translatable from '../Translatable';
 
 // Replace unicode to text for other languages
 const unicodeToText = text =>
@@ -62,12 +63,14 @@ class CodeEditor extends Component {
     if (showBabelErrorMessage) {
       errorMessage = (
         <span>
-          Babel could not be loaded.
+          <Translatable>Babel could not be loaded.</Translatable>
           <br />
           <br />
-          This can be caused by an ad blocker. If you're using one, consider
-          adding reactjs.org to the whitelist so the live code examples will
-          work.
+          <Translatable>
+            This can be caused by an ad blocker. If you're using one, consider
+            adding reactjs.org to the whitelist so the live code examples will
+            work.
+          </Translatable>
         </span>
       );
     } else if (error != null) {

--- a/src/components/CodeExample/CodeExample.js
+++ b/src/components/CodeExample/CodeExample.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import {colors, media} from 'theme';
 import CodeEditor from '../CodeEditor/CodeEditor';
+import Translatable from '../Translatable';
 
 class CodeExample extends Component {
   render() {
@@ -61,7 +62,9 @@ class CodeExample extends Component {
         {loaded ? (
           <CodeEditor code={code} containerNodeID={containerNodeID} />
         ) : (
-          <h4>Loading code example...</h4>
+          <h4>
+            <Translatable>Loading code example...</Translatable>
+          </h4>
         )}
       </div>
     );

--- a/src/components/ErrorDecoder/ErrorDecoder.js
+++ b/src/components/ErrorDecoder/ErrorDecoder.js
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import type {Node} from 'react';
+import Translatable from '../Translatable';
 
 function replaceArgs(msg: string, argList: Array<string>): string {
   let argIdx = 0;
@@ -69,8 +70,10 @@ function ErrorResult(props: {|code: ?string, msg: string|}) {
   if (!code) {
     return (
       <p>
-        When you encounter an error, you'll receive a link to this page for that
-        specific error and we'll show you the full error text.
+        <Translatable>
+          When you encounter an error, you'll receive a link to this page for
+          that specific error and we'll show you the full error text.
+        </Translatable>
       </p>
     );
   }
@@ -78,7 +81,11 @@ function ErrorResult(props: {|code: ?string, msg: string|}) {
   return (
     <div>
       <p>
-        <b>The full text of the error you just encountered is:</b>
+        <b>
+          <Translatable>
+            The full text of the error you just encountered is:
+          </Translatable>
+        </b>
       </p>
       <code>
         <b>{urlify(errorMsg)}</b>

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -18,6 +18,7 @@ import {sharedStyles} from 'theme';
 import createCanonicalUrl from 'utils/createCanonicalUrl';
 
 import type {Node} from 'types';
+import Translatable from '../Translatable';
 
 type Props = {
   authors: Array<string>,
@@ -115,7 +116,7 @@ const MarkdownPage = ({
                       href={`https://github.com/reactjs/reactjs.org/tree/master/${
                         markdownRemark.fields.path
                       }`}>
-                      Edit this page
+                      <Translatable>Edit this page</Translatable>
                     </a>
                   </div>
                 )}

--- a/src/components/Translatable/Translatable.js
+++ b/src/components/Translatable/Translatable.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * @emails react-core
+ * @flow
+ */
+
+// $FlowFixMe
+import strings from '../../../content/strings.yml';
+
+const Translatable = ({children}: {children: string}) => {
+  if (children in strings && strings[children] !== '') {
+    return strings[children];
+  }
+  return children;
+};
+
+export default Translatable;

--- a/src/components/Translatable/index.js
+++ b/src/components/Translatable/index.js
@@ -1,0 +1,3 @@
+import Translatable from './Translatable';
+
+export default Translatable;


### PR DESCRIPTION
In this ongoing PR, I am extracting strings to into a separate YAML file called "content/strings.yml"

In order to use the translation, I have added a `Translatable` component. This component accepts strings as children (enforced via Flow) and returns the translatable text if it exists. If the key does not exist in strings.yml or if the value for the key is an empty string (`""`), it will return the original, untranslated text. This way, we can easily apply the translations into existing texts without a hassle. 

Some things that I am considering but would like a feedback before I can move forward. Add `as` prop to `Translatable` component that accepts React Type or DOM Element Type. So, instead of writing the following:

```
<p>
  <Translatable>When you encounter an error, you'll receive a link to this page for that specific error and we'll show you the full error text.</Translatable>
</p>
```

We can write down the following:

```
<Translatable as="p">When you encounter an error, you'll receive a link to this page for that specific error and we'll show you the full error text.</Translatable>
```

---

Components that need to be translated

- [x] components/CodeEditor
- [x] components/CodeExample
- [x] components/ErrorDecoder
- [ ] components/LayoutFooter
- [ ] components/LayoutHeader
- [x] components/MarkdownPage
- [ ] components/TitleAndMetaTags
- [ ] pages/blog/all.html.js
- [ ] pages/404.js
- [ ] pages/acknowledgements.html.js
- [ ] pages/index.js
- [ ] pages/jsx-compiler.html.js
- [ ] pages/languages.js
- [ ] pages/versions.js
- [ ] templates/components/NavigationFooter.js
- [ ] templates/codepen-example.js
- [ ] templates/blog.js (Not sure)
