### PR TITLE
Update typechecking-with-proptypes.md

### DIFF
--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -199,7 +199,7 @@ The `defaultProps` will be used to ensure that `this.props.name` will have a val
 
 ### Function Components {#function-components}
 
-If you are using function components in your regular development, you may want to make some small changes to allow PropTypes to be proper applied.
+If you are using function components in your regular development, you may want to make some small changes to allow PropTypes to be properly applied.
 
 Let's say you have a component like this:
 


### PR DESCRIPTION
Typo: "allow PropTypes to be proper applied" => "allow PropTypes to be properly applied"

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
