### PR TITLE
Fix incorrect section and out-of-date info for "Road to React" course

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -18,8 +18,6 @@ permalink: community/courses.html
 
 - [React Armory: Learn React by Itself](https://reactarmory.com/guides/learn-react-by-itself) - With React Armory, you can learn React without the buzzwords.
 
-- [The Road to Learn React](https://www.robinwieruch.de/the-road-to-learn-react/) - Build a real world application in plain React without complicated tooling.
-
 - [Egghead.io: The Beginner's Guide to ReactJS](https://egghead.io/courses/the-beginner-s-guide-to-reactjs) - Free course for React newbies and those looking to get a better understanding of React fundamentals.
 
 - [Free React Bootcamp](https://tylermcginnis.com/free-react-bootcamp/) - Recordings from three days of a free online React bootcamp.
@@ -49,3 +47,5 @@ permalink: community/courses.html
 - [Tyler McGinnis](https://tylermcginnis.com/courses) - Tyler McGinnis provides access to his courses for a monthly fee. Courses include "React Fundamentals" and "Universal React".
 
 - [Mastering React](https://codewithmosh.com/p/mastering-react/) - Build professional interactive apps with React.
+
+- [The Road to Learn React](https://www.robinwieruch.de/the-road-to-learn-react/) - Build a real world application in plain React without complicated tooling.

--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -48,4 +48,4 @@ permalink: community/courses.html
 
 - [Mastering React](https://codewithmosh.com/p/mastering-react/) - Build professional interactive apps with React.
 
-- [The Road to Learn React](https://www.robinwieruch.de/the-road-to-learn-react/) - Build a real world application in plain React without complicated tooling.
+- [Road to React](https://www.roadtoreact.com/) - Your journey to master React in JavaScript.


### PR DESCRIPTION
Someone pointed out to me that "The Road to Learning React" was not available for free, despite being listed in the section for free courses. It seems like the book is now complete and it has since been premium-only.

I've moved it to the bottom of the paid section and updated the title, URL, and description to match its new branding. Feel free to move it around the paid section, I'm not sure how they're supposed to be sorted.