### PR TITLE
Mention re-throwing from error boundaries

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -21,6 +21,8 @@ Error boundaries are React components that **catch JavaScript errors anywhere in
 > * Asynchronous code (e.g. `setTimeout` or `requestAnimationFrame` callbacks)
 > * Server side rendering
 > * Errors thrown in the error boundary itself (rather than its children)
+>
+> (!) Error boundaries re-throw errors in react's [development mode](/docs/optimizing-performance.html).
 
 A class component becomes an error boundary if it defines either (or both) of the lifecycle methods [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) or [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Use `static getDerivedStateFromError()` to render a fallback UI after an error has been thrown. Use `componentDidCatch()` to log error information.
 


### PR DESCRIPTION
I had a hard time finding out that in development mode, react re-throws errors up from the boundary.
I only found it mentioned in the Sentry.io's docs.

So I thought that adding this to the official docs might be helpful.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
