### PR TITLE
Replace alert() with console.log() (#3656)

### DIFF
--- a/content/docs/composition-vs-inheritance.md
+++ b/content/docs/composition-vs-inheritance.md
@@ -156,7 +156,7 @@ class SignUpDialog extends React.Component {
   }
 
   handleSignUp() {
-    alert(`Welcome aboard, ${this.state.login}!`);
+    console.log(`Welcome aboard, ${this.state.login}!`);
   }
 }
 ```

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -46,7 +46,7 @@ class NameForm extends React.Component {
   }
 
   handleSubmit(event) {
-    alert('A name was submitted: ' + this.state.value);
+    console.log('A name was submitted: ' + this.state.value);
     event.preventDefault();
   }
 
@@ -99,7 +99,7 @@ class EssayForm extends React.Component {
   }
 
   handleSubmit(event) {
-    alert('An essay was submitted: ' + this.state.value);
+    console.log('An essay was submitted: ' + this.state.value);
     event.preventDefault();
   }
 
@@ -149,7 +149,7 @@ class FlavorForm extends React.Component {
   }
 
   handleSubmit(event) {
-    alert('Your favorite flavor is: ' + this.state.value);
+    console.log('Your favorite flavor is: ' + this.state.value);
     event.preventDefault();
   }
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -390,9 +390,9 @@ Any function inside a component, including event handlers and effects, "sees" th
 function Example() {
   const [count, setCount] = useState(0);
 
-  function handleAlertClick() {
+  function handleMessageClick() {
     setTimeout(() => {
-      alert('You clicked on: ' + count);
+      console.log('You clicked on: ' + count);
     }, 3000);
   }
 
@@ -402,15 +402,15 @@ function Example() {
       <button onClick={() => setCount(count + 1)}>
         Click me
       </button>
-      <button onClick={handleAlertClick}>
-        Show alert
+      <button onClick={handleMessageClick}>
+        Show message
       </button>
     </div>
   );
 }
 ```
 
-If you first click "Show alert" and then increment the counter, the alert will show the `count` variable **at the time you clicked the "Show alert" button**. This prevents bugs caused by the code assuming props and state don't change.
+If you first click "Show message" and then increment the counter, the message will show the `count` variable **at the time you clicked the "Show message" button**. This prevents bugs caused by the code assuming props and state don't change.
 
 If you intentionally want to read the *latest* state from some asynchronous callback, you could keep it in [a ref](/docs/hooks-faq.html#is-there-something-like-instance-variables), mutate it, and read from it.
 
@@ -930,7 +930,7 @@ function Form() {
 
   const handleSubmit = useCallback(() => {
     const currentText = textRef.current; // Read it from the ref
-    alert(currentText);
+    console.log(currentText);
   }, [textRef]); // Don't recreate handleSubmit like [text] would do
 
   return (
@@ -949,7 +949,7 @@ function Form() {
   const [text, updateText] = useState('');
   // Will be memoized even if `text` changes:
   const handleSubmit = useEventCallback(() => {
-    alert(text);
+    console.log(text);
   }, [text]);
 
   return (

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -205,7 +205,7 @@ So the following jQuery implementation...
 ```js
 $('#container').html('<button id="btn">Say Hello</button>');
 $('#btn').click(function() {
-  alert('Hello!');
+  console.log('Hello!');
 });
 ```
 
@@ -221,7 +221,7 @@ ReactDOM.render(
   document.getElementById('container'),
   function() {
     $('#btn').click(function() {
-      alert('Hello!');
+      console.log('Hello!');
     });
   }
 );
@@ -236,7 +236,7 @@ function Button(props) {
 
 function HelloButton() {
   function handleClick() {
-    alert('Hello!');
+    console.log('Hello!');
   }
   return <Button onClick={handleClick} />;
 }

--- a/content/docs/react-without-es6.md
+++ b/content/docs/react-without-es6.md
@@ -96,7 +96,7 @@ class SayHello extends React.Component {
   }
 
   handleClick() {
-    alert(this.state.message);
+    console.log(this.state.message);
   }
 
   render() {
@@ -119,7 +119,7 @@ var SayHello = createReactClass({
   },
 
   handleClick: function() {
-    alert(this.state.message);
+    console.log(this.state.message);
   },
 
   render: function() {
@@ -146,7 +146,7 @@ class SayHello extends React.Component {
   // WARNING: this syntax is experimental!
   // Using an arrow here binds the method:
   handleClick = () => {
-    alert(this.state.message);
+    console.log(this.state.message);
   }
 
   render() {

--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -19,7 +19,7 @@ class NameForm extends React.Component {
   }
 
   handleSubmit(event) {
-    alert('A name was submitted: ' + this.input.current.value);
+    console.log('A name was submitted: ' + this.input.current.value);
     event.preventDefault();
   }
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -235,7 +235,7 @@ First, change the button tag that is returned from the Square component's `rende
 class Square extends React.Component {
   render() {
     return (
-      <button className="square" onClick={function() { alert('click'); }}>
+      <button className="square" onClick={function() { console.log('click'); }}>
         {this.props.value}
       </button>
     );
@@ -243,7 +243,7 @@ class Square extends React.Component {
 }
 ```
 
-If you click on a Square now, you should see an alert in your browser.
+If you click on a Square now, you should see a message in your browser console.
 
 >Note
 >
@@ -253,7 +253,7 @@ If you click on a Square now, you should see an alert in your browser.
 >class Square extends React.Component {
 >  render() {
 >    return (
->      <button className="square" onClick={() => alert('click')}>
+>      <button className="square" onClick={() => console.log('click')}>
 >        {this.props.value}
 >      </button>
 >    );
@@ -261,7 +261,7 @@ If you click on a Square now, you should see an alert in your browser.
 >}
 >```
 >
->Notice how with `onClick={() => alert('click')}`, we're passing *a function* as the `onClick` prop. React will only call this function after a click. Forgetting `() =>` and writing `onClick={alert('click')}` is a common mistake, and would fire the alert every time the component re-renders.
+>Notice how with `onClick={() => console.log('click')}`, we're passing *a function* as the `onClick` prop. React will only call this function after a click. Forgetting `() =>` and writing `onClick={console.log('click')}` is a common mistake, and would fire the message every time the component re-renders.
 
 As a next step, we want the Square component to "remember" that it got clicked, and fill it with an "X" mark. To "remember" things, components use **state**.
 
@@ -280,7 +280,7 @@ class Square extends React.Component {
 
   render() {
     return (
-      <button className="square" onClick={() => alert('click')}>
+      <button className="square" onClick={() => console.log('click')}>
         {this.props.value}
       </button>
     );


### PR DESCRIPTION
The following Chromium feature is currently being tested.
"Feature: Remove alert(), confirm(), and prompt for cross origin iframes§
https://www.chromestatus.com/feature/5148698084376576

Therefore, alert() will no longer work on Codepen. console.log() still works. The feature is not yet in the stable version of Chromium, but in the current beta (tested with Chrome beta version 91.0.4472.27).