### PR TITLE
Activate banner for 2021 survey

### DIFF
--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -11,7 +11,7 @@ import {colors, fonts, media} from 'theme';
 import ExternalLinkSvg from 'templates/components/ExternalLinkSvg';
 
 const linkProps = {
-  href: 'https://www.surveymonkey.co.uk/r/673TZ7T',
+  href: 'https://surveys.savanta.com/survey/selfserve/21e3/210643?list=2',
   target: '_blank',
   rel: 'noopener',
 };
@@ -135,7 +135,7 @@ export default function Banner() {
             target="_blank"
             rel="noopener">
             <span css={{color: colors.brand}}>
-              Take our 2020 Community Survey!
+              Take our 2021 Community Survey!
             </span>
             <ExternalLinkSvg
               cssProps={{

--- a/src/html.js
+++ b/src/html.js
@@ -62,11 +62,11 @@ export default class HTML extends React.Component<Props> {
                   }
 
                   activeBanner = {
-                    storageId: 'reactjs_banner_2020survey',
+                    storageId: 'reactjs_banner_2021survey',
                     normalHeight: 50,
                     smallHeight: 75,
-                    campaignStartDate: '2020-10-05T00:00:00Z', // the Z is for UTC
-                    campaignEndDate: '2020-10-19T00:00:00Z', // the Z is for UTC
+                    campaignStartDate: '2021-08-16T00:00:00Z', // the Z is for UTC
+                    campaignEndDate: '2021-08-31T00:00:00Z', // the Z is for UTC
                     snoozeForDays: 7,
                   };
 


### PR DESCRIPTION
Activating banner for an upcoming survey set to run for two weeks.

![Screen Shot 2021-08-16 at 10 58 03 AM](https://user-images.githubusercontent.com/691109/129603383-9477ed6e-05e9-4cba-8230-b5f2a31a4ad8.png)

![Screen Shot 2021-08-16 at 10 58 26 AM](https://user-images.githubusercontent.com/691109/129603391-657154b3-1ff5-453e-8070-410ecc267ec7.png)

