### PR TITLE
Add note that shallowRenderer.createRenderrer can be used 

### DIFF
--- a/content/docs/addons-shallow-renderer.md
+++ b/content/docs/addons-shallow-renderer.md
@@ -47,6 +47,10 @@ expect(result.props.children).toEqual([
 ]);
 ```
 
+> Note:
+>
+> If you receive warnings or compiler errors about `ShallowRender` not being a constructable expression, the `ShallowRenderer.createRenderer();` function can be called instead of using the the new keyword.
+
 Shallow testing currently has some limitations, namely not supporting refs.
 
 > Note:


### PR DESCRIPTION
Hello! I was following the docs here for Shallow rendering, and I was using it in a project with typescript. Doing "new ShallowRenderer()" would not even compile in typescript, and tbh I don't disagree with its "expression is not constructible" error message. 

You can find more about the error I was having here: https://github.com/facebook/react/issues/17726

I had worried my dear little self for a great deal of time until stumbling across a stack overflow question with an answer that shed a sparkling glimmer of hope on this mystery method: https://stackoverflow.com/questions/45047316/how-to-use-react-test-renderer-shallow-with-typescript/

The purpose of this PR is to add a small note on the ShallowRendering page letting the users of this ShallowRendering api know they can use `ShallowRenderer.createRenderer();` if they receive errors about `ShallowRender` not being a constructible expression. 

Also, just wanted to throw it out there that maybe the regular, recommended way should be calling the "createRenderer" function. What is the current reasoning for instructing the users to try to instantiate this object with the `new` keyword?

Thanks!
- Jimbo