### PR TITLE
Replace var with const

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -235,9 +235,9 @@ The names on the left aren't a part of the React API. You can name your own stat
 This JavaScript syntax is called ["array destructuring"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Array_destructuring). It means that we're making two new variables `fruit` and `setFruit`, where `fruit` is set to the first value returned by `useState`, and `setFruit` is the second. It is equivalent to this code:
 
 ```js
-  var fruitStateVariable = useState('banana'); // Returns a pair
-  var fruit = fruitStateVariable[0]; // First item in a pair
-  var setFruit = fruitStateVariable[1]; // Second item in a pair
+  const fruitStateVariable = useState('banana'); // Returns a pair
+  const fruit = fruitStateVariable[0]; // First item in a pair
+  const setFruit = fruitStateVariable[1]; // Second item in a pair
 ```
 
 When we declare a state variable with `useState`, it returns a pair — an array with two items. The first item is the current value, and the second is a function that lets us update it. Using `[0]` and `[1]` to access them is a bit confusing because they have a specific meaning. This is why we use array destructuring instead.


### PR DESCRIPTION
I replaced `var` with `const` in the document below.
https://reactjs.org/docs/hooks-state.html#tip-what-do-square-brackets-mean

Reference: https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#use-const-where-possible-otherwise-let-dont-use-var