### PR TITLE
Passing post content on the key passing example

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -254,7 +254,8 @@ const content = posts.map((post) =>
   <Post
     key={post.id}
     id={post.id}
-    title={post.title} />
+    title={post.title} 
+    content={post.content} />
 );
 ```
 


### PR DESCRIPTION
In the official documentation (https://reactjs.org/docs/lists-and-keys.html) there is this Blog Posts example.

In one section (https://reactjs.org/docs/lists-and-keys.html), there's one example of creating a Post component and passing the key, besides the id and other fields. Since the example refers to the post contents it should also pass the "content" field, besides key, id, and title. Otherwise, it is not possible to list the posts with their contents in the newly created Post component.

I recognize the example does not go far into showing the Post component. It just lists how the Blog component would use it, but still, it should use it by passing also the content field, as I mentioned above, besides the other fields (id, key as id, title).

This is a minor issue but still can improve the learning experience of many React beginners, or at least avoid beginners' confusion, especially if they try it on CodePen.