### PR TITLE
Updated strict-mode docs to use `UNSAFE_*` lifecycle method names

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -87,9 +87,9 @@ The commit phase is usually very fast, but rendering can be slow. For this reaso
 
 Render phase lifecycles include the following class component methods:
 * `constructor`
-* `componentWillMount`
-* `componentWillReceiveProps`
-* `componentWillUpdate`
+* `UNSAFE_componentWillMount`
+* `UNSAFE_componentWillReceiveProps`
+* `UNSAFE_componentWillUpdate`
 * `getDerivedStateFromProps`
 * `shouldComponentUpdate`
 * `render`

--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -87,9 +87,9 @@ The commit phase is usually very fast, but rendering can be slow. For this reaso
 
 Render phase lifecycles include the following class component methods:
 * `constructor`
-* `UNSAFE_componentWillMount`
-* `UNSAFE_componentWillReceiveProps`
-* `UNSAFE_componentWillUpdate`
+* `componentWillMount` (or `UNSAFE_componentWillMount`)
+* `componentWillReceiveProps` (or `UNSAFE_componentWillReceiveProps`)
+* `componentWillUpdate` (or `UNSAFE_componentWillUpdate`)
 * `getDerivedStateFromProps`
 * `shouldComponentUpdate`
 * `render`


### PR DESCRIPTION
The strict mode docs still reference the old `componentWill*` lifecycle method names, this updates them to be `UNSAFE_componentWill*`



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
