### PR TITLE
Rename returned value of `create` in examples (`root` => `testRenderer`)

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -118,21 +118,21 @@ import {create, act} from 'react-test-renderer';
 import App from './app.js'; // The component being tested
 
 // render the component
-let root; 
+let testRenderer;
 act(() => {
-  root = create(<App value={1}/>)
+  testRenderer = create(<App value={1}/>)
 });
 
-// make assertions on root 
-expect(root.toJSON()).toMatchSnapshot();
+// make assertions on rendered tree
+expect(testRenderer.toJSON()).toMatchSnapshot();
 
 // update with some different props
 act(() => {
-  root.update(<App value={2}/>);
+  testRenderer.update(<App value={2}/>);
 })
 
-// make assertions on root 
-expect(root.toJSON()).toMatchSnapshot();
+// make assertions on rendered tree
+expect(testRenderer.toJSON()).toMatchSnapshot();
 ```
 
 ### `testRenderer.toJSON()` {#testrenderertojson}

--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -612,13 +612,13 @@ In rare cases, you may be running a test on a component that uses multiple rende
 import { act as domAct } from "react-dom/test-utils";
 import { act as testAct, create } from "react-test-renderer";
 // ...
-let root;
+let testRenderer;
 domAct(() => {
   testAct(() => {
-    root = create(<App />);
+    testRenderer = create(<App />);
   });
 });
-expect(root).toMatchSnapshot();
+expect(testRenderer).toMatchSnapshot();
 ```
 
 ---


### PR DESCRIPTION
Rename `root` to `testRenderer` in the code examples.

`create` returns a `ReactTestRenderer`, not a `ReactTestInstance` (which is what the name `root` implies). 