### PR TITLE
Redirect en.reactjs.org to reactjs.org

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,7 @@
+# Ensure English site redirects to Apex. While not used directly by us, may be linked elsewhere.
+http://en.reactjs.org/* https://reactjs.org/:splat 301!
+https://en.reactjs.org/* https://reactjs.org/:splat 301!
+
 /tips/controlled-input-null-value.html  /docs/forms.html#controlled-input-null-value
 /concurrent     /docs/concurrent-mode-intro.html
 /hooks          /docs/hooks-intro.html


### PR DESCRIPTION
Currently this resolves to the same Netlify site, but is an alias and just serves the same content. There's no good reason to support both domains, so redirect.

This pattern should not be copied into any translation sites.