### PR TITLE
Fix state update that might cause race condition

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -47,7 +47,7 @@ class Example extends React.Component {
     return (
       <div>
         <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+        <button onClick={() => this.setState( ({count}) => ({count: count + 1}) )}>
           Click me
         </button>
       </div>
@@ -174,7 +174,7 @@ In a function, we can use `count` directly:
 In a class, we need to call `this.setState()` to update the `count` state:
 
 ```js{1}
-  <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+  <button onClick={() => this.setState( ({count}) => ({count: count + 1}) )}>
     Click me
   </button>
 ```


### PR DESCRIPTION
In React, state updates might be asynchronous. Hence, when updating state based on old state or props, `setState` should receive a function as its argument instead of an object.

More information: https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous