### PR TITLE
Improve Web Components Section

### DIFF
--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -12,20 +12,58 @@ Most people who use React don't use Web Components, but you may want to, especia
 
 ## Using Web Components in React {#using-web-components-in-react}
 
+Web components are just custom (HTML) elements which can be used directly in React:
+
 ```javascript
-class HelloMessage extends React.Component {
-  render() {
-    return <div>Hello <x-search>{this.props.name}</x-search>!</div>;
-  }
-}
+const Dropdown = props => {
+  return <my-dropdown></my-dropdown>;
+};
 ```
 
-> Note:
->
-> Web Components often expose an imperative API. For instance, a `video` Web Component might expose `play()` and `pause()` functions. To access the imperative APIs of a Web Component, you will need to use a ref to interact with the DOM node directly. If you are using third-party Web Components, the best solution is to write a React component that behaves as a wrapper for your Web Component.
->
-> Events emitted by a Web Component may not properly propagate through a React render tree.
-> You will need to manually attach event handlers to handle these events within your React components.
+It's possible to pass primitive JavaScript data types directly as attributes. However, in case of arrays and objects, make sure to pass them in JSON format if you want to use them as attributes. As alternative, it's also possible to pass information as properties by defining them on the element instance. Last but not least, functions should be registered as event listeners. Events emitted by a Web Component may not properly propagate through a React render tree. You will need to manually attach event handlers to handle these events within your React components.
+
+```javascript
+const Dropdown = ({ label, option, options, onChange }) => {
+  const ref = React.useRef();
+  
+  React.useLayoutEffect(() => {
+    ref.current.addEventListener('onChange', customEvent =>
+      onChange(customEvent.detail)
+    );
+  }, []);
+  
+  return (
+    <my-dropdown
+      ref={ref}
+      label={label}
+      option={option}
+      options={JSON.stringify(options)}
+    />
+  );
+};
+```
+
+There exists a custom React hook, called [use-custom-element](https://github.com/the-road-to-learn-react/use-custom-element), which takes care about all the event listener registration, unregistration, and transformation of arrays/objects into JSON.
+
+```javascript
+import useCustomElement from 'use-custom-element';
+
+const Dropdown = props => {
+  const [customElementProps, ref] = useCustomElement(props);
+  
+  return <my-dropdown {...customElementProps} ref={ref} />;
+};
+```
+
+Check out [this tutorial about integrating a Web Component in React](https://www.robinwieruch.de/react-web-components/), if you want to dig deeper. 
+
+### FAQ
+
+**Imperative API**
+
+Web Components often expose an imperative API. For instance, a `video` Web Component might expose `play()` and `pause()` functions. To access the imperative APIs of a Web Component, you will need to use a ref to interact with the DOM node directly. If you are using third-party Web Components, the best solution is to write a React component that behaves as a wrapper for your Web Component.
+
+**JSX Sepcific Attributes**
 
 One common confusion is that Web Components use "class" instead of "className".
 


### PR DESCRIPTION
Hello there,

for a recent client of mine I had to dive into Web Components and how to use them in React. Their goal is to create a UI library, based on Web Standards, which shares a common structure, style  **and behavior**. This way they would enable all their developer teams to pick their frameworks of choice (React, Angular, ...) to wrap these common UI components. Long story short: I had to come up with a way to use Web Components in React. 

It's fairly straight forward, but I didn't find lots of documentation in the official React docs. Since I wrote extensively about [Web Components](https://www.robinwieruch.de/web-components-tutorial/) and [how to use them in React](https://www.robinwieruch.de/react-web-components/) myself, I thought it may be helpful for people who face the same scenario. 

Optionally it comes also with a [custom React hook](https://github.com/the-road-to-learn-react/use-custom-element) which takes care about formatting information to JSON and attaching (and detaching) event listeners. I hope it's useful for the community 🚀 🙂 

**Note: The original PR is from June 2019 https://github.com/reactjs/reactjs.org/pull/2094, but I applied some improvements**