### PR TITLE
remove componentWillMount/WillReceiveProps

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -27,7 +27,7 @@ When diffing two trees, React first compares the two root elements. The behavior
 
 Whenever the root elements have different types, React will tear down the old tree and build the new tree from scratch. Going from `<a>` to `<img>`, or from `<Article>` to `<Comment>`, or from `<Button>` to `<div>` - any of those will lead to a full rebuild.
 
-When tearing down a tree, old DOM nodes are destroyed. Component instances receive `componentWillUnmount()`. When building up a new tree, new DOM nodes are inserted into the DOM. Component instances receive `componentDidMount()`. Any state associated with the old tree is lost.
+When tearing down a tree, old DOM nodes are destroyed. Component instances receive `componentWillUnmount()`. When building up a new tree, new DOM nodes are inserted into the DOM. Component instances receive `UNSAFE_componentWillMount()` and then `componentDidMount()`. Any state associated with the old tree is lost.
 
 Any components below the root will also get unmounted and have their state destroyed. For example, when diffing:
 
@@ -42,6 +42,12 @@ Any components below the root will also get unmounted and have their state destr
 ```
 
 This will destroy the old `Counter` and remount a new one.
+
+>Note:
+>
+>These methods are considered legacy and you should [avoid them](/blog/2018/03/27/update-on-async-rendering.html) in new code:
+>
+>- `UNSAFE_componentWillMount()`
 
 ### DOM Elements Of The Same Type {#dom-elements-of-the-same-type}
 
@@ -69,9 +75,16 @@ After handling the DOM node, React then recurses on the children.
 
 ### Component Elements Of The Same Type {#component-elements-of-the-same-type}
 
-When a component updates, the instance stays the same, so that state is maintained across renders. React updates the props of the underlying component instance to match the new element, and calls `componentDidUpdate()` on the underlying instance.
+When a component updates, the instance stays the same, so that state is maintained across renders. React updates the props of the underlying component instance to match the new element, and calls `UNSAFE_componentWillReceiveProps()`, `UNSAFE_componentWillUpdate()` and `componentDidUpdate()` on the underlying instance.
 
 Next, the `render()` method is called and the diff algorithm recurses on the previous result and the new result.
+
+>Note:
+>
+>These methods are considered legacy and you should [avoid them](/blog/2018/03/27/update-on-async-rendering.html) in new code:
+>
+>- `UNSAFE_componentWillUpdate()`
+>- `UNSAFE_componentWillReceiveProps()`
 
 ### Recursing On Children {#recursing-on-children}
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -27,7 +27,7 @@ When diffing two trees, React first compares the two root elements. The behavior
 
 Whenever the root elements have different types, React will tear down the old tree and build the new tree from scratch. Going from `<a>` to `<img>`, or from `<Article>` to `<Comment>`, or from `<Button>` to `<div>` - any of those will lead to a full rebuild.
 
-When tearing down a tree, old DOM nodes are destroyed. Component instances receive `componentWillUnmount()`. When building up a new tree, new DOM nodes are inserted into the DOM. Component instances receive `componentWillMount()` and then `componentDidMount()`. Any state associated with the old tree is lost.
+When tearing down a tree, old DOM nodes are destroyed. Component instances receive `componentWillUnmount()`. When building up a new tree, new DOM nodes are inserted into the DOM. Component instances receive `componentDidMount()`. Any state associated with the old tree is lost.
 
 Any components below the root will also get unmounted and have their state destroyed. For example, when diffing:
 
@@ -69,7 +69,7 @@ After handling the DOM node, React then recurses on the children.
 
 ### Component Elements Of The Same Type {#component-elements-of-the-same-type}
 
-When a component updates, the instance stays the same, so that state is maintained across renders. React updates the props of the underlying component instance to match the new element, and calls `componentWillReceiveProps()` and `componentWillUpdate()` on the underlying instance.
+When a component updates, the instance stays the same, so that state is maintained across renders. React updates the props of the underlying component instance to match the new element, and calls `componentDidUpdate()` on the underlying instance.
 
 Next, the `render()` method is called and the diff algorithm recurses on the previous result and the new result.
 


### PR DESCRIPTION
componentWillMount and componentWillReceiveProps are no longer supported by React

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
