### PR TITLE
Change "rerender" to "re-render" for consistency

### DIFF
--- a/content/blog/2014-07-25-react-v0.11.1.md
+++ b/content/blog/2014-07-25-react-v0.11.1.md
@@ -37,7 +37,7 @@ Please try these builds out and [file an issue on GitHub](https://github.com/fac
 * `SyntheticMouseEvent.getEventModifierState` correctly renamed to `getModifierState`
 * `getModifierState` correctly returns a `boolean`
 * `getModifierState` is now correctly case sensitive
-* Empty Text node used in IE8 `innerHTML` workaround is now removed, fixing rerendering in certain cases
+* Empty Text node used in IE8 `innerHTML` workaround is now removed, fixing re-rendering in certain cases
 
 ### JSXTransformer {#jsxtransformer}
 * Fix duplicate variable declaration (caused issues in some browsers)

--- a/content/blog/2016-01-08-A-implies-B-does-not-imply-B-implies-A.md
+++ b/content/blog/2016-01-08-A-implies-B-does-not-imply-B-implies-A.md
@@ -3,7 +3,7 @@ title: "(A => B) !=> (B => A)"
 author: [jimfb]
 ---
 
-The documentation for `componentWillReceiveProps` states that `componentWillReceiveProps` will be invoked when the props change as the result of a rerender. Some people assume this means "if `componentWillReceiveProps` is called, then the props must have changed", but that conclusion is logically incorrect.
+The documentation for `componentWillReceiveProps` states that `componentWillReceiveProps` will be invoked when the props change as the result of a re-render. Some people assume this means "if `componentWillReceiveProps` is called, then the props must have changed", but that conclusion is logically incorrect.
 
 The guiding principle is one of my favorites from formal logic/mathematics:
  > A implies B does not imply B implies A

--- a/content/blog/2018-03-27-update-on-async-rendering.md
+++ b/content/blog/2018-03-27-update-on-async-rendering.md
@@ -60,7 +60,7 @@ Together with `componentDidUpdate`, this new lifecycle should cover all use case
 
 `embed:update-on-async-rendering/definition-getsnapshotbeforeupdate.js`
 
-The new `getSnapshotBeforeUpdate` lifecycle is called right before mutations are made (e.g. before the DOM is updated). The return value for this lifecycle will be passed as the third parameter to `componentDidUpdate`. (This lifecycle isn't often needed, but can be useful in cases like manually preserving scroll position during rerenders.)
+The new `getSnapshotBeforeUpdate` lifecycle is called right before mutations are made (e.g. before the DOM is updated). The return value for this lifecycle will be passed as the third parameter to `componentDidUpdate`. (This lifecycle isn't often needed, but can be useful in cases like manually preserving scroll position during re-renders.)
 
 Together with `componentDidUpdate`, this new lifecycle should cover all use cases for the legacy `componentWillUpdate`.
 

--- a/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
+++ b/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
@@ -38,7 +38,7 @@ Problems arise when any of these constraints are changed. This typically comes i
 
 ### Anti-pattern: Unconditionally copying props to state {#anti-pattern-unconditionally-copying-props-to-state}
 
-A common misconception is that `getDerivedStateFromProps` and `componentWillReceiveProps` are only called when props "change". These lifecycles are called any time a parent component rerenders, regardless of whether the props are "different" from before. Because of this, it has always been unsafe to _unconditionally_ override state using either of these lifecycles. **Doing so will cause state updates to be lost.**
+A common misconception is that `getDerivedStateFromProps` and `componentWillReceiveProps` are only called when props "change". These lifecycles are called any time a parent component re-renders, regardless of whether the props are "different" from before. Because of this, it has always been unsafe to _unconditionally_ override state using either of these lifecycles. **Doing so will cause state updates to be lost.**
 
 Let’s consider an example to demonstrate the problem. Here is a `EmailInput` component that "mirrors" an email prop in state:
 ```js
@@ -61,9 +61,9 @@ class EmailInput extends Component {
 }
 ```
 
-At first, this component might look okay. State is initialized to the value specified by props and updated when we type into the `<input>`. But if our component's parent rerenders, anything we've typed into the `<input>` will be lost! ([See this demo for an example.](https://codesandbox.io/s/m3w9zn1z8x)) This holds true even if we were to compare `nextProps.email !== this.state.email` before resetting.
+At first, this component might look okay. State is initialized to the value specified by props and updated when we type into the `<input>`. But if our component's parent re-renders, anything we've typed into the `<input>` will be lost! ([See this demo for an example.](https://codesandbox.io/s/m3w9zn1z8x)) This holds true even if we were to compare `nextProps.email !== this.state.email` before resetting.
 
-In this simple example, adding `shouldComponentUpdate` to rerender only when the email prop has changed could fix this. However in practice, components usually accept multiple props; another prop changing would still cause a rerender and improper reset. Function and object props are also often created inline, making it hard to implement a `shouldComponentUpdate` that reliably returns true only when a material change has happened. [Here is a demo that shows that happening.](https://codesandbox.io/s/jl0w6r9w59) As a result, `shouldComponentUpdate` is best used as a performance optimization, not to ensure correctness of derived state.
+In this simple example, adding `shouldComponentUpdate` to re-render only when the email prop has changed could fix this. However in practice, components usually accept multiple props; another prop changing would still cause a re-render and improper reset. Function and object props are also often created inline, making it hard to implement a `shouldComponentUpdate` that reliably returns true only when a material change has happened. [Here is a demo that shows that happening.](https://codesandbox.io/s/jl0w6r9w59) As a result, `shouldComponentUpdate` is best used as a performance optimization, not to ensure correctness of derived state.
 
 Hopefully it's clear by now why **it is a bad idea to unconditionally copy props to state**. Before reviewing possible solutions, let's look at a related problematic pattern: what if we were to only update the state when the email prop changes?
 
@@ -270,7 +270,7 @@ class Example extends Component {
 This implementation avoids recalculating `filteredList` more often than necessary. But it is more complicated than it needs to be, because it has to separately track and detect changes in both props and state in order to properly update the filtered list. In this example, we could simplify things by using `PureComponent` and moving the filter operation into the render method: 
 
 ```js
-// PureComponents only rerender if at least one state or prop value changes.
+// PureComponents only re-render if at least one state or prop value changes.
 // Change is determined by doing a shallow comparison of state and prop keys.
 class Example extends PureComponent {
   // State only needs to hold the current filter text value:
@@ -299,7 +299,7 @@ class Example extends PureComponent {
 }
 ```
 
-The above approach is much cleaner and simpler than the derived state version. Occasionally, this won't be good enough—filtering may be slow for large lists, and `PureComponent` won't prevent rerenders if another prop were to change. To address both of these concerns, we could add a memoization helper to avoid unnecessarily re-filtering our list:
+The above approach is much cleaner and simpler than the derived state version. Occasionally, this won't be good enough—filtering may be slow for large lists, and `PureComponent` won't prevent re-renders if another prop were to change. To address both of these concerns, we could add a memoization helper to avoid unnecessarily re-filtering our list:
 
 ```js
 import memoize from "memoize-one";

--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -13,7 +13,7 @@ Class components can bail out from rendering when their input props are the same
 
 ```js
 const MyComponent = React.memo(function MyComponent(props) {
-  /* only rerenders if props change */
+  /* only re-renders if props change */
 });
 ```
 

--- a/content/docs/concurrent-mode-adoption.md
+++ b/content/docs/concurrent-mode-adoption.md
@@ -129,7 +129,7 @@ You can think of the Blocking Mode as a "gracefully degraded" version of the Con
 |Cooperative Multitasking |🚫  |🚫  |✅  |
 |Automatic batching of multiple setStates     |🚫* |✅  |✅  |
 |[Priority-based Rendering](/docs/concurrent-mode-patterns.html#splitting-high-and-low-priority-state) |🚫  |🚫  |✅  |
-|[Interruptible Prerendering](/docs/concurrent-mode-intro.html#interruptible-rendering) |🚫  |🚫  |✅  |
+|[Interruptible Pre-rendering](/docs/concurrent-mode-intro.html#interruptible-rendering) |🚫  |🚫  |✅  |
 |[useTransition](/docs/concurrent-mode-patterns.html#transitions)  |🚫  |🚫  |✅  |
 |[useDeferredValue](/docs/concurrent-mode-patterns.html#deferring-a-value) |🚫  |🚫  |✅  |
 |[Suspense Reveal "Train"](/docs/concurrent-mode-patterns.html#suspense-reveal-train)  |🚫  |🚫  |✅  |

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -490,7 +490,7 @@ We didn't choose `useRef` in this example because an object ref doesn't notify u
 
 Note that we pass `[]` as a dependency array to `useCallback`. This ensures that our ref callback doesn't change between the re-renders, and so React won't call it unnecessarily.
 
-In this example, the callback ref will be called only when the component mounts and unmounts, since the rendered `<h1>` component stays present throughout any rerenders. If you want to be notified any time a component resizes, you may want to use [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) or a third-party Hook built on it.
+In this example, the callback ref will be called only when the component mounts and unmounts, since the rendered `<h1>` component stays present throughout any re-renders. If you want to be notified any time a component resizes, you may want to use [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) or a third-party Hook built on it.
 
 If you want, you can [extract this logic](https://codesandbox.io/s/m5o42082xy) into a reusable Hook:
 
@@ -907,7 +907,7 @@ function DeepChild(props) {
 
 This is both more convenient from the maintenance perspective (no need to keep forwarding callbacks), and avoids the callback problem altogether. Passing `dispatch` down like this is the recommended pattern for deep updates.
 
-Note that you can still choose whether to pass the application *state* down as props (more explicit) or as context (more convenient for very deep updates). If you use context to pass down the state too, use two different context types -- the `dispatch` context never changes, so components that read it don't need to rerender unless they also need the application state.
+Note that you can still choose whether to pass the application *state* down as props (more explicit) or as context (more convenient for very deep updates). If you use context to pass down the state too, use two different context types -- the `dispatch` context never changes, so components that read it don't need to re-render unless they also need the application state.
 
 ### How to read an often-changing value from `useCallback`? {#how-to-read-an-often-changing-value-from-usecallback}
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -69,7 +69,7 @@ function Counter({initialCount}) {
 
 The "+" and "-" buttons use the functional form, because the updated value is based on the previous value. But the "Reset" button uses the normal form, because it always sets the count back to the initial value.
 
-If your update function returns the exact same value, the subsequent rerender will be skipped completely.
+If your update function returns the exact same value, the subsequent re-render will be skipped completely.
 
 > Note
 >
@@ -182,7 +182,7 @@ const value = useContext(MyContext);
 
 Accepts a context object (the value returned from `React.createContext`) and returns the current context value for that context. The current context value is determined by the `value` prop of the nearest `<MyContext.Provider>` above the calling component in the tree.
 
-When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a rerender with the latest context `value` passed to that `MyContext` provider. Even if an ancestor uses [`React.memo`](/docs/react-api.html#reactmemo) or [`shouldComponentUpdate`](/docs/react-component.html#shouldcomponentupdate), a rerender will still happen starting at the component itself using `useContext`.
+When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a re-render with the latest context `value` passed to that `MyContext` provider. Even if an ancestor uses [`React.memo`](/docs/react-api.html#reactmemo) or [`shouldComponentUpdate`](/docs/react-component.html#shouldcomponentupdate), a re-render will still happen starting at the component itself using `useContext`.
 
 Don't forget that the argument to `useContext` must be the *context object itself*:
 

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -289,7 +289,7 @@ While it is generally recommended to use unidirectional data flow such as [React
 
 The simplest way to consume [Backbone](https://backbonejs.org/) models and collections from a React component is to listen to the various change events and manually force an update.
 
-Components responsible for rendering models would listen to `'change'` events, while components responsible for rendering collections would listen for `'add'` and `'remove'` events. In both cases, call [`this.forceUpdate()`](/docs/react-component.html#forceupdate) to rerender the component with the new data.
+Components responsible for rendering models would listen to `'change'` events, while components responsible for rendering collections would listen for `'add'` and `'remove'` events. In both cases, call [`this.forceUpdate()`](/docs/react-component.html#forceupdate) to re-render the component with the new data.
 
 In the example below, the `List` component renders a Backbone collection, using the `Item` component to render individual items.
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -146,9 +146,9 @@ Reorders can also cause issues with component state when indexes are used as key
 
 ## Tradeoffs {#tradeoffs}
 
-It is important to remember that the reconciliation algorithm is an implementation detail. React could rerender the whole app on every action; the end result would be the same. Just to be clear, rerender in this context means calling `render` for all components, it doesn't mean React will unmount and remount them. It will only apply the differences following the rules stated in the previous sections.
+It is important to remember that the reconciliation algorithm is an implementation detail. React could re-render the whole app on every action; the end result would be the same. Just to be clear, re-render in this context means calling `render` for all components, it doesn't mean React will unmount and remount them. It will only apply the differences following the rules stated in the previous sections.
 
-We are regularly refining the heuristics in order to make common use cases faster. In the current implementation, you can express the fact that a subtree has been moved amongst its siblings, but you cannot tell that it has moved somewhere else. The algorithm will rerender that full subtree.
+We are regularly refining the heuristics in order to make common use cases faster. In the current implementation, you can express the fact that a subtree has been moved amongst its siblings, but you cannot tell that it has moved somewhere else. The algorithm will re-render that full subtree.
 
 Because React relies on heuristics, if the assumptions behind them are not met, performance will suffer.
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,7 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
 
-`React.memo` only affects props changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
+`React.memo` only affects props changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still re-render when state or context change.
 
 By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
 


### PR DESCRIPTION
I noticed that there's some level of inconsistency of spelling the word "rerender"/"re-render", so I took a chance and changed from "rerender" to "re-render", because the latter has a wider use, at least in reactjs.org.

But feel free to close it if you feel it's an unnecessary churn.