### PR TITLE
Revert "Use vanity URL for Reactiflux"

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -26,7 +26,7 @@ Each community consists of many thousands of React users.
 
 * [DEV's React community](https://dev.to/t/react)
 * [Hashnode's React community](https://hashnode.com/n/reactjs)
-* [Reactiflux online chat](https://discord.gg/reactiflux)
+* [Reactiflux online chat](https://discord.gg/0ZcbPKXt5bZjGY5n)
 * [Reddit's React community](https://www.reddit.com/r/reactjs/)
 * [Spectrum's React community](https://spectrum.chat/react)
 

--- a/content/footerNav.yml
+++ b/content/footerNav.yml
@@ -30,7 +30,7 @@ channels:
       to: https://reactjs.org/community/support.html#popular-discussion-forums
       external: true
     - title: Reactiflux Chat
-      to: https://discord.gg/reactiflux
+      to: https://discord.gg/0ZcbPKXt5bZjGY5n
       external: true
     - title: DEV Community
       to: https://dev.to/t/react

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -118,7 +118,7 @@ We recommend following [these instructions](https://babeljs.io/docs/editors/) to
 
 ### Help, I'm Stuck! {#help-im-stuck}
 
-If you get stuck, check out the [community support resources](/community/support.html). In particular, [Reactiflux Chat](https://discord.gg/reactiflux) is a great way to get help quickly. If you don't receive an answer, or if you remain stuck, please file an issue, and we'll help you out.
+If you get stuck, check out the [community support resources](/community/support.html). In particular, [Reactiflux Chat](https://discord.gg/0ZcbPKXt5bZjGY5n) is a great way to get help quickly. If you don't receive an answer, or if you remain stuck, please file an issue, and we'll help you out.
 
 ## Overview {#overview}
 


### PR DESCRIPTION
Reverts reactjs/reactjs.org#2372

We're allowing direct links to the #react-native channel again (though #help-react-native is a more popular channel, it's not in the React Native category)