### PR TITLE
Fix useReducer init param docs

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -314,7 +314,7 @@ function init(initialCount) {
   return {count: initialCount};
 }
 
-function reducer(state, action) {
+function reducer(state, action, init) {
   switch (action.type) {
     case 'increment':
       return {count: state.count + 1};


### PR DESCRIPTION
Fix docs to correctly illustrator the use of the init param, passed to useReducer.
The last doc was giving the impression that the init funcion was comming from the upper scope, not the hook parameter

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
