### PR TITLE
Fix node version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 ### Prerequisites
 
 1. Git
-1. Node: any 8.x version starting with 8.4.0 or greater
+1. Node: any 12.x version starting with v12.0.0 or greater
 1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
 1. A fork of the repo (for any contributions)
 1. A clone of the [reactjs.org repo](https://github.com/reactjs/reactjs.org) on your local machine


### PR DESCRIPTION
I forgot to change the Node version in README when upgrading to Node 12 in #2831 , so here is the fix