### PR TITLE
refactor : replace double [if] with one [if]

### DIFF
--- a/scripts/generateHeadingIDs.js
+++ b/scripts/generateHeadingIDs.js
@@ -23,14 +23,11 @@ function stripLinks(line) {
 }
 
 function addHeaderID(line, slugger) {
-  // check if we're a header at all
-  if (!line.startsWith('#')) {
+// check if we're a header at all || it already has an id
+if (!line.startsWith('#') || /\{#[^}]+\}/.test(line)) {
     return line;
-  }
-  // check if it already has an id
-  if (/\{#[^}]+\}/.test(line)) {
-    return line;
-  }
+}
+  
   const headingText = line.slice(line.indexOf(' ')).trim();
   const headingLevel = line.slice(0, line.indexOf(' '));
   return `${headingLevel} ${headingText} {#${slugger.slug(


### PR DESCRIPTION
The previous double `if` are redundant because they return the same result.
We combine their conditions together in single `if`.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
