### PR TITLE
Add temporary note to various doc pages pointing to docs with functional components

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -20,7 +20,7 @@ Components let you split the UI into independent, reusable pieces, and think abo
 
 Conceptually, components are like JavaScript functions. They accept arbitrary inputs (called "props") and return React elements describing what should appear on the screen.
 
-**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 ## Function and Class Components {#function-and-class-components}
 

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -20,6 +20,8 @@ Components let you split the UI into independent, reusable pieces, and think abo
 
 Conceptually, components are like JavaScript functions. They accept arbitrary inputs (called "props") and return React elements describing what should appear on the screen.
 
+**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+
 ## Function and Class Components {#function-and-class-components}
 
 The simplest way to define a component is to write a JavaScript function:

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -20,7 +20,9 @@ Components let you split the UI into independent, reusable pieces, and think abo
 
 Conceptually, components are like JavaScript functions. They accept arbitrary inputs (called "props") and return React elements describing what should appear on the screen.
 
->**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>Note
+>
+>We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 ## Function and Class Components {#function-and-class-components}
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -22,7 +22,9 @@ This page is an overview of the React documentation and related resources.
 
 **React** is a JavaScript library for building user interfaces. Learn what React is all about on [our homepage](/) or [in the tutorial](/tutorial/tutorial.html).
 
->**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>Note
+>
+>We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 ---
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -22,6 +22,8 @@ This page is an overview of the React documentation and related resources.
 
 **React** is a JavaScript library for building user interfaces. Learn what React is all about on [our homepage](/) or [in the tutorial](/tutorial/tutorial.html).
 
+**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+
 ---
 
 - [Try React](#try-react)

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -22,7 +22,7 @@ This page is an overview of the React documentation and related resources.
 
 **React** is a JavaScript library for building user interfaces. Learn what React is all about on [our homepage](/) or [in the tutorial](/tutorial/tutorial.html).
 
-**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>**Note**: We're currently working on a rewrite of the React docs to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 ---
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -16,6 +16,8 @@ This tutorial doesn't assume any existing React knowledge.
 
 ## Before We Start the Tutorial {#before-we-start-the-tutorial}
 
+**Note**: We're currently working on a rewrite of the React docs and this tutorial to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+
 We will build a small game during this tutorial. **You might be tempted to skip it because you're not building games -- but give it a chance.** The techniques you'll learn in the tutorial are fundamental to building any React app, and mastering it will give you a deep understanding of React.
 
 >Tip

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -16,7 +16,7 @@ This tutorial doesn't assume any existing React knowledge.
 
 ## Before We Start the Tutorial {#before-we-start-the-tutorial}
 
-**Note**: We're currently working on a rewrite of the React docs and this tutorial to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>**Note**: We're currently working on a rewrite of the React docs and this tutorial to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 We will build a small game during this tutorial. **You might be tempted to skip it because you're not building games -- but give it a chance.** The techniques you'll learn in the tutorial are fundamental to building any React app, and mastering it will give you a deep understanding of React.
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -16,7 +16,9 @@ This tutorial doesn't assume any existing React knowledge.
 
 ## Before We Start the Tutorial {#before-we-start-the-tutorial}
 
->**Note**: We're currently working on a rewrite of the React docs and this tutorial to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
+>Note
+>
+>We're currently working on a rewrite of the React docs and this tutorial to teach functional components with hooks as the default approach. In the meantime, all of the tutorials found in these docs can be found at https://reactwithhooks.netlify.app/ using functional components and hooks.
 
 We will build a small game during this tutorial. **You might be tempted to skip it because you're not building games -- but give it a chance.** The techniques you'll learn in the tutorial are fundamental to building any React app, and mastering it will give you a deep understanding of React.
 


### PR DESCRIPTION
Addresses https://github.com/reactjs/reactjs.org/issues/3435

Adds a temporary link to the [netlify docs](https://reactwithhooks.netlify.app/docs/getting-started.html) where all tutorials and examples have been ported to use functional components with hooks.

This can be removed once the docs have been updated.