### PR TITLE
Is the bail out to not render the whole component?

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -97,7 +97,7 @@ const [state, setState] = useState(() => {
 
 #### Bailing out of a state update {#bailing-out-of-a-state-update}
 
-If you update a State Hook to the same value as the current state, React will bail out without rendering the children or firing effects. (React uses the [`Object.is` comparison algorithm](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description).)
+If you update a State Hook to the same value as the current state, React will bail out without rendering the component or firing effects. (React uses the [`Object.is` comparison algorithm](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description).)
 
 Note that React may still need to render that specific component again before bailing out. That shouldn't be a concern because React won't unnecessarily go "deeper" into the tree. If you're doing expensive calculations while rendering, you can optimize them with `useMemo`.
 


### PR DESCRIPTION
Could you double check with somebody who knows `setState()` really well? (Dan?)  It seems like the bail out is that React will not render the component itself.  It is not that it will not render the "children".

For a moment I was thinking that it will somehow render the component but not the children, so what does that mean -- does it mean for:

```js
return (
  <div>
    <span>... </span>
  </div>
);
```
that React will render the `<div>` but not the `<span>`?  It seems that React will not render the whole component:

In https://codesandbox.io/s/inspiring-rubin-ukxme?file=/src/App.js

In the Developer's console, the first click would setCount(0), and then setCount(1), setCount(1), so it would set to the same count twice.

So if we inspect the `<div className="App" a={Math.random()} b={Date.now()}>`, we can see that it is not changed if it is setCount() to the same value as before.

So that means, it is not rendering the whole component, not the "children".  I think the use of the word "children" is a little bit confusing, because I think when we say component, that's everything the `return` is returning, and since none of that whole fragment is rendered, so therefore I think it is "If you update a State Hook to the same value as the current state, React will bail out without rendering the component or firing effects."

However, I noticed that the function is still entered, as the `console.log("Coming into the function");` shows, and I wonder if you'd like to add that into the docs. Supposedly, since any effect and render is not done, it shouldn't really do anything, except for any possible side effects. If there is no side effects, it would be as if the function is never invoked.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
