### PR TITLE
Fix link to moved GH repo

### DIFF
--- a/content/community/tools-debugging.md
+++ b/content/community/tools-debugging.md
@@ -5,4 +5,4 @@ layout: community
 permalink: community/debugging-tools.html
 ---
 
-  * **[React Developer Tools](https://github.com/facebook/react-devtools):** an extension available for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), [Firefox](https://addons.mozilla.org/firefox/addon/react-devtools/), and as a [standalone app](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) that allows you to inspect the React component hierarchy in the Chrome Developer Tools.
+  * **[React Developer Tools](https://github.com/facebook/react-devtools):** an extension available for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), [Firefox](https://addons.mozilla.org/firefox/addon/react-devtools/), and as a [standalone app](https://github.com/facebook/react/tree/master/packages/react-devtools) that allows you to inspect the React component hierarchy in the Chrome Developer Tools.


### PR DESCRIPTION
https://github.com/facebook/react-devtools/ says: "This project has migrated to github.com/facebook/react".



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
