### PR TITLE
Add PropType instructions for function components

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -197,7 +197,7 @@ class Greeting extends React.Component {
 
 The `defaultProps` will be used to ensure that `this.props.name` will have a value if it was not specified by the parent component. The `propTypes` typechecking happens after `defaultProps` are resolved, so typechecking will also apply to the `defaultProps`.
 
-### Functional Components
+### Function Components
 
 If you are using Functional Components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
 

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -201,7 +201,7 @@ The `defaultProps` will be used to ensure that `this.props.name` will have a val
 
 If you are using Functional Components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
 
-Let's say you have a simple component like this:
+Let's say you have a component like this:
 
 ```javascript
 export default function ({ name }) {

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -199,7 +199,7 @@ The `defaultProps` will be used to ensure that `this.props.name` will have a val
 
 ### Function Components
 
-If you are using Functional Components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
+If you are using function components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
 
 Let's say you have a component like this:
 

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -214,7 +214,7 @@ export default function ({ name }) {
 To add PropTypes, you may want to isolate the component in a constant before exporting, like this:
 
 ```javascript
-const HelloWorldComponent = function ({ name }) {
+function HelloWorldComponent({ name }) {
   return (
     <div>Hello, {name}</div>
   )

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -223,7 +223,7 @@ const HelloWorldComponent = function ({ name }) {
 export default HelloWorldComponent
 ```
 
-Then, adding PropTypes should be easy:
+Then, you can add PropTypes directly to the `HelloWorldComponent`:
 
 ```javascript
 import PropTypes from 'prop-types'

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -211,7 +211,7 @@ export default function ({ name }) {
 }
 ```
 
-To add PropTypes, you may want to isolate component in a constant before exporting, like this:
+To add PropTypes, you may want to isolate the component in a constant before exporting, like this:
 
 ```javascript
 const HelloWorldComponent = function ({ name }) {

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -228,7 +228,7 @@ Then, you can add PropTypes directly to the `HelloWorldComponent`:
 ```javascript
 import PropTypes from 'prop-types'
 
-const HelloWorldComponent = function ({ name }) {
+function HelloWorldComponent({ name }) {
   return (
     <div>Hello, {name}</div>
   )

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -61,7 +61,7 @@ MyComponent.propTypes = {
 
   // A React element type (ie. MyComponent).
   optionalElementType: PropTypes.elementType,
-  
+
   // You can also declare that a prop is an instance of a class. This uses
   // JS's instanceof operator.
   optionalMessage: PropTypes.instanceOf(Message),
@@ -88,7 +88,7 @@ MyComponent.propTypes = {
     color: PropTypes.string,
     fontSize: PropTypes.number
   }),
-  
+
   // An object with warnings on extra properties
   optionalObjectWithStrictShape: PropTypes.exact({
     name: PropTypes.string,
@@ -196,3 +196,47 @@ class Greeting extends React.Component {
 ```
 
 The `defaultProps` will be used to ensure that `this.props.name` will have a value if it was not specified by the parent component. The `propTypes` typechecking happens after `defaultProps` are resolved, so typechecking will also apply to the `defaultProps`.
+
+### Functional Components
+
+If you are using Functional Components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
+
+Let's say you have a simple component like this:
+
+```javascript
+export default function ({ name }) {
+  return (
+    <div>Hello, {name}</div>
+  )
+}
+```
+
+To add PropTypes, you may want to isolate component in a constant before exporting, like this:
+
+```javascript
+const HelloWorldComponent = function ({ name }) {
+  return (
+    <div>Hello, {name}</div>
+  )
+}
+
+export default HelloWorldComponent
+```
+
+Then, adding PropTypes should be easy:
+
+```javascript
+import PropTypes from 'prop-types'
+
+const HelloWorldComponent = function ({ name }) {
+  return (
+    <div>Hello, {name}</div>
+  )
+}
+
+HelloWorldComponent.propTypes = {
+  name: PropTypes.string
+}
+
+export default HelloWorldComponent
+```

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -204,14 +204,14 @@ If you are using function components in your regular development, you may want t
 Let's say you have a component like this:
 
 ```javascript
-export default function ({ name }) {
+export default function HelloWorldComponent({ name }) {
   return (
     <div>Hello, {name}</div>
   )
 }
 ```
 
-To add PropTypes, you may want to isolate the component in a constant before exporting, like this:
+To add PropTypes, you may want to declare the component in a separate function before exporting, like this:
 
 ```javascript
 function HelloWorldComponent({ name }) {


### PR DESCRIPTION
## What changed?
I've added a new block of instructions for people using React with Functional components.

## Why did you do it?
It may not be super obvious how to apply the PropTypes to functional components, so I thought it would be a good way.

## Testing
To test this change, you need to navigate to this page:
https://deploy-preview-3403--reactjs.netlify.app/docs/typechecking-with-proptypes.html

My changes should be at the end, in the sub-section "Functional Components".

## Note
Also, this is my first contribution to React, so please tell me If I missed something!