### PR TITLE
Update code-splitting.md

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -215,3 +215,10 @@ export { MyComponent as default } from "./ManyComponents.js";
 import React, { lazy } from 'react';
 const MyComponent = lazy(() => import("./MyComponent.js"));
 ```
+
+Instead of creating an additional file to export MyComponent as default in MyComponent.js, you can import ManyComponent.js and export MyComponent as default directly from MyApp.js
+
+```js
+// MyApp.js
+import React, { lazy } from 'react';
+const MyComponent = lazy(() => import('./ManyComponents.js').then(module => ({default: module.MyComponent})))


### PR DESCRIPTION
A convenient one-liner to convert named exports to default export for lazy loading

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
