### PR TITLE
Add doc for context displayaName

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -203,7 +203,7 @@ Context object accepts a `displayName` string property. React DevTools uses this
 
 For example, the following component will appear as MyContext in the DevTools:
 
-```js
+```js{2}
 const MyContext = React.createContext(/* some value */);
 MyContext.displayName = 'MyDisplayName';
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -15,7 +15,7 @@ In a typical React application, data is passed top-down (parent to child) via pr
   - [Context.Provider](#contextprovider)
   - [Class.contextType](#classcontexttype)
   - [Context.Consumer](#contextconsumer)
-  - [Context.displayName](#contextdisplayName)
+  - [Context.displayName](#contextdisplayname)
 - [Examples](#examples)
   - [Dynamic Context](#dynamic-context)
   - [Updating Context from a Nested Component](#updating-context-from-a-nested-component)
@@ -197,7 +197,7 @@ Requires a [function as a child](/docs/render-props.html#using-props-other-than-
 > 
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
 
-### `Context.displayName` {#contextdisplayName}
+### `Context.displayName` {#contextdisplayname}
 
 Context object accepts a `displayName` string property. React DevTools uses this string to determine what to display for the context.
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -207,8 +207,8 @@ For example, the following component will appear as MyContext in the DevTools:
 const MyContext = React.createContext(/* some value */);
 MyContext.displayName = 'MyDisplayName';
 
-<MyContext.Provider> // "MyContext.Provider" in DevTools
-<MyContext.Consumer> // "MyContext.Consumer" in DevTools
+<MyContext.Provider> // "MyDisplayName.Provider" in DevTools
+<MyContext.Consumer> // "MyDisplayName.Consumer" in DevTools
 ```
 
 ## Examples {#examples}

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -15,6 +15,7 @@ In a typical React application, data is passed top-down (parent to child) via pr
   - [Context.Provider](#contextprovider)
   - [Class.contextType](#classcontexttype)
   - [Context.Consumer](#contextconsumer)
+  - [Context.displayName](#contextdisplayName)
 - [Examples](#examples)
   - [Dynamic Context](#dynamic-context)
   - [Updating Context from a Nested Component](#updating-context-from-a-nested-component)
@@ -195,6 +196,20 @@ Requires a [function as a child](/docs/render-props.html#using-props-other-than-
 > Note
 > 
 > For more information about the 'function as a child' pattern, see [render props](/docs/render-props.html).
+
+### `Context.displayName` {#contextdisplayName}
+
+Context object accepts a `displayName` string property. React DevTools uses this string to determine what to display for the context.
+
+For example, the following component will appear as MyContext in the DevTools:
+
+```js
+const MyContext = React.createContext(/* some value */);
+MyContext.displayName = 'MyDisplayName';
+
+<MyContext.Provider> // "MyContext.Provider" in DevTools
+<MyContext.Consumer> // "MyContext.Consumer" in DevTools
+```
 
 ## Examples {#examples}
 


### PR DESCRIPTION
This PR adds a description of `Context.displayName` which is used to show a specific name for the React DevTools.
Also solved [this Issue](https://github.com/facebook/react/issues/16851)