### PR TITLE
There was no telling how to reproduce the issue

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -142,7 +142,7 @@ As a last resort, you can pass an item's index in the array as a key. This can w
 
 Reorders can also cause issues with component state when indexes are used as keys. Component instances are updated and reused based on their key. If the key is an index, moving an item changes it. As a result, component state for things like uncontrolled inputs can get mixed up and updated in unexpected ways.
 
-Here is [an example of the issues that can be caused by using indexes as keys](codepen://reconciliation/index-used-as-key) on CodePen, and here is [an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues](codepen://reconciliation/no-index-used-as-key).
+Here is [an example of the issues that can be caused by using indexes as keys](codepen://reconciliation/index-used-as-key) on CodePen, and here is [an updated version of the same example showing how not using indexes as keys will fix these reordering, sorting, and prepending issues](codepen://reconciliation/no-index-used-as-key). Enter some text in the box and click "Add New to End". Repeat three times and now reorder the list by clicking on "Sort by Earliest" and "Sort by Latest". In the first example,  the "created at" data is re-ordered but the entered text is not. In the second example, the entered text is re-ordered as expected.
 
 ## Tradeoffs {#tradeoffs}
 


### PR DESCRIPTION
I for one, went to the Codepen and click "Add New to Start" and "Add New To End" several times, and re-ordered the list, and they seemed to all work fine, in both examples. I then tried to Add New to Start or to the End alternatively, they seemed to work fine in both examples. I then wonder how to make it show there is a problem. Some readers may leave the site without thinking further. Some ReactJS programmer think it is only a performance issue and not related to data being not shown correctly. It turns out in the example the user has to type in some text and see the text not being ordered in the first example.  Add to start or end really doesn't matter.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
