### PR TITLE
Add reference to Hooks API for more details

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -187,6 +187,8 @@ In a function, we already have `setCount` and `count` as variables so we don't n
   </button>
 ```
 
+For more details how you can update the state have a look at the [Hooks API Reference: `useState`](/docs/hooks-reference.html#functional-updates)
+
 ## Recap {#recap}
 
 Let's now **recap what we learned line by line** and check our understanding.


### PR DESCRIPTION
I was recently searching for the documentation of function state updates with hooks, and wouldn't find what I was looking for in the `useState` documentation, neither a reference to a different part of the documentation. This PR is to add a reference in the documentation to where further details about `useState` can be found.