### PR TITLE
Add explanation of step and move variables

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1045,6 +1045,8 @@ Let's `map` over the `history` in the Game's `render` method:
 
 **[View the full code at this point](https://codepen.io/gaearon/pen/EmmGEa?editors=0010)**
 
+As we iterate through `history` array, `step` variable refers to the current `history` element value, and `move` refers to the current `history` element index.
+
 For each move in the tic-tac-toe game's history, we create a list item `<li>` which contains a button `<button>`. The button has a `onClick` handler which calls a method called `this.jumpTo()`. We haven't implemented the `jumpTo()` method yet. For now, we should see a list of the moves that have occurred in the game and a warning in the developer tools console that says:
 
 >  Warning:

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1045,7 +1045,7 @@ Let's `map` over the `history` in the Game's `render` method:
 
 **[View the full code at this point](https://codepen.io/gaearon/pen/EmmGEa?editors=0010)**
 
-As we iterate through `history` array, `step` variable refers to the current `history` element value, and `move` refers to the current `history` element index.
+As we iterate through `history` array, `step` variable refers to the current `history` element value, and `move` refers to the current `history` element index. We only interested in `move` here, hence `step` is not getting assigned to anything.
 
 For each move in the tic-tac-toe game's history, we create a list item `<li>` which contains a button `<button>`. The button has a `onClick` handler which calls a method called `this.jumpTo()`. We haven't implemented the `jumpTo()` method yet. For now, we should see a list of the moves that have occurred in the game and a warning in the developer tools console that says:
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
I (and [some people](https://stackoverflow.com/questions/54016624/react-tutorial-history-map-step-move) to be honest) found that `step` and `move` variable in `history.map` method is ambiguous and need to be explained more. I add brief explanation for these variables to avoid confusion. Let me know if it needs changes.