### PR TITLE
Update concurrent-mode-suspense.md

### DIFF
--- a/content/docs/concurrent-mode-suspense.md
+++ b/content/docs/concurrent-mode-suspense.md
@@ -108,7 +108,7 @@ So what's the point of Suspense? There's a few ways we can answer this:
 
 * **It lets you orchestrate intentionally designed loading states.** It doesn't say _how_ the data is fetched, but it lets you closely control the visual loading sequence of your app.
 
-* **It helps you avoid race conditions.** Even with `await`, asynchronous code is often error-prone. Suspense feels more like reading data *synchronously* — as if it was already loaded.
+* **It helps you avoid race conditions.** Even with `await`, asynchronous code is often error-prone. Suspense feels more like reading data *synchronously* — as if it were already loaded.
 
 ## Using Suspense in Practice {#using-suspense-in-practice}
 


### PR DESCRIPTION
According to [ProofreadNOW](https://www.proofreadnow.com/blog/bid/101485/If-I-Were-or-If-I-Was-Which-is-Correct),
> Guideline: Use were (instead of was) in statements that are contrary to fact.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
