### PR TITLE
Move React Summit 2020 to Past Conferences section

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -12,11 +12,6 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences {#upcoming-conferences}
 
-### React Summit 2020 {#react-summit-2020}
-October 15-16, 2020, 7am PST / 10am EST / 4pm CEST - remote event
-
-[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
-
 ### React Conf Brasil 2020 {#react-conf-brasil-2020}
 November 21, 2020 - remote event
 
@@ -475,3 +470,8 @@ May 14-15, 2020 in Paris, France
 September 3-4, 2020 - remote event
 
 [Website](https://www.react-native.eu/) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu/) - [YouTube](https://www.youtube.com/watch?v=m0GfmlGFh3E&list=PLZ3MwD-soTTHy9_88QPLF8DEJkvoB5Tl-) - [Instagram](https://www.instagram.com/reactnative_eu/)
+
+### React Summit 2020 {#react-summit-2020}
+October 15-16, 2020, 7am PST / 10am EST / 4pm CEST - remote event
+
+[Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)


### PR DESCRIPTION
October 15 is now in the past :smile:.
