### PR TITLE
Update reference-javascript-environment-requirements.md

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -6,13 +6,14 @@ category: Reference
 permalink: docs/javascript-environment-requirements.html
 ---
 
-React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js).
+React 16 depends on the types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) and [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js).
 
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
 import 'core-js/es/map';
 import 'core-js/es/set';
+import 'core-js/es/symbol';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
React also needs `Symbol` type. So if you want to support older browsers, it will be great to include it as polyfill.
