### PR TITLE
removing "import React"

### DIFF
--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -21,7 +21,7 @@ Hooks are [backwards-compatible](/docs/hooks-intro.html#no-breaking-changes). Th
 This example renders a counter. When you click the button, it increments the value:
 
 ```js{1,4,5}
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 function Example() {
   // Declare a new state variable, which we'll call "count"
@@ -77,7 +77,7 @@ The Effect Hook, `useEffect`, adds the ability to perform side effects from a fu
 For example, this component sets the document title after React updates the DOM:
 
 ```js{1,6-10}
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 function Example() {
   const [count, setCount] = useState(0);
@@ -104,7 +104,7 @@ When you call `useEffect`, you're telling React to run your "effect" function af
 Effects may also optionally specify how to "clean up" after them by returning a function. For example, this component uses an effect to subscribe to a friend's online status, and cleans up by unsubscribing from it:
 
 ```js{10-16}
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 function FriendStatus(props) {
   const [isOnline, setIsOnline] = useState(null);
@@ -181,7 +181,7 @@ Earlier on this page, we introduced a `FriendStatus` component that calls the `u
 First, we'll extract this logic into a custom Hook called `useFriendStatus`:
 
 ```js{3}
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 function useFriendStatus(friendID) {
   const [isOnline, setIsOnline] = useState(null);


### PR DESCRIPTION
removing "import React" as it is not required anymore

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
