### PR TITLE
Updated URL in Footer

### DIFF
--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -122,7 +122,7 @@ const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
             },
           }}>
           <a
-            href="https://code.facebook.com/projects/"
+            href="https://opensource.facebook.com/projects/"
             target="_blank"
             rel="noopener">
             <img


### PR DESCRIPTION
Now `https://code.facebook.com/projects/` redirects to `https://opensource.facebook.com/`. 
So I changed the link `href` in Footer.
