### PR TITLE
Hint at the fact that useState is pure

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -37,7 +37,7 @@ Returns a stateful value, and a function to update it.
 
 During the initial render, the returned state (`state`) is the same as the value passed as the first argument (`initialState`).
 
-The `setState` function is used to update the state. It accepts a new state value and enqueues a re-render of the component.
+The `setState` function is used to update the state. It accepts a new state value and enqueues a re-render of the component when the value has changed.
 
 ```js
 setState(newState);


### PR DESCRIPTION
Why
===

When migrating from React classes with state it can easily
be assumed that React classes' state behaves just like
`useState`. However this is not exactly right. The state
updater returned by `useState` does not cause a re-render
when the state value hasn't changed. In that sense it is
more similar to a class extending from `PureComponent`.

Currently it is not mentioned/hinted at the fact that these
are different.

What
====

Add a hint that points at this behavior. For a lot of users
this piece of information is probably irrelevant, but for
users migrating older codebases to hooks this is important
to know.
