### PR TITLE
Indicate that create react app 4.0 has been released

### DIFF
--- a/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
+++ b/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
@@ -99,7 +99,7 @@ Since the new JSX transform doesn't require React to be in scope, [we've also pr
 
 ### Create React App {#create-react-app}
 
-Create React App support [has been added](https://github.com/facebook/create-react-app/pull/9645) and it is available in the [new v4.0 release](https://github.com/facebook/create-react-app/releases/tag/v4.0.0) which has been released recently.
+Create React App [4.0.0](https://github.com/facebook/create-react-app/releases/tag/v4.0.0)+ uses the new transform for compatible React versions.
 
 ### Next.js {#nextjs}
 

--- a/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
+++ b/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
@@ -99,7 +99,7 @@ Since the new JSX transform doesn't require React to be in scope, [we've also pr
 
 ### Create React App {#create-react-app}
 
-Create React App support [has been added](https://github.com/facebook/create-react-app/pull/9645) and will be available in the [upcoming v4.0 release](https://gist.github.com/iansu/4fab7a9bfa5fa6ebc87a908c62f5340b) which is currently in beta testing.
+Create React App support [has been added](https://github.com/facebook/create-react-app/pull/9645) and it is available in the [new v4.0 release](https://github.com/facebook/create-react-app/releases/tag/v4.0.0) which has been released recently.
 
 ### Next.js {#nextjs}
 


### PR DESCRIPTION
A minor adjustment to the the JSX transform docs to indicate that create react app version 4.0.0 is now released and no longer in beta testing.