### PR TITLE
remove parantheses from onClick method

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -440,7 +440,7 @@ class Square extends React.Component {
     return (
       <button
         className="square"
-        onClick={() => this.props.onClick()}
+        onClick={() => this.props.onClick}
       >
         {this.props.value}
       </button>


### PR DESCRIPTION
writing this.props.onClick() (with parantheses) invokes the passed method immediately. This causes an update of the component. In turn the render() method calls the method again, resulting in an infinite loop that finally crashes in a "Maximum depth exceeded" error.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
