### PR TITLE
Fix broken link to devtools

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -297,7 +297,7 @@ The `compose` utility function is provided by many third-party libraries includi
 
 ## Convention: Wrap the Display Name for Easy Debugging {#convention-wrap-the-display-name-for-easy-debugging}
 
-The container components created by HOCs show up in the [React Developer Tools](https://github.com/facebook/react-devtools) like any other component. To ease debugging, choose a display name that communicates that it's the result of a HOC.
+The container components created by HOCs show up in the [React Developer Tools](https://github.com/facebook/react/tree/master/packages/react-devtools) like any other component. To ease debugging, choose a display name that communicates that it's the result of a HOC.
 
 The most common technique is to wrap the display name of the wrapped component. So if your higher-order component is named `withSubscription`, and the wrapped component's display name is `CommentList`, use the display name `WithSubscription(CommentList)`:
 


### PR DESCRIPTION
The old link (https://github.com/facebook/react-devtools) pointed to an archived repo. I've updated it to point to the devtools package in the React repo (https://github.com/facebook/react/tree/master/packages/react-devtools)