### PR TITLE
Highlight all modified lines in the React forms example

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -31,7 +31,7 @@ We can combine the two by making the React state be the "single source of truth"
 
 For example, if we want to make the previous example log the name when it is submitted, we can write the form as a controlled component:
 
-```javascript{4,10-12,24}
+```javascript{4,10-12,21,24}
 class NameForm extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
The change at line 21 was not highlighted, which has been modified with the `handleSubmit` handler added.

Original: https://reactjs.org/docs/forms.html#controlled-components
PR Preview: https://reactjs-org-gi9eds13l.vercel.app/docs/forms.html#controlled-components
or https://deploy-preview-3486--reactjs.netlify.app/docs/forms.html#controlled-components

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
