### PR TITLE
Fix a bug in the TestRenderer.act() example code

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -128,7 +128,7 @@ expect(root.toJSON()).toMatchSnapshot();
 
 // update with some different props
 act(() => {
-  root = root.update(<App value={2}/>);
+  root.update(<App value={2}/>);
 })
 
 // make assertions on root 


### PR DESCRIPTION
`TestRenderer.act()` is a void function, so assigning its result to `root` breaks the final assertion.