### PR TITLE
Add redirect from old blog post url

### DIFF
--- a/content/blog/2020-02-26-react-v16.13.0.md
+++ b/content/blog/2020-02-26-react-v16.13.0.md
@@ -2,7 +2,7 @@
 title: "React v16.13.0"
 author: [threepointone]
 redirect_from:
-  - "blog/2020-03-02-react-v16.13.0.html"
+  - "blog/2020/03/02/react-v16.13.0.html"
 ---
 
 Today we are releasing React 16.13.0. It contains bugfixes and new deprecation warnings to help prepare for a future major release.

--- a/content/blog/2020-02-26-react-v16.13.0.md
+++ b/content/blog/2020-02-26-react-v16.13.0.md
@@ -1,6 +1,8 @@
 ---
 title: "React v16.13.0"
 author: [threepointone]
+redirect_from:
+  - "blog/2020-03-02-react-v16.13.0.html"
 ---
 
 Today we are releasing React 16.13.0. It contains bugfixes and new deprecation warnings to help prepare for a future major release.


### PR DESCRIPTION
https://github.com/reactjs/reactjs.org/pull/2782 broke the old link which might get cached in RSS clients etc. Maybe this works as an easy fix.