### PR TITLE
Remove event pooling and SyntheticEvent#persist from documents

### DIFF
--- a/content/docs/faq-functions.md
+++ b/content/docs/faq-functions.md
@@ -289,9 +289,6 @@ class Searchbox extends React.Component {
   }
 
   handleChange(e) {
-    // React pools events, so we read the value before debounce.
-    // Alternately we could call `event.persist()` and pass the entire event.
-    // For more info see reactjs.org/docs/events.html#event-pooling
     this.emitChangeDebounced(e.target.value);
   }
 

--- a/content/docs/legacy-event-pooling.md
+++ b/content/docs/legacy-event-pooling.md
@@ -4,7 +4,7 @@ title: Legacy Event Pooling
 permalink: docs/legacy-event-pooling.html
 ---
 
-The [`SyntheticEvent`](/docs/events.html) has been pooled until React 17. This means that the `SyntheticEvent` object will be reused and all properties will be nullified after the event callback has been invoked.
+In React 16 and earlier, the [`SyntheticEvent`](/docs/events.html) was pooled. This means that the `SyntheticEvent` object will be reused and all properties will be nullified after the event callback has been invoked.
 This is for performance reasons.
 As such, you cannot access the event in an asynchronous way.
 

--- a/content/docs/legacy-event-pooling.md
+++ b/content/docs/legacy-event-pooling.md
@@ -1,6 +1,6 @@
 ---
 id: legacy-event-pooling
-title: Legacy Event Pooling
+title: Event Pooling
 permalink: docs/legacy-event-pooling.html
 ---
 

--- a/content/docs/legacy-event-pooling.md
+++ b/content/docs/legacy-event-pooling.md
@@ -1,0 +1,29 @@
+---
+id: legacy-event-pooling
+title: Legacy Event Pooling
+permalink: docs/legacy-event-pooling.html
+---
+
+The [`SyntheticEvent`](/docs/events.html) has been pooled until React 17. This means that the `SyntheticEvent` object will be reused and all properties will be nullified after the event callback has been invoked.
+This is for performance reasons.
+As such, you cannot access the event in an asynchronous way.
+
+```javascript
+function onClick(event) {
+  console.log(event); // => nullified object.
+  console.log(event.type); // => "click"
+  const eventType = event.type; // => "click"
+  setTimeout(function() {
+    console.log(event.type); // => null
+    console.log(eventType); // => "click"
+  }, 0);
+  // Won't work. this.state.clickEvent will only contain null values.
+  this.setState({clickEvent: event});
+  // You can still export event properties.
+  this.setState({eventType: event.type});
+}
+```
+
+> Note:
+>
+> If you want to access the event properties in an asynchronous way, you should call `event.persist()` on the event, which will remove the synthetic event from the pool and allow references to the event to be retained by user code.

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -26,10 +26,15 @@ void preventDefault()
 boolean isDefaultPrevented()
 void stopPropagation()
 boolean isPropagationStopped()
+void persist()
 DOMEventTarget target
 number timeStamp
 string type
 ```
+
+> Note:
+>
+> As of v17, `e.persist()` doesn't do anything because the `SyntheticEvent` is no longer pooled.
 
 > Note:
 >

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -26,7 +26,6 @@ void preventDefault()
 boolean isDefaultPrevented()
 void stopPropagation()
 boolean isPropagationStopped()
-void persist()
 DOMEventTarget target
 number timeStamp
 string type
@@ -35,35 +34,6 @@ string type
 > Note:
 >
 > As of v0.14, returning `false` from an event handler will no longer stop event propagation. Instead, `e.stopPropagation()` or `e.preventDefault()` should be triggered manually, as appropriate.
-
-### Event Pooling {#event-pooling}
-
-The `SyntheticEvent` is pooled. This means that the `SyntheticEvent` object will be reused and all properties will be nullified after the event callback has been invoked.
-This is for performance reasons.
-As such, you cannot access the event in an asynchronous way.
-
-```javascript
-function onClick(event) {
-  console.log(event); // => nullified object.
-  console.log(event.type); // => "click"
-  const eventType = event.type; // => "click"
-
-  setTimeout(function() {
-    console.log(event.type); // => null
-    console.log(eventType); // => "click"
-  }, 0);
-
-  // Won't work. this.state.clickEvent will only contain null values.
-  this.setState({clickEvent: event});
-
-  // You can still export event properties.
-  this.setState({eventType: event.type});
-}
-```
-
-> Note:
->
-> If you want to access the event properties in an asynchronous way, you should call `event.persist()` on the event, which will remove the synthetic event from the pool and allow references to the event to be retained by user code.
 
 ## Supported Events {#supported-events}
 

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -34,7 +34,7 @@ string type
 
 > Note:
 >
-> As of v17, `e.persist()` doesn't do anything because the `SyntheticEvent` is no longer pooled.
+> As of v17, `e.persist()` doesn't do anything because the `SyntheticEvent` is no longer [pooled](/docs/legacy-event-pooling.html).
 
 > Note:
 >

--- a/static/_redirects
+++ b/static/_redirects
@@ -12,7 +12,7 @@
 /link/dangerously-set-inner-html    /docs/dom-elements.html#dangerouslysetinnerhtml
 /link/derived-state                 /blog/2018/06/07/you-probably-dont-need-derived-state.html
 /link/error-boundaries              /docs/error-boundaries.html
-/link/event-pooling                 /docs/events.html#event-pooling
+/link/event-pooling                 /docs/legacy-event-pooling.html
 /link/hooks-data-fetching           /docs/hooks-faq.html#how-can-i-do-data-fetching-with-hooks
 /link/invalid-aria-props            /warnings/invalid-aria-prop.html
 /link/invalid-hook-call             /warnings/invalid-hook-call-warning.html

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
     { "source": "/link/dangerously-set-inner-html", "destination": "/docs/dom-elements.html#dangerouslysetinnerhtml", "permanent": false },
     { "source": "/link/derived-state", "destination": "/blog/2018/06/07/you-probably-dont-need-derived-state.html", "permanent": false },
     { "source": "/link/error-boundaries", "destination": "/docs/error-boundaries.html", "permanent": false },
-    { "source": "/link/event-pooling", "destination": "/docs/events.html#event-pooling", "permanent": false },
+    { "source": "/link/event-pooling", "destination": "/docs/legacy-event-pooling.html", "permanent": false },
     { "source": "/link/hooks-data-fetching", "destination": "/docs/hooks-faq.html#how-can-i-do-data-fetching-with-hooks", "permanent": false },
     { "source": "/link/invalid-aria-props", "destination": "/warnings/invalid-aria-prop.html", "permanent": false },
     { "source": "/link/invalid-hook-call", "destination": "/warnings/invalid-hook-call-warning.html", "permanent": false },


### PR DESCRIPTION
As the blog mentioned, React has stopped event pooling, and the `SyntheticEvent#persist` mthod does nothing in v17, so I remove the description from the documentation.

https://reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling

~**v17 is still in RC, so this PR might have to be merged after releasing v17 stable.**~

Does React have a plan to deprecate and remove the `SyntheticEvent#persist` method in the future??

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
