### PR TITLE
Remove react summit 2021 dates

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -22,11 +22,6 @@ December 1-2, 2020 - remote event
 
 [Website](https://react-next.com/) - [Twitter](https://twitter.com/reactnext) - [Facebook](https://www.facebook.com/ReactNext2016/)
 
-### React Summit 2021 {#react-summit-2021}
-June 2-4, 2021. Amsterdam, The Netherlands
-
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
-
 ### render(ATL) 2021 {#render-atlanta-2021} 
 September 13-15, 2021. Atlanta, GA, USA
 


### PR DESCRIPTION
Sorry for a quick follow-up PR, it's too soon to plan 2021 dates at the moment, thus removing it for React Summit.