### PR TITLE
Adding Halifax, Nova Scotia to the list of meetups

### DIFF
--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -43,6 +43,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [Bolivia](https://www.meetup.com/ReactBolivia/)
 
 ## Canada {#canada}
+* [Halifax, NS](https://www.meetup.com/Halifax-ReactJS-Meetup/)
 * [Montreal, QC - React Native](https://www.meetup.com/fr-FR/React-Native-MTL/)
 * [Vancouver, BC](https://www.meetup.com/ReactJS-Vancouver-Meetup/)
 * [Ottawa, ON](https://www.meetup.com/Ottawa-ReactJS-Meetup/)


### PR DESCRIPTION
This PR adds Halifax NS to the list of meetups on the React Docs.
