### PR TITLE
Renames props.author to props.user

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -182,9 +182,9 @@ function Comment(props) {
   return (
     <div className="Comment">
       <div className="UserInfo">
-        <Avatar user={props.author} />
+        <Avatar user={props.user} />
         <div className="UserInfo-name">
-          {props.author.name}
+          {props.user.name}
         </div>
       </div>
       <div className="Comment-text">
@@ -219,7 +219,7 @@ This lets us simplify `Comment` even further:
 function Comment(props) {
   return (
     <div className="Comment">
-      <UserInfo user={props.author} />
+      <UserInfo user={props.user} />
       <div className="Comment-text">
         {props.text}
       </div>


### PR DESCRIPTION
Renamed props.author to props.user to be more generic as documented



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
