### PR TITLE
Change "React node" to "React element"

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -306,7 +306,7 @@ You can also use it with the shorthand `<></>` syntax. For more information, see
 * [Forwarding refs to DOM components](/docs/forwarding-refs.html#forwarding-refs-to-dom-components)
 * [Forwarding refs in higher-order-components](/docs/forwarding-refs.html#forwarding-refs-in-higher-order-components)
 
-`React.forwardRef` accepts a rendering function as an argument. React will call this function with `props` and `ref` as two arguments. This function should return a React node.
+`React.forwardRef` accepts a rendering function as an argument. React will call this function with `props` and `ref` as two arguments. This function should return a React element.
 
 `embed:reference-react-forward-ref.js`
 


### PR DESCRIPTION
Should this be React element and not node?
