### PR TITLE
Remove broken Glitch template

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -36,7 +36,7 @@ React has been designed from the start for gradual adoption, and **you can use a
 
 ### Online Playgrounds {#online-playgrounds}
 
-If you're interested in playing around with React, you can use an online code playground. Try a Hello World template on [CodePen](codepen://hello-world), [CodeSandbox](https://codesandbox.io/s/new), [Glitch](https://glitch.com/edit/#!/remix/starter-react-template), or [Stackblitz](https://stackblitz.com/fork/react).
+If you're interested in playing around with React, you can use an online code playground. Try a Hello World template on [CodePen](codepen://hello-world), [CodeSandbox](https://codesandbox.io/s/new), or [Stackblitz](https://stackblitz.com/fork/react).
 
 If you prefer to use your own text editor, you can also [download this HTML file](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html), edit it, and open it from the local filesystem in your browser. It does a slow runtime code transformation, so we'd only recommend using this for simple demos.
 


### PR DESCRIPTION
This is

1) using real CRA unnecessarily despite being in the browser so is slow to boot
2) shows "error" immediately to me and doesn't load
3) doesn't seem to get updated with newer React releases

We can readd it if it's fixed and doesn't have these problems (which none of the other templates do).
