### PR TITLE
Updated onclick method from props to prevent error

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -440,7 +440,7 @@ class Square extends React.Component {
     return (
       <button
         className="square"
-        onClick={() => this.props.onClick()}
+        onClick={() => this.props.onClick}
       >
         {this.props.value}
       </button>


### PR DESCRIPTION
I was going through the  tutorial and got the following error because the onclick props were expressed with parentheses:
"Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops."

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

![handle_click_react_tutorial](https://user-images.githubusercontent.com/34905588/119056609-00d49a00-b999-11eb-8132-ab359a924cf5.PNG)

