### PR TITLE
Sync Reservation Component with CodePen example

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -214,7 +214,7 @@ class Reservation extends React.Component {
 
   handleInputChange(event) {
     const target = event.target;
-    const value = target.name === 'isGoing' ? target.checked : target.value;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
 
     this.setState({


### PR DESCRIPTION
This is not much and it doesn't make any difference
But I was having some problems with the same example and I decided to check the source on [CodePen](https://codepen.io/gaearon/pen/wgedvV?editors=0010)

I found out where my mistake was (not related to the difference between tutorial and code pen source code) but I also realized there is a little difference between the given CodePen and the source code

In CodePen version it was using `event.target.type` to determine the value while on the tutorial it was using `event.target.name`