### PR TITLE
Remove outdated info in react-without-jsx

### DIFF
--- a/content/docs/react-without-jsx.md
+++ b/content/docs/react-without-jsx.md
@@ -40,7 +40,7 @@ ReactDOM.render(
 
 If you're curious to see more examples of how JSX is converted to JavaScript, you can try out [the online Babel compiler](babel://jsx-simple-example).
 
-The component can either be provided as a string, or as a subclass of `React.Component`, or a plain function for stateless components.
+The component can either be provided as a string, as a subclass of `React.Component`, or a plain function.
 
 If you get tired of typing `React.createElement` so much, one common pattern is to assign a shorthand:
 


### PR DESCRIPTION
Since Hooks were introduced to React, using plain functions to create components is not the same as creating stateless components.