### PR TITLE
Updated URL to react performance article

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -176,7 +176,7 @@ To do this in Chrome:
 
 6. React events will be grouped under the **User Timing** label.
 
-For a more detailed walkthrough, check out [this article by Ben Schwarz](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad).
+For a more detailed walkthrough, check out [this article by Ben Schwarz](https://calibreapp.com/blog/react-performance-profiling-optimization).
 
 Note that **the numbers are relative so components will render faster in production**. Still, this should help you realize when unrelated UI gets updated by mistake, and how deep and how often your UI updates occur.
 


### PR DESCRIPTION
We've since moved all of our articles away from Medium as a publishing platform. 

This PR update the URL to the canonical source on the Calibre site. 