### PR TITLE
Automatic Language Redirection and fixing Search bar Overlapping

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -45,7 +45,7 @@ class DocSearch extends Component<{}, State> {
           paddingLeft: '0.25rem',
           paddingRight: '0.25rem',
 
-          [media.lessThan('expandedSearch')]: {
+          [media.lessThan('smallSearch')]: {
             justifyContent: 'flex-end',
             marginRight: 10,
           },
@@ -54,9 +54,6 @@ class DocSearch extends Component<{}, State> {
           // [media.between('mediumSearch', 'largerSearch')]: {
           //   width: 'calc(100% / 8)',
           // },
-          [media.greaterThan('expandedSearch')]: {
-            minWidth: 100,
-          },
         }}>
         <input
           css={{
@@ -82,7 +79,7 @@ class DocSearch extends Component<{}, State> {
               borderRadius: '0.25rem',
             },
 
-            [media.lessThan('expandedSearch')]: {
+            [media.lessThan('smallSearch')]: {
               fontSize: 16,
               width: '16px',
               transition: 'width 0.2s ease, padding 0.2s ease',
@@ -93,6 +90,15 @@ class DocSearch extends Component<{}, State> {
                 width: '8rem',
                 outline: 'none',
               },
+            },
+            [media.size('smallSearch')]: {
+              width: '150px',
+            },
+            [media.size('mediumSearch')]: {
+              width: '200px',
+            },
+            [media.size('largeSearch')]: {
+              width: '220px',
             },
           }}
           id="algolia-doc-search"

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -190,7 +190,10 @@ const Header = ({location}: {location: Location}) => (
                 borderRadius: 15,
               },
             }}
-            to="/languages">
+            to="/languages"
+            state={{
+              redirectPath: window.location.pathname,
+            }}>
             <LanguagesIcon />{' '}
             <span
               css={{

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -39,7 +39,7 @@ const {complete, incomplete, partial} = languages.reduce(
 );
 
 type Props = {
-  location: Location,
+  location: Object,
 };
 
 const Languages = ({location}: Props) => (

--- a/src/pages/languages.js
+++ b/src/pages/languages.js
@@ -58,13 +58,22 @@ const Languages = ({location}: Props) => (
               The React documentation is available in the following languages:
             </p>
 
-            <LanguagesGrid languages={complete} />
+            <LanguagesGrid
+              languages={complete}
+              redirectPath={location.state.redirectPath}
+            />
 
             <h2>In Progress</h2>
-            <LanguagesGrid languages={partial} />
+            <LanguagesGrid
+              languages={partial}
+              redirectPath={location.state.redirectPath}
+            />
 
             <h2>Needs Contributors</h2>
-            <LanguagesGrid languages={incomplete} />
+            <LanguagesGrid
+              languages={incomplete}
+              redirectPath={location.state.redirectPath}
+            />
 
             <p>
               Don't see your language above?{' '}
@@ -83,7 +92,7 @@ const Languages = ({location}: Props) => (
   </Layout>
 );
 
-const LanguagesGrid = ({languages}) => (
+const LanguagesGrid = ({languages, redirectPath}) => (
   <ul
     css={{
       display: 'flex',
@@ -99,12 +108,13 @@ const LanguagesGrid = ({languages}) => (
           name={name}
           status={status}
           translatedName={translated_name}
+          redirectPath={redirectPath}
         />
       ))}
   </ul>
 );
 
-const Language = ({code, name, status, translatedName}) => {
+const Language = ({code, name, status, translatedName, redirectPath}) => {
   const prefix = code === 'en' ? '' : `${code}.`;
 
   return (
@@ -141,7 +151,7 @@ const Language = ({code, name, status, translatedName}) => {
         {status === 0 && translatedName}
         {status > 0 && (
           <a
-            href={`https://${prefix}reactjs.org/`}
+            href={`https://${prefix}reactjs.org${redirectPath}`}
             rel="nofollow"
             lang={code}
             hrefLang={code}>

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,7 +40,9 @@ const SIZES = {
   sidebarFixed: {min: 2000, max: Infinity},
 
   // Topbar related tweakpoints
-  expandedSearch: {min: 1180, max: Infinity},
+  smallSearch: {min: 1100, max: 1199},
+  mediumSearch: {min: 1200, max: 1299},
+  largeSearch: {min: 1300, max: 1400},
 };
 
 type Size = $Keys<typeof SIZES>;


### PR DESCRIPTION
This pr completes 2 motives 
first if a user has opened a particular page and then clicks on languages and select one it redirects to home page of that language so user has to search again for previous page. Now if user clicks on language and select any language user will be redirected to same path of selected language.

Second it fixes search bar overlapping problem in navbar.