### PR TITLE
Remove mention of state only in class component

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -161,7 +161,7 @@ class Parent extends React.Component {
 }
 ```
 
-You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
+You should convert the component to a class if you need a ref to it.
 
 You can, however, **use the `ref` attribute inside a function component** as long as you refer to a DOM element or a class component:
 


### PR DESCRIPTION
The phrase `just like you do when you need lifecycle methods or state.` sounds like only Class components have state or lifecycles, which is not true with the introduction of Hooks. It can introduce confusion for people that know about Hooks, better to not mention it at all.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
