### PR TITLE
Added Privacy and Terms footer links

### DIFF
--- a/src/components/LayoutFooter/Footer.js
+++ b/src/components/LayoutFooter/Footer.js
@@ -100,6 +100,12 @@ const Footer = ({layoutHasSidebar = false}: {layoutHasSidebar: boolean}) => (
           <FooterNav layoutHasSidebar={layoutHasSidebar}>
             <MetaTitle onDark={true}>{navFooter.more.title}</MetaTitle>
             <SectionLinks links={navFooter.more.items} />
+            <ExternalFooterLink href="https://opensource.facebook.com/legal/privacy">
+              Privacy
+            </ExternalFooterLink>
+            <ExternalFooterLink href="https://opensource.facebook.com/legal/terms">
+              Terms
+            </ExternalFooterLink>
           </FooterNav>
         </div>
         <section


### PR DESCRIPTION
These links don't really fit in to the existing categories very well, so I added them under "More"

![Screen Shot 2020-07-07 at 10 58 16 AM](https://user-images.githubusercontent.com/29597/86800198-c6903180-c040-11ea-913c-f57100ebdd15.png)
