### PR TITLE
Remove prev/next links from the Advanced Guide

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -2,8 +2,6 @@
 id: accessibility
 title: Accessibility
 permalink: docs/accessibility.html
-prev: integrating-with-other-libraries.html
-next: code-splitting.html
 ---
 
 ## Why Accessibility? {#why-accessibility}

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -2,7 +2,6 @@
 id: code-splitting
 title: Code-Splitting
 permalink: docs/code-splitting.html
-prev: accessibility.html
 ---
 
 ## Bundling {#bundling}

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -2,8 +2,6 @@
 id: context
 title: Context
 permalink: docs/context.html
-prev: reconciliation.html
-next: fragments.html
 ---
 
 Context provides a way to pass data through the component tree without having to pass props down manually at every level.

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -2,8 +2,6 @@
 id: error-boundaries
 title: Error Boundaries
 permalink: docs/error-boundaries.html
-prev: portals.html
-next: web-components.html
 ---
 
 In the past, JavaScript errors inside components used to corrupt React’s internal state and cause it to [emit](https://github.com/facebook/react/issues/4026) [cryptic](https://github.com/facebook/react/issues/6895) [errors](https://github.com/facebook/react/issues/8579) on next renders. These errors were always caused by an earlier error in the application code, but React did not provide a way to handle them gracefully in components, and could not recover from them.

--- a/content/docs/fragments.md
+++ b/content/docs/fragments.md
@@ -2,8 +2,6 @@
 id: fragments
 title: Fragments
 permalink: docs/fragments.html
-prev: context.html
-next: portals.html
 ---
 
 A common pattern in React is for a component to return multiple elements. Fragments let you group a list of children without adding extra nodes to the DOM.

--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -2,8 +2,6 @@
 id: higher-order-components
 title: Higher-Order Components
 permalink: docs/higher-order-components.html
-prev: web-components.html
-next: render-props.html
 ---
 
 A higher-order component (HOC) is an advanced technique in React for reusing component logic. HOCs are not part of the React API, per se. They are a pattern that emerges from React's compositional nature.

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -2,8 +2,6 @@
 id: integrating-with-other-libraries
 title: Integrating with Other Libraries
 permalink: docs/integrating-with-other-libraries.html
-prev: render-props.html
-next: accessibility.html
 ---
 
 React can be used in any web application. It can be embedded in other applications and, with a little care, other applications can be embedded in React. This guide will examine some of the more common use cases, focusing on integration with [jQuery](https://jquery.com/) and [Backbone](https://backbonejs.org/), but the same ideas can be applied to integrating components with any existing code.

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -2,7 +2,6 @@
 id: jsx-in-depth
 title: JSX In Depth
 permalink: docs/jsx-in-depth.html
-next: typechecking-with-proptypes.html
 redirect_from:
   - "docs/jsx-spread.html"
   - "docs/jsx-gotchas.html"

--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -2,8 +2,6 @@
 id: optimizing-performance
 title: Optimizing Performance
 permalink: docs/optimizing-performance.html
-prev: uncontrolled-components.html
-next: react-without-es6.html
 redirect_from:
   - "docs/advanced-performance.html"
 ---

--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -2,8 +2,6 @@
 id: portals
 title: Portals
 permalink: docs/portals.html
-prev: fragments.html
-next: error-boundaries.html
 ---
 
 Portals provide a first-class way to render children into a DOM node that exists outside the DOM hierarchy of the parent component.

--- a/content/docs/react-without-es6.md
+++ b/content/docs/react-without-es6.md
@@ -2,8 +2,6 @@
 id: react-without-es6
 title: React Without ES6
 permalink: docs/react-without-es6.html
-prev: optimizing-performance.html
-next: react-without-jsx.html
 ---
 
 Normally you would define a React component as a plain JavaScript class:

--- a/content/docs/react-without-jsx.md
+++ b/content/docs/react-without-jsx.md
@@ -2,8 +2,6 @@
 id: react-without-jsx
 title: React Without JSX
 permalink: docs/react-without-jsx.html
-prev: react-without-es6.html
-next: reconciliation.html
 ---
 
 JSX is not a requirement for using React. Using React without JSX is especially convenient when you don't want to set up compilation in your build environment.

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -2,8 +2,6 @@
 id: reconciliation
 title: Reconciliation
 permalink: docs/reconciliation.html
-prev: react-without-jsx.html
-next: context.html
 ---
 
 React provides a declarative API so that you don't have to worry about exactly what changes on every update. This makes writing applications a lot easier, but it might not be obvious how this is implemented within React. This article explains the choices we made in React's "diffing" algorithm so that component updates are predictable while being fast enough for high-performance apps.

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -1,8 +1,7 @@
 ---
 id: refs-and-the-dom
 title: Refs and the DOM
-prev: static-type-checking.html
-next: uncontrolled-components.html
+permalink: docs/refs-and-the-dom.html
 redirect_from:
   - "docs/working-with-the-browser.html"
   - "docs/more-about-refs.html"
@@ -10,7 +9,6 @@ redirect_from:
   - "docs/more-about-refs-zh-CN.html"
   - "tips/expose-component-functions.html"
   - "tips/children-undefined.html"
-permalink: docs/refs-and-the-dom.html
 ---
 
 Refs provide a way to access DOM nodes or React elements created in the render method.

--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -2,8 +2,6 @@
 id: render-props
 title: Render Props
 permalink: docs/render-props.html
-prev: higher-order-components.html
-next: integrating-with-other-libraries.html
 ---
 
 The term ["render prop"](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce) refers to a technique for sharing code between React components using a prop whose value is a function.

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -2,8 +2,6 @@
 id: typechecking-with-proptypes
 title: Typechecking With PropTypes
 permalink: docs/typechecking-with-proptypes.html
-prev: jsx-in-depth.html
-next: static-type-checking.html
 redirect_from:
   - "docs/react-api.html#typechecking-with-proptypes"
 ---

--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -2,8 +2,6 @@
 id: uncontrolled-components
 title: Uncontrolled Components
 permalink: docs/uncontrolled-components.html
-prev: refs-and-the-dom.html
-next: optimizing-performance.html
 ---
 
 In most cases, we recommend using [controlled components](/docs/forms.html#controlled-components) to implement forms. In a controlled component, form data is handled by a React component. The alternative is uncontrolled components, where form data is handled by the DOM itself.

--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -2,8 +2,6 @@
 id: web-components
 title: Web Components
 permalink: docs/web-components.html
-prev: error-boundaries.html
-next: higher-order-components.html
 redirect_from:
   - "docs/webcomponents.html"
 ---


### PR DESCRIPTION
See original discussion on PR #540 and more recently PR #3264. 

Summary is that since the Advanced Guide is alphabetical the chore of resorting new articles in the future may not be worth it.