### PR TITLE
fix: use context Provider typo

### DIFF
--- a/content/languages.yml
+++ b/content/languages.yml
@@ -42,7 +42,7 @@
 - name: Persian
   translated_name: فارسی
   code: fa
-  status: 0
+  status: 1
 - name: French
   translated_name: Français
   code: fr
@@ -66,7 +66,7 @@
 - name: Hungarian
   translated_name: magyar
   code: hu
-  status: 1
+  status: 2
 - name: Armenian
   translated_name: Հայերեն
   code: hy


### PR DESCRIPTION
Salute for your awesome work, the PR is for the purpose to fix the typo of component, modified `<Provider>` to `<MyContext.Provider>`

The reactjs.org context part, found [here](https://reactjs.org/docs/context.html#caveats), source code found [here](https://github.com/reactjs/reactjs.org/blob/master/examples/context/reference-caveats-solution.js).