### PR TITLE
Fix wrong highlighted line numbers in nested Profiler example

### DIFF
--- a/content/docs/reference-profiler.md
+++ b/content/docs/reference-profiler.md
@@ -49,7 +49,7 @@ render(
 ```
 
 `Profiler` components can also be nested to measure different components within the same subtree:
-```js{2,6,8}
+```js{3,5,8}
 render(
   <App>
     <Profiler id="Panel" onRender={callback}>


### PR DESCRIPTION
**Before:** The Profiler component is not highlighted.

![image](https://user-images.githubusercontent.com/193136/90792927-49412780-e335-11ea-911c-dfa74d3f0707.png)

**After:**

No more deploy previews? 🥺 