### PR TITLE
chore: add deploys to Netlify badge

### DIFF
--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -134,6 +134,12 @@ const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
               src={ossLogoPng}
             />
           </a>
+          <a href="https://www.netlify.com" target="_blank" rel="noopener">
+            <img
+              src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"
+              alt="deploys by Netlify"
+            />
+          </a>
           <p
             css={{
               color: colors.subtleOnDark,


### PR DESCRIPTION
this PR adds a "deploys to Netlify" badge to the footer of reactjs.org to meet [Netlify's open source policy](https://www.netlify.com/legal/open-source-policy/) requirements

in a previous PR, I misunderstood Netlify's open source policy (I am very good at reading) and added a "deploy to netlify" badge to the README, which actually has nothing to do with the policy. if https://github.com/reactjs/reactjs.org/pull/2680 is useful, I'm happy to see it through — if not, I can also close it

thanks, and sorry for the double-tap! 💜