### PR TITLE
Updated paths to UMD builds for React and React-DOM in 'How to Contribute' page

### DIFF
--- a/content/docs/how-to-contribute.md
+++ b/content/docs/how-to-contribute.md
@@ -130,7 +130,7 @@ First, run `yarn build`. This will produce pre-built bundles in `build` folder, 
 
 The easiest way to try your changes is to run `yarn build react/index,react-dom/index --type=UMD` and then open `fixtures/packaging/babel-standalone/dev.html`. This file already uses `react.development.js` from the `build` folder so it will pick up your changes.
 
-If you want to try your changes in your existing React project, you may copy `build/dist/react.development.js`, `build/dist/react-dom.development.js`, or any other build products into your app and use them instead of the stable version. 
+If you want to try your changes in your existing React project, you may copy `build/node_modules/react/umd/react.development.js`, `build/node_modules/react-dom/umd/react-dom.development.js`, or any other build products into your app and use them instead of the stable version. 
 
 If your project uses React from npm, you may delete `react` and `react-dom` in its dependencies and use `yarn link` to point them to your local `build` folder. Note that **instead of `--type=UMD` you'll want to pass `--type=NODE` when building**. You'll also need to build the `scheduler` package:
 


### PR DESCRIPTION
After building react (using either `yarn build` or `yarn build react/index,react-dom/index --type=UMD`), the resulting UMD builds no longer reside at `build/dist/react.development.js` and `build/dist/react-dom.development.js`, which is what is currently documented (see [How to Contribute](https://reactjs.org/docs/how-to-contribute.html): 

```
If you want to try your changes in your existing React project, you may copy build/dist/react.development.js, build/dist/react-dom.development.js, or any other build products into your app and use them instead of the stable version.
```

 The builds now appear to be located at `build/node_modules/react/umd/react.development.js` and `build/node_modules/react-dom/umd/react-dom.development.js`. This PR updates the paths in the documentation. 

Opened an issue for this: https://github.com/reactjs/reactjs.org/issues/3524
