### PR TITLE
Add sidebar item padding

### DIFF
--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -34,15 +34,14 @@ class Section extends React.Component {
             backgroundColor: 'transparent',
             border: 0,
             marginTop: 10,
-            paddingRight: 7,
-            paddingLeft: 7,
           }}
           onClick={onSectionTitleClick}>
           <MetaTitle
             cssProps={{
               [media.greaterThan('small')]: {
                 color: isActive ? colors.text : colors.subtle,
-
+                paddingRight: 7,
+                paddingLeft: 7,
                 ':hover': {
                   color: colors.text,
                 },

--- a/src/templates/components/Sidebar/Section.js
+++ b/src/templates/components/Sidebar/Section.js
@@ -34,6 +34,8 @@ class Section extends React.Component {
             backgroundColor: 'transparent',
             border: 0,
             marginTop: 10,
+            paddingRight: 7,
+            paddingLeft: 7,
           }}
           onClick={onSectionTitleClick}>
           <MetaTitle


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

# Quick CSS fix that Closes #3029

* Added paddingLeft & paddingRight to every sidebar title for better visualization when on focus.

## Before the fix
![image](https://user-images.githubusercontent.com/47342588/86871646-8ad08880-c08f-11ea-949c-7b286777d1b0.png)

## After the fix
![image](https://user-images.githubusercontent.com/47342588/86871635-83a97a80-c08f-11ea-9e40-34e4594e620c.png)

(Screenshots by @rickhanlonii ✨)