### PR TITLE
Mention useReducer as a cause of rerender in React.memo

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,7 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 If your component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
 
-`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
+`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html), [`useReducer`](/docs/hooks-reference.html#usereducer) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
 
 By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
 


### PR DESCRIPTION
When using `React.memo` HOC function, `useReducer` will also cause the component to be rendered despite their props didn't change.