### PR TITLE
Add usage example for useContext.

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -197,7 +197,7 @@ A component calling `useContext` will always re-render when the context value ch
 >`useContext(MyContext)` only lets you *read* the context and subscribe to its changes. You still need a `<MyContext.Provider>` above in the tree to *provide* the value for this context.
 
 **Putting it together with Context.Provider**
-```js{31-37}
+```js{31-36}
 const themes = {
   light: {
     foreground: "#000000",
@@ -230,7 +230,6 @@ function Toolbar(props) {
 function ThemedButton() {
   const theme = useContext(ThemeContext);
 
-  // Button is a component that is styled based on a 'theme'
   return (
     <button style={{ background: theme.background, color: theme.foreground }}>
       I am styled by theme context!

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -196,6 +196,51 @@ A component calling `useContext` will always re-render when the context value ch
 >
 >`useContext(MyContext)` only lets you *read* the context and subscribe to its changes. You still need a `<MyContext.Provider>` above in the tree to *provide* the value for this context.
 
+**Putting it together with Context.Provider**
+```js{31-37}
+const themes = {
+  light: {
+    foreground: "#000000",
+    background: "#eeeeee"
+  },
+  dark: {
+    foreground: "#ffffff",
+    background: "#222222"
+  }
+};
+
+const ThemeContext = React.createContext(themes.light);
+
+function App() {
+  return (
+    <ThemeContext.Provider value={themes.dark}>
+      <Toolbar />
+    </ThemeContext.Provider>
+  );
+}
+
+function Toolbar(props) {
+  return (
+    <div>
+      <ThemedButton />
+    </div>
+  );
+}
+
+function ThemedButton() {
+  const theme = useContext(ThemeContext);
+
+  // Button is a component that is styled based on a 'theme'
+  return (
+    <button style={{ background: theme.background, color: theme.foreground }}>
+      I am styled by theme context!
+    </button>
+  );
+}
+```
+This example is modified for hooks from a previous example in the [Context Advanced Guide](/docs/context.html), where you can find more information about when and how to use Context.
+
+
 ## Additional Hooks {#additional-hooks}
 
 The following Hooks are either variants of the basic ones from the previous section, or only needed for specific edge cases. Don't stress about learning them up front.


### PR DESCRIPTION
The intent of this PR is to show where the `useContext` hook fits in to the usual Context usage. As I've been training co-workers and friends I've had a few ask me how to use the `useContext` hook, even after they have looked at the docs and scoured the internet for a "minimal" example. I believe the problem stems from newer developers who have not used Context before, or developers who used Redux and avoided Context but want to try it now with hooks.

I've been asked a couple times if you still need a `Provider` or a `Consumer` and where the hook fits in. I deliberated on where to place this example for a bit, but it seems that the docs don't mention hooks at all in any of the previous posted articles (such as the Context page under Advanced Guides).

Finally, I tried to use the existing intro code example in `Advanced Guides > Context` but it obviously didn't make sense to mix classes with hooks or to call a `Button` component and pass it a value from context rather than just using context inside the actual component using it, so I made some modifications.

Let me know if there are any changes you'd like me to make, happy to oblige. Here are the before and afters if it helps.

### "Before" screenshot
![react-useContext-pr-before](https://user-images.githubusercontent.com/3894120/66449642-0fb04800-ea13-11e9-8f70-84f8ec2bbf27.png)
### "After" screenshot
![react-useContext-pr-after](https://user-images.githubusercontent.com/3894120/66449644-1212a200-ea13-11e9-9110-e1cf618c2920.png)
