### PR TITLE
fixed search bar overlapping problem

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -45,7 +45,7 @@ class DocSearch extends Component<{}, State> {
           paddingLeft: '0.25rem',
           paddingRight: '0.25rem',
 
-          [media.lessThan('expandedSearch')]: {
+          [media.lessThan('smallSearch')]: {
             justifyContent: 'flex-end',
             marginRight: 10,
           },
@@ -54,9 +54,6 @@ class DocSearch extends Component<{}, State> {
           // [media.between('mediumSearch', 'largerSearch')]: {
           //   width: 'calc(100% / 8)',
           // },
-          [media.greaterThan('expandedSearch')]: {
-            minWidth: 100,
-          },
         }}>
         <input
           css={{
@@ -82,7 +79,7 @@ class DocSearch extends Component<{}, State> {
               borderRadius: '0.25rem',
             },
 
-            [media.lessThan('expandedSearch')]: {
+            [media.lessThan('smallSearch')]: {
               fontSize: 16,
               width: '16px',
               transition: 'width 0.2s ease, padding 0.2s ease',
@@ -93,6 +90,15 @@ class DocSearch extends Component<{}, State> {
                 width: '8rem',
                 outline: 'none',
               },
+            },
+            [media.size('smallSearch')]: {
+              width: '150px',
+            },
+            [media.size('mediumSearch')]: {
+              width: '200px',
+            },
+            [media.size('largeSearch')]: {
+              width: '220px',
             },
           }}
           id="algolia-doc-search"

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,7 +40,9 @@ const SIZES = {
   sidebarFixed: {min: 2000, max: Infinity},
 
   // Topbar related tweakpoints
-  expandedSearch: {min: 1180, max: Infinity},
+  smallSearch: {min: 1100, max: 1199},
+  mediumSearch: {min: 1200, max: 1299},
+  largeSearch: {min: 1300, max: 1400},
 };
 
 type Size = $Keys<typeof SIZES>;


### PR DESCRIPTION
This pull request fixes the search bar overlapping navbar options problem. 
Now there are 3 different search bar sizes small, medium and large for every window size.

Below are the screenshots in every mode of search bar.

![largeSearch](https://user-images.githubusercontent.com/29986758/64942523-e6265580-d886-11e9-80af-9f0b0c2a9a32.png)
![mediumSearch](https://user-images.githubusercontent.com/29986758/64942524-e6beec00-d886-11e9-908b-94e8650203b2.png)
![smallSearch](https://user-images.githubusercontent.com/29986758/64942526-e7578280-d886-11e9-8bc2-3a6ce994ed6d.png)
