### PR TITLE
add empty dependencies to useEffect in custom hook

### DIFF
--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -27,7 +27,7 @@ function FriendStatus(props) {
     return () => {
       ChatAPI.unsubscribeFromFriendStatus(props.friend.id, handleStatusChange);
     };
-  });
+  }, []);
 
   if (isOnline === null) {
     return 'Loading...';


### PR DESCRIPTION
The useEffect in https://reactjs.org/docs/hooks-custom.html#extracting-a-custom-hook is missing the empty dependency array



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
