### PR TITLE
Rename handle useRef/TextInputWithFocusButton

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -407,14 +407,14 @@ A common use case is to access a child imperatively:
 ```js
 function TextInputWithFocusButton() {
   const inputEl = useRef(null);
-  const onButtonClick = () => {
+  const handleButtonClick = () => {
     // `current` points to the mounted text input element
     inputEl.current.focus();
   };
   return (
     <>
       <input ref={inputEl} type="text" />
-      <button onClick={onButtonClick}>Focus the input</button>
+      <button onClick={handleButtonClick}>Focus the input</button>
     </>
   );
 }


### PR DESCRIPTION
if you are creating component and exposing event hooks, those props would be on: onClick, onHover, onUsernameChanged, onError. From inside your components, these props are just functions you call on some event. You don't care what they do, your job is to just call them at the right time
if you are consuming another component, you want to add handling in response to these events, so you use handle: handleChange, handleClick, handleUserLogout, because your job is now to handle some event and make something happen in response to it. If you don't handle, no changes to the app state will be made



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
