### PR TITLE
Fix redirects

### DIFF
--- a/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
@@ -23,7 +23,7 @@ exports.onPostBuild = async ({store}) => {
   );
 
   // versions.yml structure is [{path: string, url: string, ...}, ...]
-  createRedirects(
+  await createRedirects(
     versions
       .filter(version => version.path && version.url)
       .map(version => ({


### PR DESCRIPTION
Should fix https://github.com/reactjs/reactjs.org/issues/3138.

This method returns a Promise which wasn't awaited. I suspect this caused a race condition with another plugin to write to the same file, and the other plugin overwrote this one's result. Now they should write sequentially. (I hope.)