### PR TITLE
Update lists-and-keys.md: eliminate huge space between properties

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -185,8 +185,7 @@ function NumberList(props) {
   const numbers = props.numbers;
   const listItems = numbers.map((number) =>
     // Correct! Key should be specified inside the array.
-    <ListItem key={number.toString()}
-              value={number} />
+    <ListItem key={number.toString()} value={number} />
   );
   return (
     <ul>


### PR DESCRIPTION
The newline compiled to a huge space between `key={number.toString()}` and `value={number}` and an empty line inside the block as the screenshot shows, and the patch fixed this.

![image](https://user-images.githubusercontent.com/25366956/82402495-5d614a00-9a11-11ea-9767-40a6a75a6e2b.png)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
