### PR TITLE
fix: extract instantiation of Remarkable

### DIFF
--- a/content/home/examples/a-component-using-external-plugins.js
+++ b/content/home/examples/a-component-using-external-plugins.js
@@ -1,6 +1,7 @@
 class MarkdownEditor extends React.Component {
   constructor(props) {
     super(props);
+    this.md = new Remarkable();
     this.handleChange = this.handleChange.bind(this);
     this.state = { value: 'Hello, **world**!' };
   }
@@ -10,8 +11,7 @@ class MarkdownEditor extends React.Component {
   }
 
   getRawMarkup() {
-    const md = new Remarkable();
-    return { __html: md.render(this.state.value) };
+    return { __html: this.md.render(this.state.value) };
   }
 
   render() {


### PR DESCRIPTION
Hello 👋!

Originally in the example **A Component Using External Plugins** `Remarkable` was instantiated each time render was called, while I believe the whole point of this example is to show how React can be integrated with other libraries, taking into account different lifecycles and how they're tied together.

With this change the plugin will be instantiated in the constructor, because it makes sense for it to exist throughout the full lifecycle of the component and the example will showcase the more complete and usual use-case this way.
