### PR TITLE
Fix a grammatical error in Context.md

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -128,7 +128,7 @@ The `defaultValue` argument is **only** used when a component does not have a ma
 
 Every Context object comes with a Provider React component that allows consuming components to subscribe to context changes.
 
-Accepts a `value` prop to be passed to consuming components that are descendants of this Provider. One Provider can be connected to many consumers. Providers can be nested to override values deeper within the tree.
+The Provider component accepts a `value` prop to be passed to consuming components that are descendants of this Provider. One Provider can be connected to many consumers. Providers can be nested to override values deeper within the tree.
 
 All consumers that are descendants of a Provider will re-render whenever the Provider's `value` prop changes. The propagation from Provider to its descendant consumers (including [`.contextType`](#classcontexttype) and [`useContext`](/docs/hooks-reference.html#usecontext)) is not subject to the `shouldComponentUpdate` method, so the consumer is updated even when an ancestor component skips an update.
 


### PR DESCRIPTION
The sentence didn't quite make sense before. I think this makes the intent more clear.

(I realize this is just a markdown change, but this has nothing to do with Hacktoberfest and I feel like it is a [minimally] valuable contribution. Thanks for all that this team does!)