### PR TITLE
fix broken link to babel repl on jsx-compiler page

### DIFF
--- a/src/pages/jsx-compiler.html.js
+++ b/src/pages/jsx-compiler.html.js
@@ -30,7 +30,7 @@ const JsxCompiler = ({location}: Props) => (
             </p>
             <p>
               We recommend using another tool such as{' '}
-              <a href="https://babeljs.io/repl/">the Babel REPL</a>.
+              <a href="https://babeljs.io/repl">the Babel REPL</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Babel's site doesn't like the trailing slash and 404's, removing it links correctly to the repl.
