### PR TITLE
Fix incorrect order for input locking

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -275,10 +275,10 @@ Specifying the value prop on a [controlled component](/docs/forms.html#controlle
 The following code demonstrates this. (The input is locked at first but becomes editable after a short delay.)
 
 ```javascript
-ReactDOM.render(<input value="hi" />, mountNode);
+ReactDOM.render(<input value={null} />, mountNode);
 
 setTimeout(function() {
-  ReactDOM.render(<input value={null} />, mountNode);
+  ReactDOM.render(<input value="hi" />, mountNode);
 }, 1000);
 
 ```


### PR DESCRIPTION
The input should be initially locked and show "hi" after a delay.
