### PR TITLE
I got this warning when using the former version

### DIFF
--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -175,7 +175,7 @@ Create React App supports TypeScript out of the box.
 To create a **new project** with TypeScript support, run:
 
 ```bash
-npx create-react-app my-app --typescript
+npx create-react-app my-app --template typescript
 ```
 
 You can also add it to an **existing Create React App project**, [as documented here](https://facebook.github.io/create-react-app/docs/adding-typescript).


### PR DESCRIPTION
The --typescript option has been deprecated and will be removed in a future release.
In future, please use --template typescript.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
