### PR TITLE
Update urls of tools examples

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -45,7 +45,7 @@ console.log(add(16, 26)); // 42
 >
 > Your bundles will end up looking a lot different than this.
 
-If you're using [Create React App](https://github.com/facebookincubator/create-react-app), [Next.js](https://github.com/zeit/next.js/), [Gatsby](https://www.gatsbyjs.org/), or a similar tool, you will have a Webpack setup out of the box to bundle your
+If you're using [Create React App](https://github.com/facebook/create-react-app/), [Next.js](https://github.com/vercel/next.js/), [Gatsby](https://www.gatsbyjs.org/), or a similar tool, you will have a Webpack setup out of the box to bundle your
 app.
 
 If you aren't, you'll need to setup bundling yourself. For example, see the

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -45,7 +45,7 @@ console.log(add(16, 26)); // 42
 >
 > Your bundles will end up looking a lot different than this.
 
-If you're using [Create React App](https://github.com/facebook/create-react-app/), [Next.js](https://github.com/vercel/next.js/), [Gatsby](https://www.gatsbyjs.org/), or a similar tool, you will have a Webpack setup out of the box to bundle your
+If you're using [Create React App](https://create-react-app.dev/), [Next.js](https://nextjs.org/), [Gatsby](https://www.gatsbyjs.org/), or a similar tool, you will have a Webpack setup out of the box to bundle your
 app.
 
 If you aren't, you'll need to setup bundling yourself. For example, see the


### PR DESCRIPTION
Some urls are outdated, they still redirect to the correct page but for example the info you can see on the bottom left of the page to know which page you're about to visit when hovering the link is wrong.

- https://github.com/facebookincubator/create-react-app -> https://github.com/facebook/create-react-app
- https://github.com/zeit/next.js/ -> https://github.com/vercel/next.js

<img width="1208" alt="Screenshot 2020-07-20 at 17 58 15" src="https://user-images.githubusercontent.com/25059869/87959059-a174d780-cab2-11ea-818b-4fb522e0981e.png">
