### PR TITLE
Updated dates for Render-Atlanta 2020

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -42,11 +42,6 @@ May 1, 2020. Streamed online on YouTube.
 
 [Website](https://www.bytesized.xyz) - [Twitter](https://twitter.com/bytesizedcode) - [YouTube](https://www.youtube.com/channel/UC046lFvJZhiwSRWsoH8SFjg)
 
-### render(ATL) 2020 {#render-atlanta-2020}
-May 4-6, 2020. Atlanta, GA, USA.
-
-[Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/)
-
 ### ReactEurope 2020 {#reacteurope-2020}
 May 14-15, 2020 in Paris, France
 
@@ -81,6 +76,11 @@ July 18, 2020. Medellín, Colombia.
 July 29-30, 2020. Portland, Oregon, USA.
 
 [Website](https://infinite.red/ChainReactConf) - [Twitter](https://twitter.com/ChainReactConf)
+
+### render(ATL) 2020 {#render-atlanta-2020} 
+August 24-26, 2020. Atlanta, GA, USA.
+
+[Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
 
 ### ComponentsConf 2020 {#components20}
 September 1, 2020 in Melbourne, Australia


### PR DESCRIPTION
Date change for Render-Atlanta 2020 due to the Coronavirus pandemic.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
