### PR TITLE
added react/jsx in development flow steps for building react

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -136,7 +136,7 @@ If your project uses React from npm, you may delete `react` and `react-dom` in i
 
 ```sh
 cd ~/path_to_your_react_clone/
-yarn build react/index,react-dom/index,scheduler --type=NODE
+yarn build react/index,react/jsx,react-dom/index,scheduler --type=NODE
 
 cd build/node_modules/react
 yarn link


### PR DESCRIPTION
While using `yarn build react/index,react-dom/index,scheduler --type=NODE` for building react for an npm project, after performing yarn link, it throws an error `couldn't file react module` because `react-jsx-dev-runtime.development.js` is missing in `build/node_modules/react/cjs`

<img width="1680" alt="Screenshot 2021-02-01 at 5 24 02 PM" src="https://user-images.githubusercontent.com/10696714/106455532-53ee1400-64b2-11eb-9400-c32057e8860a.png">
<img width="1389" alt="Screenshot 2021-02-01 at 5 17 33 PM" src="https://user-images.githubusercontent.com/10696714/106455225-e8a44200-64b1-11eb-9351-a65ebfc0195d.png">
<img width="861" alt="Screenshot 2021-02-01 at 5 17 49 PM" src="https://user-images.githubusercontent.com/10696714/106455240-ee018c80-64b1-11eb-9b78-e07ee6ed9c3f.png">

By adding react/jsx in the build command, `react-jsx-dev-runtime.development.js` is generated and the error goes away

<img width="1368" alt="Screenshot 2021-02-01 at 5 19 05 PM" src="https://user-images.githubusercontent.com/10696714/106455243-ee9a2300-64b1-11eb-8cf5-0a1106f83a0f.png">
<img width="1488" alt="Screenshot 2021-02-01 at 5 21 15 PM" src="https://user-images.githubusercontent.com/10696714/106455249-f063e680-64b1-11eb-856d-1bf67276bf73.png">



This might be helpful for first time contributors of react, because I was not able to run react locally.

Open for suggestions!