### PR TITLE
More explicit docs about uncontrolled forms.

### DIFF
--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -45,7 +45,7 @@ If it's still not clear which type of component you should use for a particular 
 
 ### Default Values {#default-values}
 
-In the React rendering lifecycle, the `value` attribute on form elements will override the value in the DOM. With an uncontrolled component, you often want React to specify the initial value, but leave subsequent updates uncontrolled. To handle this case, you can specify a `defaultValue` attribute instead of `value`.
+In the React rendering lifecycle, the `value` attribute on form elements will override the value in the DOM. With an uncontrolled component, you often want React to specify the initial value, but leave subsequent updates uncontrolled. To handle this case, you can specify a `defaultValue` attribute instead of `value`. Changing the value of `defaultValue` attribute after a component has mounted will not cause any update of the value in the DOM.
 
 ```javascript{7}
 render() {


### PR DESCRIPTION
It is worth to point out `defaultValue` attribute behaviour explicitly. In a use case when a form is reused across different sub-routes of an app, where said routes are changed by a user, input fields to change their value on user's action. With uncontrolled forms, `defaultValue` change may be expected to trigger DOM changes. The docs only mention the behaviour on a component's mount, but don't describe what happens when the attribute changes.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Related:
https://github.com/reactjs/reactjs.org/issues/1126
