### PR TITLE
Fix broken link on external-resources page

### DIFF
--- a/content/community/external-resources.md
+++ b/content/community/external-resources.md
@@ -18,4 +18,4 @@ There are many wonderful curated resources the React community has put together.
 
 - [Awesome React Talks](https://github.com/tiaanduplessis/awesome-react-talks) - A curated list of React talks.
 
-- [Hero35 React Hub](https://hero35.com/stack/react) - A website with _all_ React conferences and talks, categorized & curated.
+- [Hero35 React Hub](https://hero35.com/topic/react) - A website with _all_ React conferences and talks, categorized & curated.


### PR DESCRIPTION
Fix broken Hero35 link



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
