### PR TITLE
Add onAuxClick to Mouse Events documentation

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -200,9 +200,9 @@ onError onLoad
 Event names:
 
 ```
-onClick onContextMenu onDoubleClick onDrag onDragEnd onDragEnter onDragExit
-onDragLeave onDragOver onDragStart onDrop onMouseDown onMouseEnter onMouseLeave
-onMouseMove onMouseOut onMouseOver onMouseUp
+onAuxClick onClick onContextMenu onDoubleClick onDrag onDragEnd onDragEnter
+onDragExit onDragLeave onDragOver onDragStart onDrop onMouseDown onMouseEnter
+onMouseLeave onMouseMove onMouseOut onMouseOver onMouseUp
 ```
 
 The `onMouseEnter` and `onMouseLeave` events propagate from the element being left to the one being entered instead of ordinary bubbling and do not have a capture phase.


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This adds `onAuxClick` to documentation which has been supported since [16.5.0 (September 5, 2018)](https://github.com/facebook/react/blob/655affa302437208e6f03c9ca6d170ea1707ace3/CHANGELOG.md#1650-september-5-2018). 

Since this is not [fully supported](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event) by all modern browsers (Safari 😕) I don't know if you guys add a warning or extra information for this event in particular.


