### PR TITLE
Fix usePrevious

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -359,7 +359,7 @@ function Counter() {
 }
 
 function usePrevious(value) {
-  const ref = useRef();
+  const ref = useRef(value);
   useEffect(() => {
     ref.current = value;
   });


### PR DESCRIPTION
Fix initial value

The initial value should not be `undefined` at start to prevent triggering the `useEffect`.

Please check the demo: <https://codesandbox.io/s/6rrey>