### PR TITLE
Reduced the height taken by BLM support message

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -41,14 +41,14 @@ const Header = ({location}: {location: Location}) => (
           padding: 20,
           textAlign: 'center',
           [media.between('small', 'large')]: {
-            fontSize: 22,
-            height: 60,
+            fontSize: 20,
+            height: 50,
           },
           [media.lessThan('small')]: {
-            height: 80,
+            height: 75,
           },
           [media.greaterThan('medium')]: {
-            fontSize: 25,
+            fontSize: 22,
           },
         }}>
         Black Lives Matter.{' '}


### PR DESCRIPTION
The BLM Support message is a bit big for people having wide screen monitors and for beginners who spend most of their time on the documentation. So, I reduced the height by very few pixels.

I donated to BLM initiative by the way 😅😅(Even though I live in India) and I spend most of my time with the documentation (still learning). 

I Don't know if the code I changed is enough... but please reduce the size a bit 😭

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
