### PR TITLE
Make React.memo documentation more clear

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,7 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
 
-`React.memo` only affects props changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
+`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change even if the props are the same.
 
 By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,7 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
 
-`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change even if the props are the same.
+`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
 
 By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
 


### PR DESCRIPTION
Just a small tweak to the language explaining `React.memo`. 

I had a discussion on Reactiflux that left me thinking that the language could be tweaked a bit here to further emphasize that it only cares about Props + "affects" seems misleading since it doesn't do anything to your props.