### PR TITLE
Move Hungarian to in progress

### DIFF
--- a/content/languages.yml
+++ b/content/languages.yml
@@ -66,7 +66,7 @@
 - name: Hungarian
   translated_name: magyar
   code: hu
-  status: 0
+  status: 1
 - name: Armenian
   translated_name: Հայերեն
   code: hy


### PR DESCRIPTION
I just realized that Hungarian was in the wrong category. I now moved it to In Progress. In fact, the `Core` is nearly finished, only reviewing of 3 pages remain.