### PR TITLE
Updates the example for useImperativeHandle for clarity

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -441,7 +441,7 @@ useImperativeHandle(ref, createHandle, [deps])
 `useImperativeHandle` customizes the instance value that is exposed to parent components when using `ref`. As always, imperative code using refs should be avoided in most cases. `useImperativeHandle` should be used with [`forwardRef`](/docs/react-api.html#reactforwardref):
 
 ```js
-function FancyInput(props, ref) {
+const FancyInput = React.forwardRef((props, ref) => {
   const inputRef = useRef();
   useImperativeHandle(ref, () => ({
     focus: () => {
@@ -449,8 +449,7 @@ function FancyInput(props, ref) {
     }
   }));
   return <input ref={inputRef} ... />;
-}
-FancyInput = forwardRef(FancyInput);
+})
 ```
 
 In this example, a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.focus()`.


### PR DESCRIPTION
The existing example assumes 'forwardRef' is already in scope as-is, which although possible, is not inline with the other examples on the same page which explicitly go via `React.someMethod` every time. 

Additionally altered the example to avoid reassignment to an existing function. `FancyInput = forwardRef(FancyInput);` in particular looks like very suspicious code to me.