### PR TITLE
Update React/Frontend armory course link

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -16,7 +16,7 @@ permalink: community/courses.html
 
 - [React Crash Course 2018](https://www.youtube.com/watch?v=Ke90Tje7VS0) - A beginner-friendly crash course through the most important React topics.
 
-- [React Armory: Learn React by Itself](https://reactarmory.com/guides/learn-react-by-itself) - With React Armory, you can learn React without the buzzwords.
+- [Frontend Armory: React Fundamentals](https://frontarm.com/courses/react-fundamentals/) - Learn React without the buzzwords.
 
 - [Egghead.io: The Beginner's Guide to ReactJS](https://egghead.io/courses/the-beginner-s-guide-to-reactjs) - Free course for React newbies and those looking to get a better understanding of React fundamentals.
 


### PR DESCRIPTION
React Armory hasn't been updated for a while, and the SSL cert is expired (see #3480). This updates the link to point to the newer free course on Frontend Armory.