### PR TITLE
Remove CSS advice that is bad for accessibility

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -73,10 +73,6 @@ class MyComponent extends React.Component {
 }
 ```
 
-> Note:
->
-> In CSS, the [`display: contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#display_contents) attribute can be used if you don't want the node to be part of the layout.
-
 ### Detecting unexpected side effects {#detecting-unexpected-side-effects}
 
 Conceptually, React does work in two phases:


### PR DESCRIPTION
From MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/display

> `display: contents` -- Due to a bug in browsers this will currently remove the element from the accessibility tree — screen readers will not look at what's inside. See the Accessibility concerns section below for more details.
