### PR TITLE
[docs] Update community docs link to React Native Radio

### DIFF
--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -16,7 +16,7 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 - [React 30](https://react30.com/) - A 30-minute podcast all about React (moved to [The React Podcast](https://reactpodcast.simplecast.fm/)).
 
-- [React Native Radio](https://devchat.tv/react-native-radio)
+- [React Native Radio](https://reactnativeradio.com) - Exploring React Native Together, hosted by [Infinite Red](https://infinite.red)
 
 - [React Wednesdays](https://www.telerik.com/react-wednesdays) - Weekly live streams with the best and brightest in the React world
 


### PR DESCRIPTION
React Native Radio was recently acquired by [Infinite Red](https://infinite.red). This PR updates it's URL so it points to the new location.