### PR TITLE
Update code-splitting note that import() is part of ES2020

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -96,10 +96,8 @@ import("./math").then(math => {
 
 > Note:
 >
-> The dynamic `import()` syntax is a ECMAScript (JavaScript)
-> [proposal](https://github.com/tc39/proposal-dynamic-import) not currently
-> part of the language standard. It is expected to be accepted in the
-> near future.
+> The dynamic `import()` syntax is part of the ECMAScript (JavaScript) 2020 
+> language [specification](https://tc39.es/ecma262/).
 
 When Webpack comes across this syntax, it automatically starts code-splitting
 your app. If you're using Create React App, this is already configured for you


### PR DESCRIPTION
This updates text in the code-splitting section indicating that the `import()` syntax has finished the proposal process and is a part of the ES2020 specification.

- [Specification](https://tc39.es/ecma262/) that lists in multiple sections if you search for `import()` on the page
- The [v8 site](https://v8.dev/features/tags/es2020) also independently lists as part of ES2020