### PR TITLE
change styling of warning message

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -37,7 +37,9 @@ Using context, we can avoid passing props through intermediate elements:
 
 Context is primarily used when some data needs to be accessible by *many* components at different nesting levels. Apply it sparingly because it makes component reuse more difficult.
 
-**If you only want to avoid passing some props through many levels, [component composition](/docs/composition-vs-inheritance.html) is often a simpler solution than context.**
+> Note
+>
+> If you only want to avoid passing some props through many levels, [component composition](/docs/composition-vs-inheritance.html) is often a simpler solution than context.
 
 For example, consider a `Page` component that passes a `user` and `avatarSize` prop several levels down so that deeply nested `Link` and `Avatar` components can read it:
 


### PR DESCRIPTION
# Change the warning message style from bold to alert type
![image](https://user-images.githubusercontent.com/64988520/101946706-3190f600-3be7-11eb-83fe-6b4644135987.png)

![image](https://user-images.githubusercontent.com/64988520/102023862-23c5a700-3d86-11eb-9f97-f994ff1da9b2.png)


```diff
Context is primarily used when some data needs to be accessible by *many* components at different nesting levels. Apply it sparingly because it makes component reuse more difficult.

- **If you only want to avoid passing some props through many levels, [component composition](/docs/composition-vs-inheritance.html) is often a simpler solution than context.**
+ > Note
+ >
+ > If you only want to avoid passing some props through many levels, [component composition](/docs/composition-vs-inheritance.html) is often a simpler solution than context.

For example, consider a `Page` component that passes a `user` and `avatarSize` prop several levels down so that deeply nested `Link` and `Avatar` components can read it:
```