### PR TITLE
change var name to make it compatible with CodePen

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -71,8 +71,8 @@ class Toggle extends React.Component {
   }
 
   handleClick() {
-    this.setState(state => ({
-      isToggleOn: !state.isToggleOn
+    this.setState(prevState => ({
+      isToggleOn: !prevState.isToggleOn
     }));
   }
 


### PR DESCRIPTION
changed the variable `state` into `prevState` to make it similar to what is used in CodePen to avoid confusion and emphasize the fact that it is in fact the previous state.