### PR TITLE
Fix search input overlap over nav links

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -50,7 +50,6 @@ const Header = ({location}: {location: Location}) => (
         <Link
           css={{
             display: 'flex',
-            marginRight: 10,
             height: '100%',
             alignItems: 'center',
             color: colors.brand,


### PR DESCRIPTION
Remove right margin on `LayoutHeader` link to fix overlap of `DocSearch` over Nav items caused due to longer React version number 

Overlap of search bar over nav links, caused by react version number(v16.10.2):

![Overlap](https://user-images.githubusercontent.com/8972095/67389765-e79b1a00-f5b8-11e9-94c4-a8657b1f9906.png)

No overlap in react version number (v16.8.0):

![16 8 6](https://user-images.githubusercontent.com/8972095/67389962-4a8cb100-f5b9-11e9-8ab4-159b82b7d64f.png)

Let me know if there is a better approach to fix this issue



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
