### PR TITLE
Remove unnecessary state and function from effect hook example

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -203,13 +203,7 @@ You might be thinking that we'd need a separate effect to perform the cleanup. B
 import React, { useState, useEffect } from 'react';
 
 function FriendStatus(props) {
-  const [isOnline, setIsOnline] = useState(null);
-
   useEffect(() => {
-    function handleStatusChange(status) {
-      setIsOnline(status.isOnline);
-    }
-
     ChatAPI.subscribeToFriendStatus(props.friend.id, handleStatusChange);
     // Specify how to clean up after this effect:
     return function cleanup() {


### PR DESCRIPTION
Presence of `handleStatusChange` function and `isOnline` state in general are unclear at this effect hook example. Also `isOnline` looks as `Boolean` by name. It might be `[status, setStatus]` state for consumers.

I could try to improve all hooks examples with this intention if it's appreciated.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
