### PR TITLE
Change term used for describing elements

### DIFF
--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -20,7 +20,7 @@ Unlike browser DOM elements, React elements are plain objects, and are cheap to 
 
 >**Note:**
 >
->One might confuse elements with a more widely known concept of "components". We will introduce components in the [next section](/docs/components-and-props.html). Elements are what components are "made of", and we encourage you to read this section before jumping ahead.
+>One might confuse elements with a more widely known concept of "components". We will introduce components in the [next section](/docs/components-and-props.html). Components can be used to create complex custom elements, and we encourage you to read this section before jumping ahead.
 
 ## Rendering an Element into the DOM {#rendering-an-element-into-the-dom}
 


### PR DESCRIPTION
This is very tricky but I think we shouldn't just settle on saying elements are what components are "made of". I'm a semi beginner here and that would've just flew over my head if I just started reading a couple pages in the docs. It reads kind of misleading. I also feel that people who take this documentation route might think more technically about their code anyway.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
