### PR TITLE
Add npm command in 'Getting started' topic in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This repo contains the source code and documentation powering [reactjs.org](http
 ### Installation
 
 1. `cd reactjs.org` to go into the project root
-1. `yarn` to install the website's npm dependencies
+1. `yarn` or `npm i` or `npm install` to install the website's npm dependencies
 
 ### Running locally
 
-1. `yarn dev` to start the hot-reloading development server (powered by [Gatsby](https://www.gatsbyjs.org))
+1. `yarn dev` or `npm run dev` to start the hot-reloading development server (powered by [Gatsby](https://www.gatsbyjs.org))
 1. `open http://localhost:8000` to open the site in your favorite browser
 
 ## Contributing


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Add npm command in 'Getting started' topic in README.md

1. Add `npm i` or `npm install` instead of only `yarn` 
2. Add `npm run dev` instead of only `yarn dev`