### PR TITLE
Update components-and-props.md

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -164,8 +164,8 @@ First, we will extract `Avatar`:
 function Avatar(props) {
   return (
     <img className="Avatar"
-      src={props.user.avatarUrl}
-      alt={props.user.name}
+      src={props.avatarUrl}
+      alt={props.name}
     />
   );
 }


### PR DESCRIPTION
In the example provided, the Avatar component is being created with props.author. Hence, inside the Avatar component itself, it must only reference the object properties as-
1. `props.avatarUrl` instead of `props.user.avatarUrl`
2. `props.name` instead of `props.user.name`
The text explaining this should be changed as well.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
