### PR TITLE
Fix object syntax error

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -242,7 +242,7 @@ function Todos() {
   const [todos, dispatch] = useReducer(todosReducer, []);
 
   function handleAddClick(text) {
-    dispatch({ type: 'add', text });
+    dispatch({ type: 'add', text: text });
   }
 
   // ...


### PR DESCRIPTION
The object passed into dispatch() function is missing the "text" key.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
