### PR TITLE
Correct broken link in acknowledgements.html.js

### DIFF
--- a/src/pages/acknowledgements.html.js
+++ b/src/pages/acknowledgements.html.js
@@ -72,7 +72,7 @@ const Acknowlegements = ({data, location}) => (
               <li>
                 <a href="https://github.com/voronianski">Dmitri Voronianski</a>{' '}
                 for letting us use the{' '}
-                <a href="https://labs.voronianski.com/oceanic-next-color-scheme/">
+                <a href="https://labs.voronianski.dev/oceanic-next-color-scheme/">
                   Oceanic Next
                 </a>{' '}
                 color scheme on this website.


### PR DESCRIPTION
Fixed a broken link on the [acknowledgements page](https://reactjs.org/acknowledgements.html). 
The link should redirect to [Oceanic Next](https://labs.voronianski.dev/oceanic-next-color-scheme/) instead of the link that's there. 
In reference to issue #3109 
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
