### PR TITLE
Update render-props.md : Added missing Mouse component in render

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -86,7 +86,7 @@ class Mouse extends React.Component {
 class MouseTracker extends React.Component {
   render() {
     return (
-      <>
+      <Mouse>
         <h1>Move the mouse around!</h1>
         <Mouse />
       </>


### PR DESCRIPTION
Added the missing <Mouse> component opening in MouseTracker render method. (Line 89)



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
