### PR TITLE
Fix typo on React 16 Roadmap page

### DIFF
--- a/content/blog/2018-11-27-react-16-roadmap.md
+++ b/content/blog/2018-11-27-react-16-roadmap.md
@@ -108,7 +108,7 @@ Hooks represent our vision for the future of React. They solve both problems tha
 
 ### React 16.x (~Q2 2019): The One with Concurrent Mode {#react-16x-q2-2019-the-one-with-concurrent-mode}
 
-*Concurrent Mode* lets React apps be more responsive by rendering component trees without blocking the main thread. It is opt-in and allows React to interrupt a long-running render (for example, rendering a new feed story) to handle a high-priority event (for example, text input or hover). Concurrent Mode also improves the user experience of Suspense by skipping unnecessary loading states on fast connections.
+*Concurrent Mode* lets React apps be more responsive by rendering component trees without blocking the main thread. It is opt-in and allows React to interrupt a long-running render (for example, rendering a news feed story) to handle a high-priority event (for example, text input or hover). Concurrent Mode also improves the user experience of Suspense by skipping unnecessary loading states on fast connections.
 
 >Note
 >


### PR DESCRIPTION
I believe it was meant to be "news feed story", but I could be misunderstanding something in the context of the paragraph.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
