### PR TITLE
Force Algolia search to redirect to window.origin URL

### DIFF
--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -25,6 +25,10 @@ class DocSearch extends Component<{}, State> {
         apiKey: '36221914cce388c46d0420343e0bb32e',
         indexName: 'react',
         inputSelector: '#algolia-doc-search',
+        handleSelected: function(input, event, suggestion, datasetNumber, context) {
+          const suggestionUrl = new URL(suggestion.url)
+          window.location = `${window.origin}${suggestionUrl.pathname}`
+        },
       });
     } else {
       console.warn('Search has failed to load and now is being disabled');


### PR DESCRIPTION
## Why did you do it?

While publishing a PR, I've noticed that search doesn't work on Vercel
Apps. This happens because Algolia results always default to production
URLs. This is not the expected behavior while testing, since you can
accidentally left the Vercel App without noticing, introducing all
kinds of confusions.

## What changed?

With this small change, we are always enforcing the origin URL to be
used as the host for the redirect.
This will work both for production an any other environment.

## Reproduction of the Issue:

https://share.getcloudapp.com/RBu9NyZb
<img src="https://p27.f0.n0.cdn.getcloudapp.com/items/RBu9NyZb/Screen%20Recording%202020-11-23%20at%2009.17%20PM.gif?source=viewer&v=088979082b80db6c45292b2a7b3abab2" />