### PR TITLE
Fix code

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -119,7 +119,7 @@ class AutoFocusTextInput extends React.Component {
   }
 
   componentDidMount() {
-    this.textInput.current.focusTextInput();
+    this.textInput.current.focus();
   }
 
   render() {


### PR DESCRIPTION
in componentDidMount function  "**focusTextInput**" is never defined manually so it is better to put "**focus**" in "**this.textInput.current**".

**Wrong:**
```
componentDidMount() {
    this.textInput.current.focusTextInput();
}
```

**Right:**
```
componentDidMount() {
    this.textInput.current.focus();
}
```



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
