### PR TITLE
Fixing syntax error in #functions-as-children

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -388,7 +388,7 @@ Normally, JavaScript expressions inserted in JSX will evaluate to a string, a Re
 function Repeat(props) {
   let items = [];
   for (let i = 0; i < props.numTimes; i++) {
-    items.push(props.children(i));
+    items.push(props.children[0](i));
   }
   return <div>{items}</div>;
 }


### PR DESCRIPTION
Changing the call to the child prop, which is a function, to first access the child in the children list before invocation.

Found this while reading the docs and copy+pasting the snippet into a Codepen.
