### PR TITLE
Update UMD build links to match npm

### DIFF
--- a/content/blog/2020-08-10-react-v17-rc.md
+++ b/content/blog/2020-08-10-react-v17-rc.md
@@ -284,8 +284,8 @@ yarn add react@17.0.0-rc.1 react-dom@17.0.0-rc.1
 We also provide UMD builds of React via a CDN:
 
 ```html
-<script crossorigin src="https://unpkg.com/react@17.0.0-rc.0/umd/react.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom@17.0.0-rc.0/umd/react-dom.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react@17.0.0-rc.1/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@17.0.0-rc.1/umd/react-dom.production.min.js"></script>
 ```
 
 Refer to the documentation for [detailed installation instructions](/docs/installation.html).


### PR DESCRIPTION
This pull request updates the UMB link version to `17.0.0-rc.1` to match the version used for the npm install command.

For some reason the version on the first line of `17.0.0-rc.1` file has a strange version number:
https://unpkg.com/react@17.0.0-rc.1/umd/react.production.min.js