### PR TITLE
Updated hook name in sample code

### DIFF
--- a/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
+++ b/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
@@ -241,7 +241,7 @@ For example,
 import React from 'react';
 
 function App() {
-  const [text, useText] = React.useState('Hello World');
+  const [text, setText] = React.useState('Hello World');
   return <h1>{text}</h1>;
 }
 ```
@@ -252,7 +252,7 @@ will be replaced with
 import { useState } from 'react';
 
 function App() {
-  const [text, useText] = useState('Hello World');
+  const [text, setText] = useState('Hello World');
   return <h1>{text}</h1>;
 }
 ```


### PR DESCRIPTION
Updated the sample code to read `setText` instead of `useText` in the example



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
