### PR TITLE
docs: fixing anti-pattern in one of the hooks state examples

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -47,7 +47,7 @@ class Example extends React.Component {
     return (
       <div>
         <p>You clicked {this.state.count} times</p>
-        <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+        <button onClick={(state) => this.setState({ count: state.count + 1 })}>
           Click me
         </button>
       </div>
@@ -174,7 +174,7 @@ In a function, we can use `count` directly:
 In a class, we need to call `this.setState()` to update the `count` state:
 
 ```js{1}
-  <button onClick={() => this.setState({ count: this.state.count + 1 })}>
+  <button onClick={(state) => this.setState({ count: state.count + 1 })}>
     Click me
   </button>
 ```


### PR DESCRIPTION
From `React.Component` `setState` function [documentation](https://reactjs.org/docs/react-component.html#setstate):

> Subsequent calls will override values from previous calls in the same cycle, so the quantity will only be incremented once. If the next state depends on the current state, we recommend using the updater function form.

In one of the Hooks [examples](https://reactjs.org/docs/hooks-state.html#equivalent-class-example) state is updated based on the `this.state` value which potentially may lead to incorrect result.