### PR TITLE
Update jsx-in-depth.md

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -52,7 +52,7 @@ If you want to test out how some specific JSX is converted into JavaScript, you 
 
 The first part of a JSX tag determines the type of the React element.
 
-Capitalized types indicate that the JSX tag is referring to a React component. These tags get compiled into a direct reference to the named variable, so if you use the JSX `<Foo />` expression, `Foo` must be in scope.
+Capitalized types indicate that the JSX tag is referring to a React component. These tags get compiled into a direct reference to the named variable, so if you use the JSX `<Foo />` expression, `React` must be in scope.
 
 ### React Must Be in Scope {#react-must-be-in-scope}
 


### PR DESCRIPTION
- I believe there's a typing mistake in this section, It specifies that if a tag name is used in JSX as <Foo />, then React (NOT Foo) must be in scope to help understand the custom component.
- A confirmation to what I am pointing at in the first point, check the title of the section following the section with the proposed changes in this PR, it states React Must Be in Scope {#react-must-be-in-scope}