### PR TITLE
Added a new (very common) false Hook usage in Doc

### DIFF
--- a/content/warnings/invalid-hook-call-warning.md
+++ b/content/warnings/invalid-hook-call-warning.md
@@ -13,6 +13,7 @@ There are three common reasons you might be seeing it:
 1. You might have **mismatching versions** of React and React DOM.
 2. You might be **breaking the [Rules of Hooks](/docs/hooks-rules.html)**.
 3. You might have **more than one copy of React** in the same app.
+4. You might be calling the component as `function` but not `component`.
 
 Let's look at each of these cases.
 
@@ -116,6 +117,11 @@ This problem can also come up when you use `npm link` or an equivalent. In that 
 >Note
 >
 >In general, React supports using multiple independent copies on one page (for example, if an app and a third-party widget both use it). It only breaks if `require('react')` resolves differently between the component and the `react-dom` copy it was rendered with.
+
+## Calling the component as `function` but not `component`
+Calling a functional component as `function` (for example, calling `ComponentWithHook()` instead of `<ComponentWithHook />`) will **not** mount the component, and eliminate the whole react lifecycle. This will block Hook from working.
+
+In this case, the solution is straightforward: just call `<ComponentWithHook />`, but not `ComponentWithHook()`.
 
 ## Other Causes {#other-causes}
 


### PR DESCRIPTION
A commonly false use case for Hook, especially for beginners in React, is to call a functional component directly as `function`. This is fine for normal components without a Hook, but for components with a Hook, code will break and show `Invalid Hook Call Warning`.

Current `Invalid Hook Call Warning` doesn't mention this cause, and made developers hard to debug. Adding this common cause to `Invalid Hook Call Warning` will make developers life much easier!



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
