### PR TITLE
Change usePrevious example in hooks-faq.md

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -373,7 +373,7 @@ Note how this would work for props, state, or any other calculated value.
 function Counter() {
   const [count, setCount] = useState(0);
 
-  const calculation = count * 100;
+  const calculation = count + 100;
   const prevCalculation = usePrevious(calculation);
   // ...
 ```


### PR DESCRIPTION
In the example, `count` is initialized to 0 and then multiplied by 100... which is 0.

Changing this to addition so the previous value and the current value aren't the same thing.