### PR TITLE
Merge duplicate props for noopener and noreferrer

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -51,8 +51,7 @@ const Header = ({location}: {location: Location}) => (
         <a
           style={{color: colors.brand}}
           target="_blank"
-          rel="noopener"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           href="https://support.eji.org/give/153413/#!/donation/checkout">
           Support&nbsp;the&nbsp;Equal&nbsp;Justice&nbsp;Initiative.
         </a>


### PR DESCRIPTION
I noticed that `rel=` is used twice here, so the resulting HTML would only be `rel="noreferrer"`. This fixes it to be `rel="noopener noreferrer"` for security.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
