### PR TITLE
Remove superfluous code in faq-functions.md example

### DIFF
--- a/content/docs/faq-functions.md
+++ b/content/docs/faq-functions.md
@@ -152,7 +152,6 @@ const A = 65 // ASCII character code
 class Alphabet extends React.Component {
   constructor(props) {
     super(props);
-    this.handleClick = this.handleClick.bind(this);
     this.state = {
       justClicked: null,
       letters: Array.from({length: 26}, (_, i) => String.fromCharCode(A + i))


### PR DESCRIPTION
The sections above this describe how to use the arrow function to bind functions to the component instance to avoid explicit binding in the constructor. This example though, uses both the arrow function and explicitly binds the function. I realise the point of this particular example isn't to describe the binding process, but considering the sections that immediately proceed it, I think it'd be good to avoid confusion here.