### PR TITLE
Make the same as the react-transition-group docs

### DIFF
--- a/content/docs/addons-animation.md
+++ b/content/docs/addons-animation.md
@@ -23,8 +23,8 @@ The [`ReactTransitionGroup`](#low-level-api-reacttransitiongroup) add-on compone
 **Importing**
 
 ```javascript
-import ReactCSSTransitionGroup from 'react-transition-group'; // ES6
-var ReactCSSTransitionGroup = require('react-transition-group'); // ES5 with npm
+import { CSSTransitionGroup } from 'react-transition-group'; // ES6
+var CSSTransitionGroup = require('react-transition-group/CSSTransitionGroup') // ES5 with npm
 ```
 
 ```javascript{31-36}


### PR DESCRIPTION
Just suggesting update to documentation 😅 


Emulating what is shown here for imports: https://github.com/reactjs/react-transition-group/tree/v1-stable

Which is what worked for me.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
