### PR TITLE
Adding padding around h2 and h3 titles

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -27,6 +27,8 @@ If you're new to Hooks, you might want to check out [the overview](/docs/hooks-o
 
 ## Basic Hooks {#basic-hooks}
 
+Hooks are functions that let you “hook into” React state and lifecycle features from function components. Here are 3 of the most basic and most often used Hooks in React.
+
 ### `useState` {#usestate}
 
 ```js

--- a/src/theme.js
+++ b/src/theme.js
@@ -320,7 +320,7 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 90,
+        paddingTop: 120,
         marginTop: -45,
       },
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -287,7 +287,7 @@ const sharedStyles = {
         content: ' ',
         display: 'block',
         borderBottom: `1px solid ${colors.divider}`,
-        paddingTop: 44,
+        paddingTop: 85,
         marginBottom: 40,
       },
 
@@ -320,7 +320,7 @@ const sharedStyles = {
       '::before': {
         content: ' ',
         display: 'block',
-        paddingTop: 120,
+        paddingTop: 125,
         marginTop: -45,
       },
 


### PR DESCRIPTION
This PR offers a fix to close #3113 and adds padding around `h2` and `h3` elements. These were previously hidden under the header navigation.

Since this change is to the `theme.js` file, take a look around the rest of the site and check you are happy with how the padding affects other pages and headlines.

I've also add some intro text for "Basic hooks". This gives a consistent intro just like the "Additional Hooks" section, but also adds some padding between the section title and the useState content. The text comes from [here](https://reactjs.org/docs/hooks-overview.html#:~:text=Hooks%20are%20functions%20that%20let,you%20use%20React%20without%20classes.&text=You%20can%20also%20create%20your,stateful%20behavior%20between%20different%20components.) and some of my own wording. I'm happy to change this as needed.

> Hooks are functions that let you “hook into” React state and lifecycle features from function components. Here are 3 of the most basic and most often used Hooks in React.

Below are some screenshots to show how these new padding values look on desktop and mobile.

### Desktop
![Screenshot 2020-07-27 at 11 24 52](https://user-images.githubusercontent.com/4730761/88526472-408e5780-cffc-11ea-8924-25845fb59762.png)

### Mobile
![Screenshot 2020-07-27 at 11 25 00](https://user-images.githubusercontent.com/4730761/88526467-3f5d2a80-cffc-11ea-8c53-bb37e494346f.png)
