### PR TITLE
fix(hook-reference): add missing props

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -448,7 +448,7 @@ function FancyInput(props, ref) {
       inputRef.current.focus();
     }
   }));
-  return <input ref={inputRef} ... />;
+  return <input ref={inputRef} {...props} />;
 }
 FancyInput = forwardRef(FancyInput);
 ```


### PR DESCRIPTION
Add missing props in `useImperativeHandle` section.