### PR TITLE
Fix og:image

### DIFF
--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -51,7 +51,7 @@ const TitleAndMetaTags = ({title, ogDescription, canonicalUrl}: Props) => {
       <meta property="og:title" content={title} />
       <meta property="og:type" content="website" />
       {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-      <meta property="og:image" content="/logo-og.png" />
+      <meta property="og:image" content="https://reactjs.org/logo-og.png" />
       <meta
         property="og:description"
         content={ogDescription || defaultDescription}


### PR DESCRIPTION
Currently, Logo is not displayed at Twitter card.
`og:image` is url, not path.
https://ogp.me/

https://deploy-preview-2745--reactjs.netlify.com
https://cards-dev.twitter.com/validator