### PR TITLE
Fix typo in state-and-lifecycle.md

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -336,7 +336,7 @@ Instead, use `setState()`:
 this.setState({comment: 'Hello'});
 ```
 
-The only place where you can assign `this.state` is the constructor.
+The only place where you can assign `this.state` as the constructor.
 
 ### State Updates May Be Asynchronous {#state-updates-may-be-asynchronous}
 


### PR DESCRIPTION
'is' should be 'as'

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
