### PR TITLE
Explain why useMemo with stable deps runs 2x in dev

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -388,6 +388,10 @@ If no array is provided, a new value will be computed on every render.
 
 **You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to "forget" some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without `useMemo` — and then add it to optimize performance.
 
+> Warning
+>
+> When React is not running in production mode, React will run all `useMemo` callbacks _at least twice_, irrespective of whether one of the dependencies has changed. This is in order to help surface any bugs that may occur should React "forget" your memoized value.
+
 > Note
 >
 > The array of dependencies is not passed as arguments to the function. Conceptually, though, that's what they represent: every value referenced inside the function should also appear in the dependencies array. In the future, a sufficiently advanced compiler could create this array automatically.


### PR DESCRIPTION
As explained here:

https://twitter.com/acdlite/status/1067541668797145090

React will always run useMemo twice, even if the dependencies are identical. This is missing in the docs, and can make for a very frustrating developer experience.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
