### PR TITLE
Change the link to the NEW Yarn installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 1. Git
 1. Node: any 12.x version starting with v12.0.0 or greater
-1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
+1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/getting-started/install)
 1. A fork of the repo (for any contributions)
 1. A clone of the [reactjs.org repo](https://github.com/reactjs/reactjs.org) on your local machine
 


### PR DESCRIPTION
Hello,

The README.md file direct users of React to use Yarn.
![react-readme](https://user-images.githubusercontent.com/60542536/106194043-feb2b980-61b6-11eb-8a55-f091fe4bcb6c.png)

The link directed to an old version of Yarn (Yarn 1. URL: https://classic.yarnpkg.com/en/docs/install/#windows-stable). I fix it so now it directs to the new version of Yarn (Yarn 2. URL: https://yarnpkg.com/getting-started/install).

Thanks.