### PR TITLE
Local state is updated without using this.setState

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -33,7 +33,12 @@ class ErrorBoundary extends React.Component {
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    //getDerivedStateFromError() is setting the local state (this.state = { hasError: false };) of the component without using this.setState (return { hasError: true };).
+   // return { hasError: true };
+   this.setState({
+      hasError: true
+    });
+   return this.state.hasError
   }
 
   componentDidCatch(error, errorInfo) {


### PR DESCRIPTION
In the first example of Error Boundaries the method getDerivedStateFromError() is setting the local state (this.state = { hasError: false };) of the component without using this.setState (return { hasError: true };).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
