### PR TITLE
docs:(content/docs/strict-mode.md) fixed the documentation around strict mode double invoking function component bodies but only those which use hooks

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -101,7 +101,7 @@ Strict mode can't automatically detect side effects for you, but it can help you
 
 * Class component `constructor`, `render`, and `shouldComponentUpdate` methods
 * Class component static `getDerivedStateFromProps` method
-* Function component bodies
+* Function component bodies with hooks (for example: `useEffect`, `useState`)
 * State updater functions (the first argument to `setState`)
 * Functions passed to `useState`, `useMemo`, or `useReducer`
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Currently the documentation says it will double invoke function component bodies in strict mode. This can get slightly confusing in a scenario like this sandbox
https://codesandbox.io/s/inspiring-water-892dq?file=/src/App.js

Here only the function component body of `H1` is being double invoked as it has a call to a react hook `useEffect`.

Functional component `H2` in above sandbox is only being called once.

This is the reason I feel adding a little more context around the documentation for double invoking of functional component bodies will help the users.
