### PR TITLE
Fix React events package link in Codebase Overview

### DIFF
--- a/content/docs/codebase-overview.md
+++ b/content/docs/codebase-overview.md
@@ -217,7 +217,7 @@ Its source code is located in [`packages/react-reconciler`](https://github.com/f
 
 ### Event System {#event-system}
 
-React implements a synthetic event system which is agnostic of the renderers and works both with React DOM and React Native. Its source code is located in [`packages/react-events`](https://github.com/facebook/react/tree/master/packages/react-events).
+React implements a synthetic event system which is agnostic of the renderers and works both with React DOM and React Native. Its source code is located in [`packages/legacy-events`](https://github.com/facebook/react/tree/master/packages/legacy-events).
 
 There is a [video with a deep code dive into it](https://www.youtube.com/watch?v=dRo_egw7tBc) (66 mins).
 


### PR DESCRIPTION
Currently on the Codebase Overview page link to the React events package uses old package name so it leads to 404 page on GitHub. This PR fixes that issue.