### PR TITLE
Move {...props} at the end of Component

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -225,7 +225,7 @@ function withMouse(Component) {
     render() {
       return (
         <Mouse render={mouse => (
-          <Component {...this.props} mouse={mouse} />
+          <Component mouse={mouse} {...this.props} />
         )}/>
       );
     }


### PR DESCRIPTION
As I had read in React docs about HOCs approach when {...props} stay at the end of <Component /> props is better because it avoids redeclaration of original props in <Component /> and unexpected behavior



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
