### PR TITLE
Changed yarn test-prod to yarn test --prod in contributing guide

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -88,7 +88,7 @@ The core team is monitoring for pull requests. We will review your pull request 
 2. Run `yarn` in the repository root.
 3. If you've fixed a bug or added code that should be tested, add tests!
 4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
-5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
+5. Run `yarn test --prod` to test in the production environment.
 6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
 7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
 8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
@@ -117,8 +117,8 @@ Then, you can run several commands:
 * `yarn linc` is like `yarn lint` but faster because it only checks files that differ in your branch.
 * `yarn test` runs the complete test suite.
 * `yarn test --watch` runs an interactive test watcher.
+* `yarn test --prod` runs tests in the production environment.
 * `yarn test <pattern>` runs tests with matching filenames.
-* `yarn test --prod` runs tests in the production environment. It supports all the same options as `yarn test`.
 * `yarn debug-test` is just like `yarn test` but with a debugger. Open `chrome://inspect` and press "Inspect".
 * `yarn flow` runs the [Flow](https://flowtype.org/) typechecks.
 * `yarn build` creates a `build` folder with all the packages.

--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -88,7 +88,7 @@ The core team is monitoring for pull requests. We will review your pull request 
 2. Run `yarn` in the repository root.
 3. If you've fixed a bug or added code that should be tested, add tests!
 4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
-5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
+5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
 6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
 7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
 8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
@@ -118,7 +118,7 @@ Then, you can run several commands:
 * `yarn test` runs the complete test suite.
 * `yarn test --watch` runs an interactive test watcher.
 * `yarn test <pattern>` runs tests with matching filenames.
-* `yarn test-prod` runs tests in the production environment. It supports all the same options as `yarn test`.
+* `yarn test --prod` runs tests in the production environment. It supports all the same options as `yarn test`.
 * `yarn debug-test` is just like `yarn test` but with a debugger. Open `chrome://inspect` and press "Inspect".
 * `yarn flow` runs the [Flow](https://flowtype.org/) typechecks.
 * `yarn build` creates a `build` folder with all the packages.


### PR DESCRIPTION
Minor update to the contributing guide. `yarn test-prod` is deprecated and displays and error message to use `yarn test --prod` instead. This is true at least as far back as yarn 1.10 (sorry couldn't figure out how to install yarn versions earlier than that one).

```
🏠 > yarn test-prod
yarn run v1.10.1
$ yarn test --deprecated 'yarn test --prod'
$ node ./scripts/jest/jest-cli.js --deprecated 'yarn test --prod'

Please run: `yarn test --prod` instead.

✨  Done in 1.74s.
```