### PR TITLE
Fix incorrect highlighting in uncontrolled components example

### DIFF
--- a/examples/uncontrolled-components/input-type-file.js
+++ b/examples/uncontrolled-components/input-type-file.js
@@ -6,7 +6,7 @@ class FileInput extends React.Component {
     this.fileInput = React.createRef();
   }
   handleSubmit(event) {
-    // highlight-range{4}
+    // highlight-range{3}
     event.preventDefault();
     alert(
       `Selected file - ${this.fileInput.current.files[0].name}`


### PR DESCRIPTION
In the example of using file input tag, incorrect line is highlighted.

Previous:
![571585658962_ pic](https://user-images.githubusercontent.com/10193500/78029449-2ff20b80-7393-11ea-915a-ab45ef2fd260.jpg)

Current:
![581585659314_ pic](https://user-images.githubusercontent.com/10193500/78029463-35e7ec80-7393-11ea-947f-cc862fa7e874.jpg)
