### PR TITLE
Add shouldComponentUpdate to list of methods double called in Strict Mode

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -103,6 +103,7 @@ Strict mode can't automatically detect side effects for you, but it can help you
 * The `render` method
 * `setState` updater functions (the first argument)
 * The static `getDerivedStateFromProps` lifecycle
+* The `shouldComponentUpdate` method
 
 > Note:
 >


### PR DESCRIPTION
This landed in 16.13 via https://github.com/facebook/react/pull/17942