### PR TITLE
Fixing some typos

### DIFF
--- a/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
+++ b/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
@@ -133,7 +133,7 @@ export default PostRoute;
 Given such a definition, a router can:
 
 * Match a URL to a route definition.
-* Call the `prepare()` function to start loading that route's data. Note that `prepare()` is synchronous -- *we don't wait for the data to be ready*, since we want to start rendering more important parts of the view (like the post body) as quickly as possible.
+* Call the `prepare()` function to start loading that route's data. Note that `prepare()` is asynchronous -- *we don't wait for the data to be ready*, since we want to start rendering more important parts of the view (like the post body) as quickly as possible.
 * Pass the preloaded data to the component. If the component is ready -- the `React.lazy` dynamic import has completed -- the component will render and try to access its data. If not, `React.lazy` will suspend until the code is ready.
 
 This approach can be generalized to other data-fetching solutions. An app that uses REST might define a route like this:
@@ -194,7 +194,7 @@ function Post(props) {
     <div>
       <h1>{postData.title}</h1>
       <h2>by {postData.author}</h2>
-      {/* @defer pairs naturally w <Suspense> to make the UI non-blocking too */}
+      {/* @defer pairs naturally w/ <Suspense> to make the UI non-blocking too */}
       <Suspense fallback={<Spinner/>}>
         <CommentList post={post} />
       </Suspense>


### PR DESCRIPTION
I'm actually not even sure your `synchronous` typo is actually a typo, but calling a function that isn't literally `async` that immediately returns an object with nested, unresolved `Promises` doesn't seem to convey the right idea, so I'm assuming it was a typo?



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
