### PR TITLE
Update cloneElement, createElement docs

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -157,7 +157,7 @@ This method only exists as a **[performance optimization](/docs/optimizing-perfo
 ```javascript
 React.createElement(
   type,
-  [props],
+  {...props},
   [...children]
 )
 ```
@@ -173,7 +173,7 @@ Code written with [JSX](/docs/introducing-jsx.html) will be converted to use `Re
 ```
 React.cloneElement(
   element,
-  [props],
+  {...props},
   [...children]
 )
 ```


### PR DESCRIPTION
The documentation for `React.cloneElement`, `React.createElement` list the second argument as an array where in reality both methods expect an object.

See `createElement` source [here](https://github.com/facebook/react/blob/22b2642a565cf9160bbf660ab030d07d8273879e/packages/react/src/ReactElement.js#L312).