### PR TITLE
Clarify useImperativeHandle usage

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -452,7 +452,7 @@ function FancyInput(props, ref) {
 FancyInput = forwardRef(FancyInput);
 ```
 
-In this example, a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.focus()`.
+In this example, a parent component that renders `<FancyInput ref={fancyRef} />` can now call `fancyRef.focus()` to focus the underlying `<input />`.
 
 ### `useLayoutEffect` {#uselayouteffect}
 


### PR DESCRIPTION
It's not clear how to use the component once it has been configured. This clarifies it by being more descriptive.

Original:

> a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.focus()`.

Modified:

> a parent component that renders `<FancyInput ref={fancyRef} />` can now call `fancyRef.focus()` to focus the underlying `<input />`.

