### PR TITLE
Missing definition of `e` alias variable for `React.createElement` in the example code

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -80,6 +80,7 @@ After **[the starter code](https://gist.github.com/gaearon/0b180827c190fe4fd98b4
 ```js{3,4}
 // ... the starter code you pasted ...
 
+const e = React.createElement;
 const domContainer = document.querySelector('#like_button_container');
 ReactDOM.render(e(LikeButton), domContainer);
 ```


### PR DESCRIPTION
## Add React to a Website
### Step 3: Create a React Component

https://reactjs.org/docs/add-react-to-a-website.html#step-3-create-a-react-component

```
edit-smart-trigger.js:19 Main script execution failed ReferenceError: e is not defined
    at main (edit-smart-trigger.js:14)
    at edit-smart-trigger.js:17
```

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
