### PR TITLE
Testing Recipes - Timers: call useFakeTimers/userRealTimers before/after each test

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -465,13 +465,12 @@ import { act } from "react-dom/test-utils";
 
 import Card from "./card";
 
-jest.useFakeTimers();
-
 let container = null;
 beforeEach(() => {
   // setup a DOM element as a render target
   container = document.createElement("div");
   document.body.appendChild(container);
+  jest.useFakeTimers();
 });
 
 afterEach(() => {
@@ -479,6 +478,7 @@ afterEach(() => {
   unmountComponentAtNode(container);
   container.remove();
   container = null;
+  jest.useRealTimers();
 });
 
 it("should select null after timing out", () => {


### PR DESCRIPTION
**Reason:**

Fixing the documentation regarding testing recipes - Timers by calling useFakeTimers before each test. For clarity, I also added  userRealTimers after each test.

**Tests**

![image](https://user-images.githubusercontent.com/9560087/112115078-14da6600-8bb9-11eb-9566-d89a83e96668.png)
