### PR TITLE
fix(content/docs): Fix broken link

### DIFF
--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -181,4 +181,4 @@ We will explore rendering React elements to the DOM in the [next section](/docs/
 
 >**Tip:**
 >
->We recommend using the ["Babel" language definition](https://babeljs.io/docs/editors) for your editor of choice so that both ES6 and JSX code is properly highlighted.
+>We recommend using the ["Babel" language definition](https://babeljs.io/docs/en/next/editors) for your editor of choice so that both ES6 and JSX code is properly highlighted.


### PR DESCRIPTION
Change broken link for Babel editors in `introducing-jsx.md`