### PR TITLE
Correct prev/next links in the Advanced Guide

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -2,7 +2,6 @@
 id: accessibility
 title: Accessibility
 permalink: docs/accessibility.html
-prev: integrating-with-other-libraries.html
 next: code-splitting.html
 ---
 

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -3,6 +3,7 @@ id: code-splitting
 title: Code-Splitting
 permalink: docs/code-splitting.html
 prev: accessibility.html
+next: context.html
 ---
 
 ## Bundling {#bundling}

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -2,8 +2,8 @@
 id: context
 title: Context
 permalink: docs/context.html
-prev: reconciliation.html
-next: fragments.html
+prev: code-splitting.html
+next: error-boundaries.html
 ---
 
 Context provides a way to pass data through the component tree without having to pass props down manually at every level.

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -2,8 +2,8 @@
 id: error-boundaries
 title: Error Boundaries
 permalink: docs/error-boundaries.html
-prev: portals.html
-next: web-components.html
+prev: context.html
+next: forwarding-refs.html
 ---
 
 In the past, JavaScript errors inside components used to corrupt React’s internal state and cause it to [emit](https://github.com/facebook/react/issues/4026) [cryptic](https://github.com/facebook/react/issues/6895) [errors](https://github.com/facebook/react/issues/8579) on next renders. These errors were always caused by an earlier error in the application code, but React did not provide a way to handle them gracefully in components, and could not recover from them.

--- a/content/docs/forwarding-refs.md
+++ b/content/docs/forwarding-refs.md
@@ -2,6 +2,8 @@
 id: forwarding-refs
 title: Forwarding Refs
 permalink: docs/forwarding-refs.html
+prev: error-boundaries.html
+next: fragments.html
 ---
 
 Ref forwarding is a technique for automatically passing a [ref](/docs/refs-and-the-dom.html) through a component to one of its children. This is typically not necessary for most components in the application. However, it can be useful for some kinds of components, especially in reusable component libraries. The most common scenarios are described below.

--- a/content/docs/fragments.md
+++ b/content/docs/fragments.md
@@ -2,8 +2,8 @@
 id: fragments
 title: Fragments
 permalink: docs/fragments.html
-prev: context.html
-next: portals.html
+prev: forwarding-refs.html
+next: higher-order-components.html
 ---
 
 A common pattern in React is for a component to return multiple elements. Fragments let you group a list of children without adding extra nodes to the DOM.

--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -2,8 +2,8 @@
 id: higher-order-components
 title: Higher-Order Components
 permalink: docs/higher-order-components.html
-prev: web-components.html
-next: render-props.html
+prev: fragments.html
+next: integrating-with-other-libraries.html
 ---
 
 A higher-order component (HOC) is an advanced technique in React for reusing component logic. HOCs are not part of the React API, per se. They are a pattern that emerges from React's compositional nature.

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -2,8 +2,8 @@
 id: integrating-with-other-libraries
 title: Integrating with Other Libraries
 permalink: docs/integrating-with-other-libraries.html
-prev: render-props.html
-next: accessibility.html
+prev: higher-order-components.html
+next: jsx-in-depth.html
 ---
 
 React can be used in any web application. It can be embedded in other applications and, with a little care, other applications can be embedded in React. This guide will examine some of the more common use cases, focusing on integration with [jQuery](https://jquery.com/) and [Backbone](https://backbonejs.org/), but the same ideas can be applied to integrating components with any existing code.

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -2,7 +2,8 @@
 id: jsx-in-depth
 title: JSX In Depth
 permalink: docs/jsx-in-depth.html
-next: typechecking-with-proptypes.html
+prev: integrating-with-other-libraries.html
+next: optimizing-performance.html
 redirect_from:
   - "docs/jsx-spread.html"
   - "docs/jsx-gotchas.html"

--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -2,8 +2,8 @@
 id: optimizing-performance
 title: Optimizing Performance
 permalink: docs/optimizing-performance.html
-prev: uncontrolled-components.html
-next: react-without-es6.html
+prev: jsx-in-depth.html
+next: portals.html
 redirect_from:
   - "docs/advanced-performance.html"
 ---

--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -2,8 +2,8 @@
 id: portals
 title: Portals
 permalink: docs/portals.html
-prev: fragments.html
-next: error-boundaries.html
+prev: optimizing-performance.html
+next: profiler.html
 ---
 
 Portals provide a first-class way to render children into a DOM node that exists outside the DOM hierarchy of the parent component.

--- a/content/docs/react-without-es6.md
+++ b/content/docs/react-without-es6.md
@@ -2,7 +2,7 @@
 id: react-without-es6
 title: React Without ES6
 permalink: docs/react-without-es6.html
-prev: optimizing-performance.html
+prev: profiler.html
 next: react-without-jsx.html
 ---
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -3,7 +3,7 @@ id: reconciliation
 title: Reconciliation
 permalink: docs/reconciliation.html
 prev: react-without-jsx.html
-next: context.html
+next: refs-and-the-dom.html
 ---
 
 React provides a declarative API so that you don't have to worry about exactly what changes on every update. This makes writing applications a lot easier, but it might not be obvious how this is implemented within React. This article explains the choices we made in React's "diffing" algorithm so that component updates are predictable while being fast enough for high-performance apps.

--- a/content/docs/reference-profiler.md
+++ b/content/docs/reference-profiler.md
@@ -4,6 +4,8 @@ title: Profiler API
 layout: docs
 category: Reference
 permalink: docs/profiler.html
+prev: portals.html
+next: react-without-es6.html
 ---
 
 The `Profiler` measures how often a React application renders and what the "cost" of rendering is.

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -1,8 +1,9 @@
 ---
 id: refs-and-the-dom
 title: Refs and the DOM
-prev: static-type-checking.html
-next: uncontrolled-components.html
+permalink: docs/refs-and-the-dom.html
+prev: reconciliation.html
+next: render-props.html
 redirect_from:
   - "docs/working-with-the-browser.html"
   - "docs/more-about-refs.html"
@@ -10,7 +11,6 @@ redirect_from:
   - "docs/more-about-refs-zh-CN.html"
   - "tips/expose-component-functions.html"
   - "tips/children-undefined.html"
-permalink: docs/refs-and-the-dom.html
 ---
 
 Refs provide a way to access DOM nodes or React elements created in the render method.

--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -2,8 +2,8 @@
 id: render-props
 title: Render Props
 permalink: docs/render-props.html
-prev: higher-order-components.html
-next: integrating-with-other-libraries.html
+prev: refs-and-the-dom.html
+next: static-type-checking.html
 ---
 
 The term ["render prop"](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce) refers to a technique for sharing code between React components using a prop whose value is a function.

--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -2,6 +2,8 @@
 id: static-type-checking
 title: Static Type Checking
 permalink: docs/static-type-checking.html
+prev: render-props.html
+next: strict-mode.html
 ---
 
 Static type checkers like [Flow](https://flow.org/) and [TypeScript](https://www.typescriptlang.org/) identify certain types of problems before you even run your code. They can also improve developer workflow by adding features like auto-completion. For this reason, we recommend using Flow or TypeScript instead of `PropTypes` for larger code bases.

--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -2,6 +2,8 @@
 id: strict-mode
 title: Strict Mode
 permalink: docs/strict-mode.html
+prev: static-type-checking.html
+next: typechecking-with-proptypes.html
 ---
 
 `StrictMode` is a tool for highlighting potential problems in an application. Like `Fragment`, `StrictMode` does not render any visible UI. It activates additional checks and warnings for its descendants.

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -2,8 +2,8 @@
 id: typechecking-with-proptypes
 title: Typechecking With PropTypes
 permalink: docs/typechecking-with-proptypes.html
-prev: jsx-in-depth.html
-next: static-type-checking.html
+prev: strict-mode.html
+next: uncontrolled-components.html
 redirect_from:
   - "docs/react-api.html#typechecking-with-proptypes"
 ---

--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -2,8 +2,8 @@
 id: uncontrolled-components
 title: Uncontrolled Components
 permalink: docs/uncontrolled-components.html
-prev: refs-and-the-dom.html
-next: optimizing-performance.html
+prev: typechecking-with-proptypes.html
+next: web-components.html
 ---
 
 In most cases, we recommend using [controlled components](/docs/forms.html#controlled-components) to implement forms. In a controlled component, form data is handled by a React component. The alternative is uncontrolled components, where form data is handled by the DOM itself.

--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -2,8 +2,7 @@
 id: web-components
 title: Web Components
 permalink: docs/web-components.html
-prev: error-boundaries.html
-next: higher-order-components.html
+prev: uncontrolled-components.html
 redirect_from:
   - "docs/webcomponents.html"
 ---


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Previous and next links in the Advanced Guide do not follow the order in the sidebar navigation. This pull request corrects that.

They currently follow the order the documents were in in 2018 when this pull request (#540) was submitted. Subsequent updates to the Advanced Guide have changed the order (it is alphabetical). 

From the comments on that pull request it seems there is some consideration about whether the Advanced Guide even needs prev/next links. FWIW I noticed the issue because I was using them, but I'm fine with submitting a separate pull request to delete them all together if there is a consensus that would be better.