### PR TITLE
Fix sample code variable name on "Building Great User Experiences with Concurrent Mode and Suspense" blog post

### DIFF
--- a/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
+++ b/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
@@ -196,7 +196,7 @@ function Post(props) {
       <h2>by {postData.author}</h2>
       {/* @defer pairs naturally w <Suspense> to make the UI non-blocking too */}
       <Suspense fallback={<Spinner/>}>
-        <CommentList post={post} />
+        <CommentList post={props.post} />
       </Suspense>
     </div>
   );

--- a/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
+++ b/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
@@ -196,7 +196,7 @@ function Post(props) {
       <h2>by {postData.author}</h2>
       {/* @defer pairs naturally w <Suspense> to make the UI non-blocking too */}
       <Suspense fallback={<Spinner/>}>
-        <CommentList post={props.post} />
+        <CommentList post={postData} />
       </Suspense>
     </div>
   );


### PR DESCRIPTION
#2540 
I think `post` is `props.post`



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
