### PR TITLE
Fix typos in callback as parameters

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -533,7 +533,7 @@ The second parameter to `setState()` is an optional callback function that will 
 You may optionally pass an object as the first argument to `setState()` instead of a function:
 
 ```javascript
-setState(stateChange[, callback])
+setState(stateChange, [callback])
 ```
 
 This performs a shallow merge of `stateChange` into the new state, e.g., to adjust a shopping cart item quantity:

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -33,7 +33,7 @@ React supports all popular browsers, including Internet Explorer 9 and above, al
 ### `render()` {#render}
 
 ```javascript
-ReactDOM.render(element, container[, callback])
+ReactDOM.render(element, container, [callback])
 ```
 
 Render a React element into the DOM in the supplied `container` and return a [reference](/docs/more-about-refs.html) to the component (or returns `null` for [stateless components](/docs/components-and-props.html#function-and-class-components)).
@@ -59,7 +59,7 @@ If the optional callback is provided, it will be executed after the component is
 ### `hydrate()` {#hydrate}
 
 ```javascript
-ReactDOM.hydrate(element, container[, callback])
+ReactDOM.hydrate(element, container, [callback])
 ```
 
 Same as [`render()`](#render), but is used to hydrate a container whose HTML contents were rendered by [`ReactDOMServer`](/docs/react-dom-server.html). React will attempt to attach event listeners to the existing markup.


### PR DESCRIPTION
This PR fixes typos in the docs when callback are being passed as parameters in 3 cases.