### PR TITLE
Small change in a statement in reconciliation.md

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -59,7 +59,7 @@ When comparing two React DOM elements of the same type, React looks at the attri
 <div className="after" title="stuff" />
 ```
 
-By comparing these two elements, React knows to only modify the `className` on the underlying DOM node.
+By comparing these two elements, React knows to only modify the `class` attribute on the underlying DOM node.
 
 When updating `style`, React also knows to update only the properties that changed. For example:
 


### PR DESCRIPTION
Since underlying DOM node will have `class` attribute. I believe this change makes more sense

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
