### PR TITLE
Use correct meetup link for React Berlin

### DIFF
--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -58,7 +58,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [Karlsruhe](https://www.meetup.com/react_ka/)
 * [Kiel](https://www.meetup.com/Kiel-React-Native-Meetup/)
 * [Munich](https://www.meetup.com/ReactJS-Meetup-Munich/)
-* [React Berlin](https://www.meetup.com/React-Berlin/)
+* [React Berlin](https://www.meetup.com/React-Open-Source/)
 * [React.JS Girls Berlin](https://www.meetup.com/ReactJS-Girls-Berlin/)
 
 ## Greece {#greece}


### PR DESCRIPTION
The previous meetup group was discontinued.
