### PR TITLE
Wrong link to Profiling components article

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -176,7 +176,7 @@ To do this in Chrome:
 
 6. React events will be grouped under the **User Timing** label.
 
-For a more detailed walkthrough, check out [this article by Ben Schwarz](https://calibreapp.com/blog/2017-11-28-debugging-react/).
+For a more detailed walkthrough, check out [this article by Ben Schwarz](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad).
 
 Note that **the numbers are relative so components will render faster in production**. Still, this should help you realize when unrelated UI gets updated by mistake, and how deep and how often your UI updates occur.
 


### PR DESCRIPTION
Recommended article link, written by Ben Schwarz, returns a 404. Updated with correct link.
