### PR TITLE
Docs: a typo and bottom nav links

### DIFF
--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -2,8 +2,6 @@
 id: static-type-checking
 title: Static Type Checking
 permalink: docs/static-type-checking.html
-prev: typechecking-with-proptypes.html
-next: refs-and-the-dom.html
 ---
 
 Static type checkers like [Flow](https://flow.org/) and [TypeScript](https://www.typescriptlang.org/) identify certain types of problems before you even run your code. They can also improve developer workflow by adding features like auto-completion. For this reason, we recommend using Flow or TypeScript instead of `PropTypes` for larger code bases.

--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -543,7 +543,7 @@ You can use fake timers only in some tests. Above, we enabled them by calling `j
 
 ### Snapshot Testing {#snapshot-testing}
 
-Frameworks like Jest also let you save "snapshots" of data with [`toMatchSnapshot` / `toMatchInlineSnapshot`](https://jestjs.io/docs/en/snapshot-testing). With these, we can "save" the renderered component output and ensure that a change to it has to be explicitly committed as a change to the snapshot.
+Frameworks like Jest also let you save "snapshots" of data with [`toMatchSnapshot` / `toMatchInlineSnapshot`](https://jestjs.io/docs/en/snapshot-testing). With these, we can "save" the rendered component output and ensure that a change to it has to be explicitly committed as a change to the snapshot.
 
 In this example, we render a component and format the rendered HTML with the [`pretty`](https://www.npmjs.com/package/pretty) package, before saving it as an inline snapshot:
 


### PR DESCRIPTION
Hey there!

- Typo fixed on the Testing Recipes page;
- Advanced guides don't have bottom navigation links except for the Static Type Checking page. And they lead to wrong prev/next articles.