### PR TITLE
<Avatar /> prop

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -182,7 +182,7 @@ function Comment(props) {
   return (
     <div className="Comment">
       <div className="UserInfo">
-        <Avatar user={props.author} />
+        <Avatar user={props.user} />
         <div className="UserInfo-name">
           {props.author.name}
         </div>


### PR DESCRIPTION
The string <Avatar user = {props.author} /> in the <Avatar /> component is confusing and should look like this:  <Avatar user = {props.user} />



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
