### PR TITLE
Add Edge extension link for Devtools

### DIFF
--- a/content/blog/2015-09-02-new-react-developer-tools.md
+++ b/content/blog/2015-09-02-new-react-developer-tools.md
@@ -20,8 +20,8 @@ It contains a handful of new features, including:
 
 ## Installation {#installation}
 
-Download the new devtools from the [Chrome Web Store](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) and on [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) for Firefox. If you're developing using React, we highly recommend installing these devtools.
+Download the new devtools from the [Chrome Web Store](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) for Firefox, and [Microsoft Edge Addons](https://microsoftedge.microsoft.com/addons/detail/gpphkfbcpidddadnkolkpfckpihlkkil) for Edge. If you're developing using React, we highly recommend installing these devtools.
 
 If you already have the Chrome extension installed, it should autoupdate within the next week. You can also head to `chrome://extensions` and click "Update extensions now" if you'd like to get the new version today. If you installed the devtools beta, please remove it and switch back to the version from the store to make sure you always get the latest updates and bug fixes.
 
-If you run into any issues, please post them on our [react-devtools GitHub repo](https://github.com/facebook/react-devtools).
+If you run into any issues, please post them on the [React GitHub repo](https://github.com/facebook/react-devtools).

--- a/content/blog/2015-09-02-new-react-developer-tools.md
+++ b/content/blog/2015-09-02-new-react-developer-tools.md
@@ -24,4 +24,4 @@ Download the new devtools from the [Chrome Web Store](https://chrome.google.com/
 
 If you already have the Chrome extension installed, it should autoupdate within the next week. You can also head to `chrome://extensions` and click "Update extensions now" if you'd like to get the new version today. If you installed the devtools beta, please remove it and switch back to the version from the store to make sure you always get the latest updates and bug fixes.
 
-If you run into any issues, please post them on the [React GitHub repo](https://github.com/facebook/react-devtools).
+If you run into any issues, please post them on the [React GitHub repo](https://github.com/facebook/react).


### PR DESCRIPTION
Adds a link to the Edge extension in the devtools release post. 