### PR TITLE
fix(docs): using ref.current instead of ref in the dependency array.

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -972,7 +972,7 @@ function useEventCallback(fn, dependencies) {
   return useCallback(() => {
     const fn = ref.current;
     return fn();
-  }, [ref]);
+  }, [ref.current]);
 }
 ```
 


### PR DESCRIPTION
Changed 'ref' -> 'ref.current' in the dependency array.
(ref doesn't change at all, we should use 'ref.current' instead of 'ref')



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
