### PR TITLE
docs(context): pass `context` to `super` when using `class` `constructor`

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -168,6 +168,8 @@ The `contextType` property on a class can be assigned a Context object created b
 >
 > You can only subscribe to a single context using this API. If you need to read more than one see [Consuming Multiple Contexts](#consuming-multiple-contexts).
 >
+> If you are using class `constructor(props, context)`, don't forget to pass `context` to `super(props, context)`, otherwise `this.context` will be an empty object.
+>
 > If you are using the experimental [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/), you can use a **static** class field to initialize your `contextType`.
 
 


### PR DESCRIPTION
Related #1395