### PR TITLE
Update portals.md code comments for accuracy

### DIFF
--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -110,8 +110,8 @@ class Parent extends React.Component {
   }
 
   handleClick() {
-    // This will fire when the button in Child is clicked,
-    // updating Parent's state, even though button
+    // This will fire when Child is clicked,
+    // updating Parent's state, even though Child
     // is not direct descendant in the DOM.
     this.setState(state => ({
       clicks: state.clicks + 1
@@ -137,8 +137,8 @@ class Parent extends React.Component {
 }
 
 function Child() {
-  // The click event on this button will bubble up to parent,
-  // because there is no 'onClick' attribute defined
+  // Any click event on this modal will bubble up to parent,
+  // because there is no 'onClick' attribute defined (e.g., on the button)
   return (
     <div className="modal">
       <button>Click</button>


### PR DESCRIPTION
I found this example a little confusing as a recommended practice (or maybe it's not recommended, in which case maybe I'd update it differently). The intention was to decouple the implementation, but in practice, it doesn't work as a replacement for an implementation using props (or context). As a demonstration of event bubbling from a portal, it's interesting, but it could confuse people because clicks anywhere in the modal will be registered on the handler, while the example suggests only button clicks would be registered. Also, trying to limit the handler to respond to only clicks on the button would break the React way of doing things, because it would require the handler to know something about the elements in the modal/portal.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
