### PR TITLE
Clarify the definition of "inside conditions"

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -12,7 +12,7 @@ Hooks are JavaScript functions, but you need to follow two rules when using them
 
 ### Only Call Hooks at the Top Level {#only-call-hooks-at-the-top-level}
 
-**Don't call Hooks inside loops, conditions, or nested functions.**. Instead, always use Hooks at the top level of your React function, before any early returns. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
+**Don't call Hooks inside loops, conditions, or nested functions.** Instead, always use Hooks at the top level of your React function, before any early returns. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
 
 ### Only Call Hooks from React Functions {#only-call-hooks-from-react-functions}
 

--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -12,7 +12,7 @@ Hooks are JavaScript functions, but you need to follow two rules when using them
 
 ### Only Call Hooks at the Top Level {#only-call-hooks-at-the-top-level}
 
-**Don't call Hooks inside loops, conditions, or nested functions.** Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
+**Don't call Hooks inside loops, nested functions, or conditions** (this includes calling them after "early exit" conditional return statements). Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
 
 ### Only Call Hooks from React Functions {#only-call-hooks-from-react-functions}
 

--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -12,7 +12,7 @@ Hooks are JavaScript functions, but you need to follow two rules when using them
 
 ### Only Call Hooks at the Top Level {#only-call-hooks-at-the-top-level}
 
-**Don't call Hooks inside loops, nested functions, or conditions** (this includes calling them after "early exit" conditional return statements). Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
+**Don't call Hooks inside loops, conditions, or nested functions.**. Instead, always use Hooks at the top level of your React function, before any early returns. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That's what allows React to correctly preserve the state of Hooks between multiple `useState` and `useEffect` calls. (If you're curious, we'll explain this in depth [below](#explanation).)
 
 ### Only Call Hooks from React Functions {#only-call-hooks-from-react-functions}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I just got tripped up violating the first rule of Hooks in a situation like this:

```js
export function ListGrid({ settings, groupId, itemId }) {
  const { Grid, Placeholder } = useLazyGrid();
  if (!Grid) {
    return <Placeholder />;
  }

  const [text, setText] = useState('');
  ...
```

I'd only been thinking in visual terms about whether `useState` was being [called at the top level](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level). Sure, it wasn't inside a conditional _statement_, but coming after that early exit meant it was still only called under certain conditions, which, now I know, still counts.

eslint-plugin-react-hooks does catch this situation, for the record, but the situation confused me so much I thought it might be nice to add a clarification to this page that "don't call Hooks inside conditions" doesn't just mean "inside conditional statements". `useState` here doesn't feel like it's "inside" anything.

Might be a better way and/or place to explain this idea, but this is a start, at least.