### PR TITLE
docs(jsx-in-depth): HTML types from expressions

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -167,6 +167,17 @@ function Story(props) {
 }
 ```
 
+The same process applies if you want to use a general expression to indicate the type as a HTML element rather than a React component. To do so, assign the HTML element name as a string to a capitalized variable:
+
+```js{4-5}
+import React from 'react';
+
+function MyList(props) {
+  const ListType = props.ordered ? 'ol' : 'ul';
+  return <ListType>{props.children}</ListType>;
+}
+```
+
 ## Props in JSX {#props-in-jsx}
 
 There are several different ways to specify props in JSX.


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This expands the JSX docs on _Choosing a Type at Runtime_  to explain how to use a HTML type from an expression since the existing info covers just React components.

Related info is presented in https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized indicating what happens with lower-cased element types (eg string gets passed to create a React element), but this specifically spells out how to programmatically define a HTML element in the relevant section.
