### PR TITLE
Memo: Document behavior with useContext

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -105,7 +105,7 @@ function Page(props) {
 
 This pattern is sufficient for many cases when you need to decouple a child from its immediate parents. You can take it even further with [render props](/docs/render-props.html) if the child needs to communicate with the parent before rendering.
 
-However, sometimes the same data needs to be accessible by many components in the tree, and at different nesting levels. Context lets you "broadcast" such data, and changes to it, to all components below. Common examples where using context might be simpler than the alternatives include managing the current locale, theme, or a data cache. 
+However, sometimes the same data needs to be accessible by many components in the tree, and at different nesting levels. Context lets you "broadcast" such data, and changes to it, to all components below. Common examples where using context might be simpler than the alternatives include managing the current locale, theme, or a data cache.
 
 ## API {#api}
 
@@ -129,12 +129,12 @@ Every Context object comes with a Provider React component that allows consuming
 
 Accepts a `value` prop to be passed to consuming components that are descendants of this Provider. One Provider can be connected to many consumers. Providers can be nested to override values deeper within the tree.
 
-All consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant consumers is not subject to the `shouldComponentUpdate` method, so the consumer is updated even when an ancestor component bails out of the update.
+All consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant consumers (including [`.contextType`](#classcontexttype) and [`useContext`](/docs/hooks-reference.html#usecontext)) is not subject to the `shouldComponentUpdate` method, so the consumer is updated even when an ancestor component skips an update.
 
-Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description). 
+Changes are determined by comparing the new and old values using the same algorithm as [`Object.is`](//developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description).
 
 > Note
-> 
+>
 > The way changes are determined can cause some issues when passing objects as `value`: see [Caveats](#caveats).
 
 ### `Class.contextType` {#classcontexttype}
@@ -193,7 +193,7 @@ A React component that subscribes to context changes. This lets you subscribe to
 Requires a [function as a child](/docs/render-props.html#using-props-other-than-render). The function receives the current context value and returns a React node. The `value` argument passed to the function will be equal to the `value` prop of the closest Provider for this context above in the tree. If there is no Provider for this context above, the `value` argument will be equal to the `defaultValue` that was passed to `createContext()`.
 
 > Note
-> 
+>
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
 
 ## Examples {#examples}
@@ -226,7 +226,7 @@ It is often necessary to update the context from a component that is nested some
 
 ### Consuming Multiple Contexts {#consuming-multiple-contexts}
 
-To keep context re-rendering fast, React needs to make each context consumer a separate node in the tree. 
+To keep context re-rendering fast, React needs to make each context consumer a separate node in the tree.
 
 `embed:context/multiple-contexts.js`
 
@@ -246,6 +246,6 @@ To get around this, lift the value into the parent's state:
 ## Legacy API {#legacy-api}
 
 > Note
-> 
+>
 > React previously shipped with an experimental context API. The old API will be supported in all 16.x releases, but applications using it should migrate to the new version. The legacy API will be removed in a future major React version. Read the [legacy context docs here](/docs/legacy-context.html).
- 
+

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -180,7 +180,7 @@ const value = useContext(MyContext);
 
 Accepts a context object (the value returned from `React.createContext`) and returns the current context value for that context. The current context value is determined by the `value` prop of the nearest `<MyContext.Provider>` above the calling component in the tree.
 
-When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a rerender with the latest context `value` passed to that `MyContext` provider.
+When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a rerender with the latest context `value` passed to that `MyContext` provider. Even if an ancestor uses [`React.memo`](/docs/react-api.html#reactmemo) or [`shouldComponentUpdate`](/docs/react-component.html#shouldcomponentupdate), a rerender will still happen starting at the component itself using `useContext`.
 
 Don't forget that the argument to `useContext` must be the *context object itself*:
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -144,6 +144,10 @@ function areEqual(prevProps, nextProps) {
 export default React.memo(MyComponent, areEqual);
 ```
 
+> Note
+>
+> [`useContext`](/docs/hooks-reference.html#usecontext) will tigger a render of the memoized component. This render will also cause the `React.memo` [higher order component](/docs/higher-order-components.html) to re-cache the result.
+
 This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
 
 > Note

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -146,7 +146,7 @@ export default React.memo(MyComponent, areEqual);
 
 > Note
 >
-> [`useContext`](/docs/hooks-reference.html#usecontext) will tigger a render of the memoized component. This render will also cause the `React.memo` [higher order component](/docs/higher-order-components.html) to re-cache the result.
+> [`useContext`](/docs/hooks-reference.html#usecontext) will trigger a render of the memoized component. This render will also cause the `React.memo` [higher order component](/docs/higher-order-components.html) to re-cache the result.
 
 This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -104,7 +104,7 @@ See the [React.Component API Reference](/docs/react-component.html) for a list o
 
 ### `React.PureComponent` {#reactpurecomponent}
 
-`React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) doesn't implement [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate), but `React.PureComponent` implements it with a shallow prop and state comparison. 
+`React.PureComponent` is similar to [`React.Component`](#reactcomponent). The difference between them is that [`React.Component`](#reactcomponent) doesn't implement [`shouldComponentUpdate()`](/docs/react-component.html#shouldcomponentupdate), but `React.PureComponent` implements it with a shallow prop and state comparison.
 
 If your React component's `render()` function renders the same result given the same props and state, you can use `React.PureComponent` for a performance boost in some cases.
 
@@ -128,6 +128,8 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
 
+`React.memo` only affects props changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
+
 By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
 
 ```javascript
@@ -143,10 +145,6 @@ function areEqual(prevProps, nextProps) {
 }
 export default React.memo(MyComponent, areEqual);
 ```
-
-> Note
->
-> [`useContext`](/docs/hooks-reference.html#usecontext) will trigger a render of the memoized component. This render will also cause the `React.memo` [higher order component](/docs/higher-order-components.html) to re-cache the result.
 
 This method only exists as a **[performance optimization](/docs/optimizing-performance.html).** Do not rely on it to "prevent" a render, as this can lead to bugs.
 


### PR DESCRIPTION
It is not obvious that useContext and Memo work well together. Namely, if a child component listens to a context and updates out from under them memo'd function, does the memo'd component have the right state if re-rendered?

yes, actually, but this is undocumented. Now it's not!

Closes: #1923
