### PR TITLE
Add link to useContext

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -19,6 +19,7 @@ In a typical React application, data is passed top-down (parent to child) via pr
 - [Examples](#examples)
   - [Dynamic Context](#dynamic-context)
   - [Updating Context from a Nested Component](#updating-context-from-a-nested-component)
+  - [Usage with useContext](#usage-with-usecontext)
   - [Consuming Multiple Contexts](#consuming-multiple-contexts)
 - [Caveats](#caveats)
 - [Legacy API](#legacy-api)
@@ -238,6 +239,10 @@ It is often necessary to update the context from a component that is nested some
 
 **app.js**
 `embed:context/updating-nested-context-app.js`
+
+### Usage with useContext
+
+https://reactjs.org/docs/hooks-reference.html#usecontext
 
 ### Consuming Multiple Contexts {#consuming-multiple-contexts}
 


### PR DESCRIPTION
I haven't created any contexts before, and I didn't know how to use the context without resorting to the ugly ctx => (<div><Component x={ctx.y} /></div>). I've read the hooks manual like a dozen times but that didn't help me remember the existence of useContext.


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
