### PR TITLE
remove unwanted vaiable from if statement

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -709,7 +709,7 @@ function calculateWinner(squares) {
   ];
   for (let i = 0; i < lines.length; i++) {
     const [a, b, c] = lines[i];
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+    if (squares[a] === squares[b] && squares[a] === squares[c]) {
       return squares[a];
     }
   }


### PR DESCRIPTION

![Screenshot from 2021-03-23 00-24-12](https://user-images.githubusercontent.com/24315018/112041284-542f9500-8b6e-11eb-9bda-34d57ef6e95c.png)

The array for above tictactoe is :
```
let squares = [
"X", null, "O",
"X", null, "O",
"X", null, null
]
```

The `calculateWinner` function in tictactoe tutorial is satisfied for indexes [0, 3, 6] .  However the function contains an unwanted variable in if statement which is not required . Using the indexes , the check is done as follows : 
```
squares[0] && squares[0] === squares[3] && squares[0] === squares[6]
X && X === X && X === X
```
This can be done as below : 
```
squares[0] === squares[3] && squares[0] === squares[6]
X === X && X === X
```



