### PR TITLE
Updated conditional rendering doc with a note on Falsy values

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,7 +152,7 @@ It works because in JavaScript, `true && expression` always evaluates to `expres
 
 Therefore, if the condition is `true`, the element right after `&&` will appear in the output. If it is `false`, React will ignore and skip it.
 
-Note that returning a falsy expression will still cause the element after `&&` to be skipped but will return the falsy expression. In the example below, 0 will be returned by the expression.
+Note that returning a falsy expression will still cause the element after `&&` to be skipped but will return the falsy expression. In the example below, `<div>0</div>` will be returned by the render method.
 
 ```javascript{2,5}
 render() {

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,6 +152,19 @@ It works because in JavaScript, `true && expression` always evaluates to `expres
 
 Therefore, if the condition is `true`, the element right after `&&` will appear in the output. If it is `false`, React will ignore and skip it.
 
+Note that returning a falsy expression will still cause the element after `&&` to be skipped but will return the falsy expression. In the example below, 0 will be returned by the expression.
+
+```javascript{2,5}
+render() {
+  const count = 0;
+  return (
+    <div>
+      { count && <h1>Messages: {count}</h1>}
+    </div>
+  );
+}
+```
+
 ### Inline If-Else with Conditional Operator {#inline-if-else-with-conditional-operator}
 
 Another method for conditionally rendering elements inline is to use the JavaScript conditional operator [`condition ? true : false`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Conditional_Operator).


### PR DESCRIPTION
Conditional rendering works if the expression returns a truthy/falsy value instead of true/false but the falsy value ends up being rendered. This can cause an unexpected value being rendered on screen. 

The discussion regarding this can be found [here](https://github.com/facebook/react-native/issues/29980#issuecomment-696437692)