### PR TITLE
Remove shallow renderer from website navigation

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -100,8 +100,6 @@
       title: SyntheticEvent
     - id: test-utils
       title: Test Utilities
-    - id: shallow-renderer
-      title: Shallow Renderer
     - id: test-renderer
       title: Test Renderer
     - id: javascript-environment-requirements


### PR DESCRIPTION
We still support it (and you can find this page in search), but we're transitioning away to community maintenance.
So we're deemphasizing it on the website.
