### PR TITLE
Fix broken link in the web-components.md file

### DIFF
--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -59,4 +59,4 @@ customElements.define('x-search', XSearch);
 >Note:
 >
 >This code **will not** work if you transform classes with Babel. See [this issue](https://github.com/w3c/webcomponents/issues/587) for the discussion.
->Include the [custom-elements-es5-adapter](https://github.com/webcomponents/polyfills/tree/main/packages/webcomponentsjs#custom-elements-es5-adapterjs) before you load your web components to fix this issue.
+>Include the [custom-elements-es5-adapter](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs#custom-elements-es5-adapterjs) before you load your web components to fix this issue.


### PR DESCRIPTION
The current URL is leading to a 404 page because webcomponents's polyfills repo default branch is master instead of main.
