### PR TITLE
faq-ajax.md: removed incorrect comment from example code

### DIFF
--- a/content/docs/faq-ajax.md
+++ b/content/docs/faq-ajax.md
@@ -101,10 +101,9 @@ function MyComponent() {
         (result) => {
           setIsLoaded(true);
           setItems(result);
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
+        }
+      )
+      .catch(
         (error) => {
           setIsLoaded(true);
           setError(error);


### PR DESCRIPTION
The cautionary comment about swallowing exceptions from the component does not hold true for the second case that utilizes useState hooks. In fact I don't think it is true for the class based component state either in the current react version. (related stackoverflow discussion https://stackoverflow.com/questions/65985507/why-shouldnt-i-use-catch-to-handle-errors-in-react-useeffect-api-calls)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
