### PR TITLE
Remove mention of React.createFactory() in docs

### DIFF
--- a/content/warnings/legacy-factories.md
+++ b/content/warnings/legacy-factories.md
@@ -27,24 +27,9 @@ function render() {
 }
 ```
 
-## Without JSX {#without-jsx}
-
-If you don't want to, or can't use JSX, then you'll need to wrap your component in a factory before calling it:
-
-```javascript
-var React = require('react');
-var MyComponent = React.createFactory(require('MyComponent'));
-
-function render() {
-  return MyComponent({ foo: 'bar' });
-}
-```
-
-This is an easy upgrade path if you have a lot of existing function calls.
-
 ## Dynamic components without JSX {#dynamic-components-without-jsx}
 
-If you get a component class from a dynamic source, then it might be unnecessary to create a factory that you immediately invoke. Instead you can just create your element inline:
+If you get a component class from a dynamic source, you can also create your element inline:
 
 ```javascript
 var React = require('react');


### PR DESCRIPTION
In React v16.13.0, the React.createFactory() [got deprecated](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-reactcreatefactory) so it would be useful to not showcase it in a warning page about legacy factories usage.

This warning page (https://reactjs.org/warnings/legacy-factories.html) was one of the top Google results for me when I searched for "react createfactory" in Google after upgrading to React v16.13.0 and got confused.

![react_createfactory_-_Google-haku_-_Mozilla_Firefox](https://user-images.githubusercontent.com/482561/75959848-b36d2980-5ec7-11ea-8dee-a965dda5d2be.png)



I'm open to any wording suggestions. Feel free to change the text directly, too, if you have any ideas on how I could describe this better :relaxed:

Deploy preview of this change: https://deploy-preview-2814--reactjs.netlify.com/warnings/legacy-factories.html