### PR TITLE
Release Channels page in the docs doesn't have "Previous article" or "Next article" links

### DIFF
--- a/content/docs/release-channels.md
+++ b/content/docs/release-channels.md
@@ -4,6 +4,8 @@ title: Release Channels
 permalink: docs/release-channels.html
 layout: docs
 category: installation
+prev: cdn-links.html
+next: hello-world.html
 ---
 
 React relies on a thriving open source community to file bug reports, open pull requests, and [submit RFCs](https://github.com/reactjs/rfcs). To encourage feedback we sometimes share special builds of React that include unreleased features.


### PR DESCRIPTION
This is a PR for bug #3068 



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
