### PR TITLE
Updating name of variable to which returned value of setState is assigned

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -71,8 +71,8 @@ class Toggle extends React.Component {
   }
 
   handleClick() {
-    this.setState(state => ({
-      isToggleOn: !state.isToggleOn
+    this.setState(prevState => ({
+      isToggleOn: !prevState.isToggleOn
     }));
   }
 


### PR DESCRIPTION
…ed for uniformity

in CodePen it is 'prevState' and in the tutorial, it is 'state', which creates confusion.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
