### PR TITLE
Add portal example using hooks

### DIFF
--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -48,7 +48,7 @@ A typical use case for portals is when a parent component has an `overflow: hidd
 >
 > For modal dialogs, ensure that everyone can interact with them by following the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal).
 
-[**Try it on CodePen**](https://codepen.io/gaearon/pen/yzMaBd)
+**Try it on CodePen**: [class version](https://codepen.io/gaearon/pen/yzMaBd), [hooks version](https://codepen.io/tjcrowder/pen/LYVeqyq)
 
 ## Event Bubbling Through Portals {#event-bubbling-through-portals}
 


### PR DESCRIPTION
If you fancy it, I converted the CodePen linked by the [Portals page](https://reactjs.org/docs/portals.html) to hooks. This PR changes the [**Try it on CodePen**](https://codepen.io/gaearon/pen/yzMaBd) link to **Try it on CodePen**: [class version](https://codepen.io/gaearon/pen/yzMaBd), [hooks version](https://codepen.io/tjcrowder/pen/LYVeqyq)

If you don't fancy it, no worries, I won't take offense. :-)

Please don't hesitate if you want anything changed, I'll update the PR accordingly.