### PR TITLE
Use implicit return in setState function example

### DIFF
--- a/content/docs/faq-state.md
+++ b/content/docs/faq-state.md
@@ -59,10 +59,8 @@ Passing an update function allows you to access the current state value inside t
 
 ```jsx
 incrementCount() {
-  this.setState((state) => {
-    // Important: read `state` instead of `this.state` when updating.
-    return {count: state.count + 1}
-  });
+  // Important: read `state` instead of `this.state` when updating.
+  this.setState((state) => ({ count: state.count + 1 }));
 }
 
 handleSomething() {


### PR DESCRIPTION
Use implicit return in setState function example, instead of the extended return
In fact official eslint, https://eslint.org/docs/rules/arrow-body-style, auto-fixes the extended return to the implicit return by default.
I think it is a good thing to teach people who are reading the react docs best practises.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
