### PR TITLE
Added "WordPress Theme Browser" example app

### DIFF
--- a/content/community/examples.md
+++ b/content/community/examples.md
@@ -28,3 +28,4 @@ There are many example projects created by the React community. Feel free to add
 * **[BMI Calculator](https://github.com/GermaVinsmoke/bmi-calculator)** A React Hooks app for calculating BMI
 * **[ReactJS Hangman Game](https://github.com/vetrivelcsamy/reactjs-hangman)** ReactJS Hangman Game Find a Programming Language.
 * **[Radix Converter](https://github.com/kumom/radix-converter)** A small tool that converts numbers in radix 2 to 36 with arbitrary precision.
+* **[WordPress Theme Browser](https://github.com/maheshwaghmare/reactjs-wp-org-themes/)** A simple ReactJS app which display and search the WordPress themes.

--- a/content/community/examples.md
+++ b/content/community/examples.md
@@ -28,4 +28,4 @@ There are many example projects created by the React community. Feel free to add
 * **[BMI Calculator](https://github.com/GermaVinsmoke/bmi-calculator)** A React Hooks app for calculating BMI
 * **[ReactJS Hangman Game](https://github.com/vetrivelcsamy/reactjs-hangman)** ReactJS Hangman Game Find a Programming Language.
 * **[Radix Converter](https://github.com/kumom/radix-converter)** A small tool that converts numbers in radix 2 to 36 with arbitrary precision.
-* **[WordPress Theme Browser](https://github.com/maheshwaghmare/reactjs-wp-org-themes/)** A simple ReactJS app which display and search the WordPress themes.
+* **[WordPress Theme Browser](https://github.com/maheshwaghmare/reactjs-wp-org-themes/)** A simple ReactJS application to search and display the WordPress themes.


### PR DESCRIPTION
Added the link of example ReactJS application called "[ReactJS WordPress Theme Browser](https://maheshwaghmare.github.io/reactjs-wp-org-themes/)".

It searches the WordPress themes which are hosted on [https://wordpress.org/themes](https://wordpress.org/themes).