### PR TITLE
WIP: add missing documentation URLs to /versions

### DIFF
--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,16 +1,23 @@
 - title: '16.13.0'
+  path: /version/16.13.0
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16130-february-26-2020
 - title: '16.12.0'
+  path: /version/16.12.0
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16120-november-14-2019
 - title: '16.11'
+  path: /version/16.11
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16110-october-22-2019
 - title: '16.10.2'
+  path: /version/16.10.2
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16102-october-3-2019
 - title: '16.10.1'
+  path: /version/16.10.1
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16101-september-28-2019
 - title: '16.10'
+  path: /version/16.10
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16100-september-27-2019
 - title: '16.9'
+  path: /version/16.9
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1690-august-8-2019
 - title: '16.8'
   path: /version/16.8


### PR DESCRIPTION
Looks like we missed adding these since 16.9. Opening a WIP till we figure out where to get the documentation urls from. 