### PR TITLE
Fix typo in code example for passing arguments to event handlers

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -146,7 +146,7 @@ Inside a loop it is common to want to pass an extra parameter to an event handle
 
 ```js
 <button onClick={(e) => this.deleteRow(id, e)}>Delete Row</button>
-<button onClick={this.deleteRow.bind(this, id)}>Delete Row</button>
+<button onClick={this.deleteRow.bind(this, id, e)}>Delete Row</button>
 ```
 
 The above two lines are equivalent, and use [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) respectively.


### PR DESCRIPTION
I believe that there's a typo in the [example showing how to pass arguments to event handlers](https://reactjs.org/docs/handling-events.html#passing-arguments-to-event-handlers).

Quoting from the docs:

```js
<button onClick={(e) => this.deleteRow(id, e)}>Delete Row</button>
<button onClick={this.deleteRow.bind(this, id)}>Delete Row</button>
```

I believe that leaving the `e` argument out when calling `this.deleteRow.bind` was a typo.

This PR adds `e` as a third argument when calling `this.deleteRow.bind`.

