### PR TITLE
Revise useState hook docs and examples to account for batched state updates

### DIFF
--- a/content/blog/2018-11-27-react-16-roadmap.md
+++ b/content/blog/2018-11-27-react-16-roadmap.md
@@ -78,17 +78,17 @@ Code splitting is just the first step for Suspense. Our longer term vision for S
 
 ```js
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 
   return (
-   <div>
-     <p>You clicked {count} times</p>
-     <button onClick={() => setCount(count + 1)}>
-       Click me
-     </button>
-   </div>
- );
+    <div>
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
+      </button>
+    </div>
+  );
 }
 ```
 

--- a/content/blog/2018-11-27-react-16-roadmap.md
+++ b/content/blog/2018-11-27-react-16-roadmap.md
@@ -82,13 +82,13 @@ function Example() {
   const [randomNumber, setRandomNumber] = useState(0);
 
   return (
-    <div>
-      <p>Random number: {randomNumber}</p>
-      <button onClick={() => setRandomNumber(Math.random())}>
-        Randomize
-      </button>
-    </div>
-  );
+   <div>
+     <p>Random number: {randomNumber}</p>
+     <button onClick={() => setRandomNumber(Math.random())}>
+       Randomize
+     </button>
+   </div>
+ );
 }
 ```
 

--- a/content/blog/2019-02-06-react-v16.8.0.md
+++ b/content/blog/2019-02-06-react-v16.8.0.md
@@ -52,7 +52,7 @@ Even while Hooks were in alpha, the React community created many interesting [ex
 
 We have added a new API called `ReactTestUtils.act()` in this release. It ensures that the behavior in your tests matches what happens in the browser more closely. We recommend to wrap any code rendering and triggering updates to your components into `act()` calls. Testing libraries can also wrap their APIs with it (for example, [`react-testing-library`](https://testing-library.com/react)'s `render` and `fireEvent` utilities do this).
 
-For example, the counter example from [this page](/docs/hooks-effect.html) can be tested like this:
+For example, the counter example from [this page](/docs/hooks-reference.html) can be tested like this:
 
 ```js{3,20-22,29-31}
 import React from 'react';

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -14,26 +14,26 @@ The *Effect Hook* lets you perform side effects in function components:
 import React, { useState, useEffect } from 'react';
 
 function Example() {
-  const [count, setCount] = useState(0);
+  const [randomNumber, setRandomNumber] = useState(0);
 
   // Similar to componentDidMount and componentDidUpdate:
   useEffect(() => {
     // Update the document title using the browser API
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );
 }
 ```
 
-This snippet is based on the [counter example from the previous page](/docs/hooks-state.html), but we added a new feature to it: we set the document title to a custom message including the number of clicks.
+This snippet is based on the [random numbers example from the previous page](/docs/hooks-state.html), but we added a new feature to it: we set the document title to a custom message including the randomized number.
 
 Data fetching, setting up a subscription, and manually changing the DOM in React components are all examples of side effects. Whether or not you're used to calling these operations "side effects" (or just "effects"), you've likely performed them in your components before.
 
@@ -51,31 +51,31 @@ Sometimes, we want to **run some additional code after React has updated the DOM
 
 In React class components, the `render` method itself shouldn't cause side effects. It would be too early -- we typically want to perform our effects *after* React has updated the DOM.
 
-This is why in React classes, we put side effects into `componentDidMount` and `componentDidUpdate`. Coming back to our example, here is a React counter class component that updates the document title right after React makes changes to the DOM:
+This is why in React classes, we put side effects into `componentDidMount` and `componentDidUpdate`. Coming back to our example, here is a React random number generator class component that updates the document title right after React makes changes to the DOM:
 
 ```js{9-15}
 class Example extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      count: 0
+      randomNumber: 0
     };
   }
 
   componentDidMount() {
-    document.title = `You clicked ${this.state.count} times`;
+    document.title = `Random number: ${this.state.randomNumber}`;
   }
 
   componentDidUpdate() {
-    document.title = `You clicked ${this.state.count} times`;
+    document.title = `Random number: ${this.state.randomNumber}`;
   }
 
   render() {
     return (
       <div>
-        <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
-          Click me
+        <p>Random number: {randomNumber}</p>
+        <button onClick={() => setRandomNumber(Math.random())}>
+          Randomize
         </button>
       </div>
     );
@@ -97,17 +97,17 @@ We've already seen this example at the top of this page, but let's take a closer
 import React, { useState, useEffect } from 'react';
 
 function Example() {
-  const [count, setCount] = useState(0);
+  const [randomNumber, setRandomNumber] = useState(0);
 
   useEffect(() => {
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );
@@ -116,7 +116,7 @@ function Example() {
 
 **What does `useEffect` do?** By using this Hook, you tell React that your component needs to do something after render. React will remember the function you passed (we'll refer to it as our "effect"), and call it later after performing the DOM updates. In this effect, we set the document title, but we could also perform data fetching or call some other imperative API.
 
-**Why is `useEffect` called inside a component?** Placing `useEffect` inside the component lets us access the `count` state variable (or any props) right from the effect. We don't need a special API to read it -- it's already in the function scope. Hooks embrace JavaScript closures and avoid introducing React-specific APIs where JavaScript already provides a solution.
+**Why is `useEffect` called inside a component?** Placing `useEffect` inside the component lets us access the `randomNumber` state variable (or any props) right from the effect. We don't need a special API to read it -- it's already in the function scope. Hooks embrace JavaScript closures and avoid introducing React-specific APIs where JavaScript already provides a solution.
 
 **Does `useEffect` run after every render?** Yes! By default, it runs both after the first render *and* after every update. (We will later talk about [how to customize this](#tip-optimizing-performance-by-skipping-effects).) Instead of thinking in terms of "mounting" and "updating", you might find it easier to think that effects happen "after render". React guarantees the DOM has been updated by the time it runs the effects.
 
@@ -126,17 +126,17 @@ Now that we know more about effects, these lines should make sense:
 
 ```js
 function Example() {
-  const [count, setCount] = useState(0);
+  const [randomNumber, setRandomNumber] = useState(0);
 
   useEffect(() => {
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 }
 ```
 
-We declare the `count` state variable, and then we tell React we need to use an effect. We pass a function to the `useEffect` Hook. This function we pass *is* our effect. Inside our effect, we set the document title using the `document.title` browser API. We can read the latest `count` inside the effect because it's in the scope of our function. When React renders our component, it will remember the effect we used, and then run our effect after updating the DOM. This happens for every render, including the first one.
+We declare the `randomNumber` state variable, and then we tell React we need to use an effect. We pass a function to the `useEffect` Hook. This function we pass *is* our effect. Inside our effect, we set the document title using the `document.title` browser API. We can read the latest `randomNumber` inside the effect because it's in the scope of our function. When React renders our component, it will remember the effect we used, and then run our effect after updating the DOM. This happens for every render, including the first one.
 
-Experienced JavaScript developers might notice that the function passed to `useEffect` is going to be different on every render. This is intentional. In fact, this is what lets us read the `count` value from inside the effect without worrying about it getting stale. Every time we re-render, we schedule a _different_ effect, replacing the previous one. In a way, this makes the effects behave more like a part of the render result -- each effect "belongs" to a particular render. We will see more clearly why this is useful [later on this page](#explanation-why-effects-run-on-each-update).
+Experienced JavaScript developers might notice that the function passed to `useEffect` is going to be different on every render. This is intentional. In fact, this is what lets us read the `randomNumber` value from inside the effect without worrying about it getting stale. Every time we re-render, we schedule a _different_ effect, replacing the previous one. In a way, this makes the effects behave more like a part of the render result -- each effect "belongs" to a particular render. We will see more clearly why this is useful [later on this page](#explanation-why-effects-run-on-each-update).
 
 >Tip
 >
@@ -253,7 +253,7 @@ Other effects might not have a cleanup phase, and don't return anything.
 
 ```js
   useEffect(() => {
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 ```
 
@@ -271,18 +271,18 @@ We'll continue this page with an in-depth look at some aspects of `useEffect` th
 
 ### Tip: Use Multiple Effects to Separate Concerns {#tip-use-multiple-effects-to-separate-concerns}
 
-One of the problems we outlined in the [Motivation](/docs/hooks-intro.html#complex-components-become-hard-to-understand) for Hooks is that class lifecycle methods often contain unrelated logic, but related logic gets broken up into several methods. Here is a component that combines the counter and the friend status indicator logic from the previous examples:
+One of the problems we outlined in the [Motivation](/docs/hooks-intro.html#complex-components-become-hard-to-understand) for Hooks is that class lifecycle methods often contain unrelated logic, but related logic gets broken up into several methods. Here is a component that combines the random number generator and the friend status indicator logic from the previous examples:
 
 ```js
-class FriendStatusWithCounter extends React.Component {
+class FriendStatusWithRandomNumbers extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { count: 0, isOnline: null };
+    this.state = { randomNumber: 0, isOnline: null };
     this.handleStatusChange = this.handleStatusChange.bind(this);
   }
 
   componentDidMount() {
-    document.title = `You clicked ${this.state.count} times`;
+    document.title = `Random number: ${this.state.randomNumber}`;
     ChatAPI.subscribeToFriendStatus(
       this.props.friend.id,
       this.handleStatusChange
@@ -290,7 +290,7 @@ class FriendStatusWithCounter extends React.Component {
   }
 
   componentDidUpdate() {
-    document.title = `You clicked ${this.state.count} times`;
+    document.title = `Random number: ${this.state.randomNumber}`;
   }
 
   componentWillUnmount() {
@@ -313,10 +313,11 @@ Note how the logic that sets `document.title` is split between `componentDidMoun
 So, how can Hooks solve this problem? Just like [you can use the *State* Hook more than once](/docs/hooks-state.html#tip-using-multiple-state-variables), you can also use several effects. This lets us separate unrelated logic into different effects:
 
 ```js{3,8}
-function FriendStatusWithCounter(props) {
-  const [count, setCount] = useState(0);
+function FriendStatusWithRandomNumbers(props) {
+  const [randomNumber, setRandomNumber] = useState(0);
+  
   useEffect(() => {
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 
   const [isOnline, setIsOnline] = useState(null);
@@ -435,8 +436,8 @@ In some cases, cleaning up or applying the effect after every render might creat
 
 ```js
 componentDidUpdate(prevProps, prevState) {
-  if (prevState.count !== this.state.count) {
-    document.title = `You clicked ${this.state.count} times`;
+  if (prevState.randomNumber !== this.state.randomNumber) {
+    document.title = `Random number: ${randomNumber}`;
   }
 }
 ```
@@ -445,13 +446,13 @@ This requirement is common enough that it is built into the `useEffect` Hook API
 
 ```js{3}
 useEffect(() => {
-  document.title = `You clicked ${count} times`;
-}, [count]); // Only re-run the effect if count changes
+  document.title = `Random number: ${randomNumber}`;
+}, [randomNumber]); // Only re-run the effect if randomNumber changes
 ```
 
-In the example above, we pass `[count]` as the second argument. What does this mean? If the `count` is `5`, and then our component re-renders with `count` still equal to `5`, React will compare `[5]` from the previous render and `[5]` from the next render. Because all items in the array are the same (`5 === 5`), React would skip the effect. That's our optimization.
+In the example above, we pass `[randomNumber]` as the second argument. What does this mean? If the `randomNumber` is `1`, and then our component re-renders with `randomNumber` still equal to `1`, React will compare `[1]` from the previous render and `[1]` from the next render. Because all items in the array are the same (`1 === 1`), React would skip the effect. That's our optimization.
 
-When we render with `count` updated to `6`, React will compare the items in the `[5]` array from the previous render to items in the `[6]` array from the next render. This time, React will re-apply the effect because `5 !== 6`. If there are multiple items in the array, React will re-run the effect even if just one of them is different.
+When we render with `randomNumber` updated to `0.5`, React will compare the items in the `[1]` array from the previous render to items in the `[0.5]` array from the next render. This time, React will re-apply the effect because `0.5 !== 1`. If there are multiple items in the array, React will re-run the effect even if just one of them is different.
 
 This also works for effects that have a cleanup phase:
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -315,7 +315,6 @@ So, how can Hooks solve this problem? Just like [you can use the *State* Hook mo
 ```js{3,8}
 function FriendStatusWithRandomNumbers(props) {
   const [randomNumber, setRandomNumber] = useState(0);
-  
   useEffect(() => {
     document.title = `Random number: ${randomNumber}`;
   });
@@ -452,7 +451,7 @@ useEffect(() => {
 
 In the example above, we pass `[randomNumber]` as the second argument. What does this mean? If the `randomNumber` is `1`, and then our component re-renders with `randomNumber` still equal to `1`, React will compare `[1]` from the previous render and `[1]` from the next render. Because all items in the array are the same (`1 === 1`), React would skip the effect. That's our optimization.
 
-When we render with `randomNumber` updated to `0.5`, React will compare the items in the `[1]` array from the previous render to items in the `[0.5]` array from the next render. This time, React will re-apply the effect because `0.5 !== 1`. If there are multiple items in the array, React will re-run the effect even if just one of them is different.
+When we render with `randomNumber` updated to `0.5`, React will compare the items in the `[1]` array from the previous render to items in the `[0.5]` array from the next render. This time, React will re-apply the effect because `1 !== 0.5`. If there are multiple items in the array, React will re-run the effect even if just one of them is different.
 
 This also works for effects that have a cleanup phase:
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -138,7 +138,7 @@ function Example() {
   return (
     <div>
       <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
+      <button onClick={() => setCount(prevCount => prevCount + 1)}>
         Click me
       </button>
     </div>
@@ -399,7 +399,7 @@ function Example() {
   return (
     <div>
       <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
+      <button onClick={() => setCount(prevCount => prevCount + 1)}>
         Click me
       </button>
       <button onClick={handleAlertClick}>
@@ -696,7 +696,7 @@ function Counter() {
 
   useEffect(() => {
     const id = setInterval(() => {
-      setCount(c => c + 1); // ✅ This doesn't depend on `count` variable outside
+      setCount(prevCount => prevCount + 1); // ✅ This doesn't depend on `count` variable outside
     }, 1000);
     return () => clearInterval(id);
   }, []); // ✅ Our effect doesn't use any variables in the component scope

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -11,14 +11,14 @@ next: hooks-overview.html
 import React, { useState } from 'react';
 
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -18,20 +18,20 @@ Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). Th
 
 ## 📌 State Hook {#state-hook}
 
-This example renders a counter. When you click the button, it increments the value:
+This example renders a random number generator. When you click the button, it generates a random number:
 
 ```js{1,4,5}
 import React, { useState } from 'react';
 
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );
@@ -40,7 +40,7 @@ function Example() {
 
 Here, `useState` is a *Hook* (we'll talk about what this means in a moment). We call it inside a function component to add some local state to it. React will preserve this state between re-renders. `useState` returns a pair: the *current* state value and a function that lets you update it. You can call this function from an event handler or somewhere else. It's similar to `this.setState` in a class, except it doesn't merge the old and new state together. (We'll show an example comparing `useState` to `this.state` in [Using the State Hook](/docs/hooks-state.html).)
 
-The only argument to `useState` is the initial state. In the example above, it is `0` because our counter starts from zero. Note that unlike `this.state`, the state here doesn't have to be an object -- although it can be if you want. The initial state argument is only used during the first render.
+The only argument to `useState` is the initial state. In the example above, it is `0` because we didn't generate a random number yet. Note that unlike `this.state`, the state here doesn't have to be an object -- although it can be if you want. The initial state argument is only used during the first render.
 
 #### Declaring multiple state variables {#declaring-multiple-state-variables}
 
@@ -80,19 +80,19 @@ For example, this component sets the document title after React updates the DOM:
 import React, { useState, useEffect } from 'react';
 
 function Example() {
-  const [count, setCount] = useState(0);
+  const [randomNumber, setRandomNumber] = useState(0);
 
   // Similar to componentDidMount and componentDidUpdate:
   useEffect(() => {
-    // Update the document title using the browser API
-    document.title = `You clicked ${count} times`;
+    // Update the document title using the browser API    
+    document.title = `Random number: ${randomNumber}`;
   });
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );
@@ -133,10 +133,10 @@ In this example, React would unsubscribe from our `ChatAPI` when the component u
 Just like with `useState`, you can use more than a single effect in a component:
 
 ```js{3,8}
-function FriendStatusWithCounter(props) {
-  const [count, setCount] = useState(0);
+function FriendStatusWithRandomNumbers(props) {
+  const [randomNumber, setRandomNumber] = useState(0);
   useEffect(() => {
-    document.title = `You clicked ${count} times`;
+    document.title = `Random number: ${randomNumber}`;
   });
 
   const [isOnline, setIsOnline] = useState(null);

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -18,7 +18,7 @@ Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). Th
 
 ## 📌 State Hook {#state-hook}
 
-This example renders a random number generator. When you click the button, it generates a random number:
+This example renders a random number. When you click the button, it generates a random number:
 
 ```js{1,4,5}
 import React, { useState } from 'react';
@@ -84,7 +84,7 @@ function Example() {
 
   // Similar to componentDidMount and componentDidUpdate:
   useEffect(() => {
-    // Update the document title using the browser API    
+    // Update the document title using the browser API
     document.title = `Random number: ${randomNumber}`;
   });
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -51,7 +51,7 @@ During subsequent re-renders, the first value returned by `useState` will always
 
 #### Functional updates {#functional-updates}
 
-If the new state is computed using the previous state, you can pass a function to `setState`. The function will receive the previous value, and return an updated value. Here's an example of a counter component that uses both forms of `setState`:
+If the new state is computed using the previous state, you should pass a function to `setState`. The function will receive the previous value, and return an updated value. Here's an example of a counter component that uses both forms of `setState`:
 
 ```js
 function Counter({initialCount}) {
@@ -266,7 +266,7 @@ function reducer(state, action) {
     case 'decrement':
       return {count: state.count - 1};
     default:
-      throw new Error();
+      return state;
   }
 }
 
@@ -321,7 +321,7 @@ function reducer(state, action) {
     case 'reset':
       return init(action.payload);
     default:
-      throw new Error();
+      return state;
   }
 }
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -14,14 +14,14 @@ The [introduction page](/docs/hooks-intro.html) used this example to get familia
 import React, { useState } from 'react';
 
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 
   return (
     <div>
-      <p>You clicked {count} times</p>
-      <button onClick={() => setCount(count + 1)}>
-        Click me
+      <p>Random number: {randomNumber}</p>
+      <button onClick={() => setRandomNumber(Math.random())}>
+        Randomize
       </button>
     </div>
   );
@@ -39,16 +39,16 @@ class Example extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      count: 0
+      randomNumber: 0
     };
   }
 
   render() {
     return (
       <div>
-        <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
-          Click me
+        <p>Random number: {this.state.randomNumber}</p>
+        <button onClick={() => this.setState({ randomNumber: Math.random() })}>
+          Randomize
         </button>
       </div>
     );
@@ -56,11 +56,11 @@ class Example extends React.Component {
 }
 ```
 
-The state starts as `{ count: 0 }`, and we increment `state.count` when the user clicks a button by calling `this.setState()`. We'll use snippets from this class throughout the page.
+The state starts as `{ randomNumber: 0 }`, and we generate a new random number `state.randomNumber` when the user clicks a button by calling `this.setState()`. We'll use snippets from this class throughout the page.
 
 >Note
 >
->You might be wondering why we're using a counter here instead of a more realistic example. This is to help us focus on the API while we're still making our first steps with Hooks.
+>You might be wondering why we're using a random number generator here instead of a more realistic example. This is to help us focus on the API while we're still making our first steps with Hooks.
 
 ## Hooks and Function Components {#hooks-and-function-components}
 
@@ -108,14 +108,14 @@ function Example() {
 
 ## Declaring a State Variable {#declaring-a-state-variable}
 
-In a class, we initialize the `count` state to `0` by setting `this.state` to `{ count: 0 }` in the constructor:
+In a class, we initialize the `randomNumber` state to `0` by setting `this.state` to `{ randomNumber: 0 }` in the constructor:
 
 ```js{4-6}
 class Example extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      count: 0
+      randomNumber: 0
     };
   }
 ```
@@ -126,15 +126,15 @@ In a function component, we have no `this`, so we can't assign or read `this.sta
 import React, { useState } from 'react';
 
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 ```
 
-**What does calling `useState` do?** It declares a "state variable". Our variable is called `count` but we could call it anything else, like `banana`. This is a way to "preserve" some values between the function calls — `useState` is a new way to use the exact same capabilities that `this.state` provides in a class. Normally, variables "disappear" when the function exits but state variables are preserved by React.
+**What does calling `useState` do?** It declares a "state variable". Our variable is called `randomNumber` but we could call it anything else, like `banana`. This is a way to "preserve" some values between the function calls — `useState` is a new way to use the exact same capabilities that `this.state` provides in a class. Normally, variables "disappear" when the function exits but state variables are preserved by React.
 
-**What do we pass to `useState` as an argument?** The only argument to the `useState()` Hook is the initial state. Unlike with classes, the state doesn't have to be an object. We can keep a number or a string if that's all we need. In our example, we just want a number for how many times the user clicked, so pass `0` as initial state for our variable. (If we wanted to store two different values in state, we would call `useState()` twice.)
+**What do we pass to `useState` as an argument?** The only argument to the `useState()` Hook is the initial state. Unlike with classes, the state doesn't have to be an object. We can keep a number or a string if that's all we need. In our example, we just want a number to start with, so pass `0` as initial state for our variable. (If we wanted to store two different values in state, we would call `useState()` twice.)
 
-**What does `useState` return?** It returns a pair of values: the current state and a function that updates it. This is why we write `const [count, setCount] = useState()`. This is similar to `this.state.count` and `this.setState` in a class, except you get them in a pair. If you're not familiar with the syntax we used, we'll come back to it [at the bottom of this page](/docs/hooks-state.html#tip-what-do-square-brackets-mean).
+**What does `useState` return?** It returns a pair of values: the current state and a function that updates it. This is why we write `const [randomNumber, setRandomNumber] = useState()`. This is similar to `this.state.randomNumber` and `this.setState` in a class, except you get them in a pair. If you're not familiar with the syntax we used, we'll come back to it [at the bottom of this page](/docs/hooks-state.html#tip-what-do-square-brackets-mean).
 
 Now that we know what the `useState` Hook does, our example should make more sense:
 
@@ -142,11 +142,11 @@ Now that we know what the `useState` Hook does, our example should make more sen
 import React, { useState } from 'react';
 
 function Example() {
-  // Declare a new state variable, which we'll call "count"
-  const [count, setCount] = useState(0);
+  // Declare a new state variable, which we'll call "randomNumber"
+  const [randomNumber, setRandomNumber] = useState(0);
 ```
 
-We declare a state variable called `count`, and set it to `0`. React will remember its current value between re-renders, and provide the most recent one to our function. If we want to update the current `count`, we can call `setCount`.
+We declare a state variable called `randomNumber`, and set it to `0`. React will remember its current value between re-renders, and provide the most recent one to our function. If we want to update the current `randomNumber`, we can call `setRandomNumber`.
 
 >Note
 >
@@ -156,34 +156,34 @@ We declare a state variable called `count`, and set it to `0`. React will rememb
 
 ## Reading State {#reading-state}
 
-When we want to display the current count in a class, we read `this.state.count`:
+When we want to display the current random number in a class, we read `this.state.randomNumber`:
 
 ```js
-  <p>You clicked {this.state.count} times</p>
+  <p>Random number {this.state.randomNumber}</p>
 ```
 
-In a function, we can use `count` directly:
+In a function, we can use `randomNumber` directly:
 
 
 ```js
-  <p>You clicked {count} times</p>
+  <p>Random number {randomNumber}</p>
 ```
 
 ## Updating State {#updating-state}
 
-In a class, we need to call `this.setState()` to update the `count` state:
+In a class, we need to call `this.setState()` to update the `randomNumber` state:
 
 ```js{1}
-  <button onClick={() => this.setState({ count: this.state.count + 1 })}>
-    Click me
+  <button onClick={() => this.setState({ randomNumber: Math.random() })}>
+    Randomize
   </button>
 ```
 
-In a function, we already have `setCount` and `count` as variables so we don't need `this`:
+In a function, we already have `setRandomNumber` and `randomNumber` as variables so we don't need `this`:
 
 ```js{1}
-  <button onClick={() => setCount(count + 1)}>
-    Click me
+  <button onClick={() => setRandomNumber(Math.random())}>
+    Randomize
   </button>
 ```
 
@@ -199,13 +199,13 @@ Let's now **recap what we learned line by line** and check our understanding.
  1:  import React, { useState } from 'react';
  2:
  3:  function Example() {
- 4:    const [count, setCount] = useState(0);
+ 4:    const [randomNumber, setRandomNumber] = useState(0);
  5:
  6:    return (
  7:      <div>
- 8:        <p>You clicked {count} times</p>
- 9:        <button onClick={() => setCount(count + 1)}>
-10:         Click me
+ 8:        <p>Random number: {randomNumber}</p>
+ 9:        <button onClick={() => setRandomNumber(Math.random())}>
+10:         Randomize
 11:        </button>
 12:      </div>
 13:    );
@@ -213,8 +213,8 @@ Let's now **recap what we learned line by line** and check our understanding.
 ```
 
 * **Line 1:** We import the `useState` Hook from React. It lets us keep local state in a function component.
-* **Line 4:** Inside the `Example` component, we declare a new state variable by calling the `useState` Hook. It returns a pair of values, to which we give names. We're calling our variable `count` because it holds the number of button clicks. We initialize it to zero by passing `0` as the only `useState` argument. The second returned item is itself a function. It lets us update the `count` so we'll name it `setCount`.
-* **Line 9:** When the user clicks, we call `setCount` with a new value. React will then re-render the `Example` component, passing the new `count` value to it.
+* **Line 4:** Inside the `Example` component, we declare a new state variable by calling the `useState` Hook. It returns a pair of values, to which we give names. We're calling our variable `randomNumber` because it holds the generated random number. We initialize it to zero by passing `0` as the only `useState` argument. The second returned item is itself a function. It lets us update the `randomNumber` so we'll name it `setRandomNumber`.
+* **Line 9:** When the user clicks, we call `setRandomNumber` with a new value. React will then re-render the `Example` component, passing the new `randomNumber` value to it.
 
 This might seem like a lot to take in at first. Don't rush it! If you're lost in the explanation, look at the code above again and try to read it from top to bottom. We promise that once you try to "forget" how state works in classes, and look at this code with fresh eyes, it will make sense.
 
@@ -223,7 +223,7 @@ This might seem like a lot to take in at first. Don't rush it! If you're lost in
 You might have noticed the square brackets when we declare a state variable:
 
 ```js
-  const [count, setCount] = useState(0);
+  const [randomNumber, setRandomNumber] = useState(0);
 ```
 
 The names on the left aren't a part of the React API. You can name your own state variables:
@@ -270,6 +270,30 @@ In the above component, we have `age`, `fruit`, and `todos` as local variables, 
 You **don't have to** use many state variables. State variables can hold objects and arrays just fine, so you can still group related data together. However, unlike `this.setState` in a class, updating a state variable always *replaces* it instead of merging it.
 
 We provide more recommendations on splitting independent state variables [in the FAQ](/docs/hooks-faq.html#should-i-use-one-or-many-state-variables).
+
+### Tip: State Updates May Be Asynchronous {#state-updates-may-be-asynchronous}
+
+React may batch multiple state update calls into a single update for performance.
+
+```js
+const [count, setCount] = useState(0);
+```
+
+Because the current state, in our case `count`, may be updated asynchronously or too fast, you should not rely on their values for calculating the next state.
+
+For example, this code may fail to update the counter:
+
+```js
+// Wrong
+setCount(count + 1);
+```
+
+To fix it, we can use the [functional update form of `setState`](/docs/hooks-reference.html#functional-updates). That function will receive the previous state as an argument like the example below shows:
+
+```js
+// Correct
+setCount(prevCount => prevCount + 1);
+```
 
 ## Next Steps {#next-steps}
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -56,7 +56,7 @@ class Example extends React.Component {
 }
 ```
 
-The state starts as `{ randomNumber: 0 }`, and we generate a new random number `state.randomNumber` when the user clicks a button by calling `this.setState()`. We'll use snippets from this class throughout the page.
+The state starts as `{ randomNumber: 0 }`, and we generate a new random number when the user clicks a button by calling `this.setState()`. We'll use snippets from this class throughout the page.
 
 >Note
 >
@@ -213,7 +213,7 @@ Let's now **recap what we learned line by line** and check our understanding.
 ```
 
 * **Line 1:** We import the `useState` Hook from React. It lets us keep local state in a function component.
-* **Line 4:** Inside the `Example` component, we declare a new state variable by calling the `useState` Hook. It returns a pair of values, to which we give names. We're calling our variable `randomNumber` because it holds the generated random number. We initialize it to zero by passing `0` as the only `useState` argument. The second returned item is itself a function. It lets us update the `randomNumber` so we'll name it `setRandomNumber`.
+* **Line 4:** Inside the `Example` component, we declare a new state variable by calling the `useState` Hook. It returns a pair of values, to which we give names. We're calling our variable `randomNumber` because it holds a generated random number. We initialize it to zero by passing `0` as the only `useState` argument. The second returned item is itself a function. It lets us update the `randomNumber` so we'll name it `setRandomNumber`.
 * **Line 9:** When the user clicks, we call `setRandomNumber` with a new value. React will then re-render the `Example` component, passing the new `randomNumber` value to it.
 
 This might seem like a lot to take in at first. Don't rush it! If you're lost in the explanation, look at the code above again and try to read it from top to bottom. We promise that once you try to "forget" how state works in classes, and look at this code with fresh eyes, it will make sense.
@@ -279,7 +279,7 @@ React may batch multiple state update calls into a single update for performance
 const [count, setCount] = useState(0);
 ```
 
-Because the current state, in our case `count`, may be updated asynchronously or too fast, you should not rely on their values for calculating the next state.
+Because the current state, in our case `count`, may be updated asynchronously, you should not rely on this value for calculating the next state.
 
 For example, this code may fail to update the counter:
 


### PR DESCRIPTION
I recently went through the Hook docs to see how they work and was a little bit confused that a counter was used to demonstrate the `useState` hook, not because of the counter, but because it was used without callback function.

I think it's important that these few intro example(s) convey the correct usage which why I have replaced the counter examples with a simple random number generator.

```js
function Example() {
  // Declare a new state variable, which we'll call "randomNumber"
  const [randomNumber, setRandomNumber] = useState(0);

  return (
   <div>
     <p>Random number: {randomNumber}</p>
     <button onClick={() => setRandomNumber(Math.random())}>
       Randomize
     </button>
   </div>
 );
}
```

It should still be easy to understand and doesn't speak of batched state updates that especially depend on the previous state in these early documentation stages yet (just mentions it at the very bottom like the `setState` page is doing it).

However, I've left the counters untouched where it makes sense (especially when the API gets explained in more detail).