### PR TITLE
Explicitly state useCallback is a perf optimization

### DIFF
--- a/content/community/examples.md
+++ b/content/community/examples.md
@@ -10,7 +10,7 @@ There are many example projects created by the React community. We're keeping th
 
 If you add a project, please commit to keeping it up to date with the latest versions of React.
 
-## Small Examples
+## Small Examples {#small-examples}
 
 * **[Calculator](https://github.com/ahfarmer/calculator)** Implementation of the iOS calculator built in React
 * **[Emoji Search](https://github.com/ahfarmer/emoji-search)** React app for searching emoji
@@ -20,7 +20,7 @@ If you add a project, please commit to keeping it up to date with the latest ver
 * **[Counter App](https://github.com/arnab-datta/counter-app)** A small shopping cart example
 * **[Tutorial Solutions](https://github.com/harman052/react-tutorial-solutions)** Solutions to challenges mentioned at the end of React tutorial
 
-## Complete Apps
+## Complete Apps {#complete-apps}
 
 * **[Hacker News Clone React/GraphQL](https://github.com/clintonwoo/hackernews-react-graphql)** Hacker News clone rewritten with universal JavaScript, using React and GraphQL
 * **[Builder Book](https://github.com/builderbook/builderbook)** Open-source web app to write and host documentation or sell books. Built with React, Material-UI, Next, Express, Mongoose, MongoDB

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -366,6 +366,8 @@ Pass an inline callback and an array of dependencies. `useCallback` will return 
 
 `useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)`.
 
+**You may rely on `useCallback` as a performance optimization, not as a semantic guarantee.** In the future, React may change the callback reference in some situations, even when the dependencies did not change (e.g. to free memory for offscreen components). Write your code so that it still works without `useCallback` — and then add it to optimize performance.
+
 > Note
 >
 > The array of dependencies is not passed as arguments to the callback. Conceptually, though, that's what they represent: every value referenced inside the callback should also appear in the dependencies array. In the future, a sufficiently advanced compiler could create this array automatically.


### PR DESCRIPTION
I've updated the useCallback documentation to explicitly state that it should be used as a perf optimization only, and that it does not guarantee the reference will always remain stable.

![Screen Shot 2020-04-29 at 4 53 22 PM](https://user-images.githubusercontent.com/3639670/80658326-b35a5780-8a3a-11ea-9a77-0b873958daba.png)

