### PR TITLE
Prefixing `unstable_`

### DIFF
--- a/content/docs/concurrent-mode-adoption.md
+++ b/content/docs/concurrent-mode-adoption.md
@@ -71,7 +71,7 @@ import ReactDOM from 'react-dom';
 //
 // You can opt into Concurrent Mode by writing:
 
-ReactDOM.createRoot(
+ReactDOM.unstable_createRoot(
   document.getElementById('root')
 ).render(<App />);
 ```


### PR DESCRIPTION
Prefixed `unstable_` for the experimental ReactDOM.createRoot().



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

#17994
#18866
-->
