### PR TITLE
Put ThemedButton inside context provider

### DIFF
--- a/examples/context/theme-detailed-app.js
+++ b/examples/context/theme-detailed-app.js
@@ -37,10 +37,10 @@ class App extends React.Component {
       <Page>
         <ThemeContext.Provider value={this.state.theme}>
           <Toolbar changeTheme={this.toggleTheme} />
+          <Section>
+            <ThemedButton />
+          </Section>      
         </ThemeContext.Provider>
-        <Section>
-          <ThemedButton />
-        </Section>
       </Page>
     );
   }


### PR DESCRIPTION
Fix a wrong example in the Context documentation: https://reactjs.org/docs/context.html


The ThemedButton used the context, so it must be inside the context provider! 
The whole page teaches us that the components that use the context has to be inside the context provider - but this was is not the case here - and as a result the button did not catch the context changes. So I placed the button INSIDE the context provider.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
