### PR TITLE
Reorganize information about the plugin

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -27,6 +27,8 @@ By following this rule, you ensure that all stateful logic in a component is cle
 
 We released an ESLint plugin called [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) that enforces these two rules. You can add this plugin to your project if you'd like to try it:
 
+This plugin is included by default in [Create React App](/docs/create-a-new-react-app.html#create-react-app).
+
 ```bash
 npm install eslint-plugin-react-hooks --save-dev
 ```
@@ -45,8 +47,6 @@ npm install eslint-plugin-react-hooks --save-dev
   }
 }
 ```
-
-This plugin is included by default in [Create React App](/docs/create-a-new-react-app.html#create-react-app).
 
 **You can skip to the next page explaining how to write [your own Hooks](/docs/hooks-custom.html) now.** On this page, we'll continue by explaining the reasoning behind these rules.
 


### PR DESCRIPTION
Having the information that the plugin is already installed by default after the installation instructions is probably wasting a lot of people's time. Moving it up probably avoids multiple installs of the plugin.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
