### PR TITLE
Add a link to Nx under the Flexible Toolchains section

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -73,6 +73,8 @@ The following toolchains offer more flexibility and choice. We recommend them to
 
 - **[Neutrino](https://neutrinojs.org/)** combines the power of [webpack](https://webpack.js.org/) with the simplicity of presets, and includes a preset for [React apps](https://neutrinojs.org/packages/react/) and [React components](https://neutrinojs.org/packages/react-components/).
 
+- **[Nx](https://nx.dev/react)** is a toolkit for full-stack monorepo development, with built-in support for React, Next.js, [Express](https://expressjs.com/), and more.
+
 - **[Parcel](https://parceljs.org/)** is a fast, zero configuration web application bundler that [works with React](https://parceljs.org/recipes.html#react).
 
 - **[Razzle](https://github.com/jaredpalmer/razzle)** is a server-rendering framework that doesn't require any configuration, but offers more flexibility than Next.js.


### PR DESCRIPTION
Hi 👋 , 

**Full disclaimer:** I'm on the Nx core team -- in charge of the React support.

We've been gaining some traction in the React community (already widely used by the Angular community), and I think it would be a useful tool for React teams using monorepos.

More info in README and docs site:
* https://www.npmjs.com/package/@nrwl/workspace
* https://nx.dev/react


PS. I added the link to Nx under Neutrino (I assume this section is sorted alphabetically).