### PR TITLE
Fix ajax hooks example

### DIFF
--- a/content/docs/faq-ajax.md
+++ b/content/docs/faq-ajax.md
@@ -100,7 +100,7 @@ function MyComponent() {
       .then(
         (result) => {
           setIsLoaded(true);
-          setItems(result.items);
+          setItems(result);
         },
         // Note: it's important to handle errors here
         // instead of a catch() block so that we don't swallow


### PR DESCRIPTION
Hello, I have been trying out  [AJAX and APIs](https://reactjs.org/docs/faq-ajax.html) examples and found out that 
```
setItems(result.items);
```
returns undefined while 
```
setItems(result);
```
returns the expected result (Array).