### PR TITLE
fix: form superimposed on nav text in some responsive sizes

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -100,7 +100,6 @@ const Header = ({location}: {location: Location}) => (
           css={{
             display: 'contents',
             flex: '1',
-            display: 'flex',
             flexDirection: 'row',
             alignItems: 'stretch',
             overflowX: 'auto',

--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -98,6 +98,7 @@ const Header = ({location}: {location: Location}) => (
 
         <nav
           css={{
+            display: 'contents',
             flex: '1',
             display: 'flex',
             flexDirection: 'row',


### PR DESCRIPTION
In some responsive sizes, the `form` element was superimposed on the` nav` text.
I hope to continue contributing to this beautiful community  :smile:  :tada: 