### PR TITLE
Fix sidebar section title alignment

### DIFF
--- a/src/templates/components/MetaTitle/index.js
+++ b/src/templates/components/MetaTitle/index.js
@@ -15,6 +15,7 @@ const MetaTitle = ({children, title, cssProps = {}, onDark = false}) => (
       fontWeight: 700,
       lineHeight: 3,
       textTransform: 'uppercase',
+      textAlign: 'start',
       letterSpacing: '0.08em',
       ...cssProps,
     }}>


### PR DESCRIPTION
For narrow screen, the sidebar section title seemed to be center aligned:

![Screenshot 2019-10-29 at 12 26 33 PM](https://user-images.githubusercontent.com/2338632/67737795-6d024c80-fa47-11e9-8e37-0474b48ed57b.png)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
