### PR TITLE
Use semantic button for event handler example

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -152,7 +152,7 @@ class MyComponent extends React.Component {
     if (this.state.error) {
       return <h1>Caught an error.</h1>
     }
-    return <div onClick={this.handleClick}>Click Me</div>
+    return <button onClick={this.handleClick}>Click Me</button>
   }
 }
 ```


### PR DESCRIPTION
As a general rule, `onClick` handlers should not be applied to non-interactive elements like a `div`. This is not substantive change to the code sample, but it does provide a better example of semantic HTML for developers reading the documentation.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
