### PR TITLE
Docs: Update wrong assignment in Test Renderer reference example

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -128,7 +128,7 @@ expect(root.toJSON()).toMatchSnapshot();
 
 // update with some different props
 act(() => {
-  root = root.update(<App value={2}/>);
+  root.update(<App value={2}/>);
 })
 
 // make assertions on root 


### PR DESCRIPTION
The existing code reassigns `root` on `root.update`, although `update` does not return the current instance of test renderer as seen [here](https://github.com/facebook/react/blob/969f4b5bb8302afb3eb1656784130651047c3718/packages/react-test-renderer/src/ReactTestRenderer.js#L497-L502).
