### PR TITLE
Clarify use of map, add missing commas

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -222,13 +222,14 @@ Verifies the object is a React element. Returns `true` or `false`.
 
 `React.Children` provides utilities for dealing with the `this.props.children` opaque data structure.
 
-#### `React.Children.map` {#reactchildrenmap}
+#### `React.Children.
+` {#reactchildrenmap}
 
 ```javascript
-React.Children.map(children, function[(thisArg)])
+React.Children.map(children, function[, (thisArg)])
 ```
 
-Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is an array it will be traversed and the function will be called for each child in the array. If children is `null` or `undefined`, this method will return `null` or `undefined` rather than an array.
+Invokes a function on every immediate child contained within `children` with `this` set to `thisArg`. If `children` is an array it will be traversed and the function will be called for each child in the array. If the function returns `null`, the child will be removed from the result. If children is `null` or `undefined`, this method will return `null` or `undefined` rather than an array.
 
 > Note
 >
@@ -237,7 +238,7 @@ Invokes a function on every immediate child contained within `children` with `th
 #### `React.Children.forEach` {#reactchildrenforeach}
 
 ```javascript
-React.Children.forEach(children, function[(thisArg)])
+React.Children.forEach(children, function[, (thisArg)])
 ```
 
 Like [`React.Children.map()`](#reactchildrenmap) but does not return an array.


### PR DESCRIPTION
`map` behavior of filtering `null` children was not specified.  The missing comma in the parameter lists for `thisArg` made it very confusing.

The parentheses around `thisArg` could also be removed.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
