### PR TITLE
explicitly remove global create-react-app before npx command

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -39,7 +39,11 @@ The React team primarily recommends these solutions:
 
 [Create React App](https://github.com/facebookincubator/create-react-app) is a comfortable environment for **learning React**, and is the best way to start building **a new [single-page](/docs/glossary.html#single-page-application) application** in React.
 
-It sets up your development environment so that you can use the latest JavaScript features, provides a nice developer experience, and optimizes your app for production. You’ll need to have Node >= 8.10 and npm >= 5.6 on your machine. To create a project, run:
+It sets up your development environment so that you can use the latest JavaScript features, provides a nice developer experience, and optimizes your app for production. You’ll need to have Node >= 8.10 and npm >= 5.6 on your machine. 
+
+> If you intalled `create-react-app` globally in the past you will want to remove it first `npm uninstall -g create-react-app`. 
+
+To create a project, run:
 
 ```bash
 npx create-react-app my-app


### PR DESCRIPTION
Having an old version of create-react-app installed globally makes this command fail in a way that is hard to understand. https://stackoverflow.com/questions/59188624/template-not-provided-using-create-react-app



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
