### PR TITLE
Rephrase the reason for duplicating the array for clarity

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -524,7 +524,7 @@ Note how in `handleClick`, we call `.slice()` to create a copy of the `squares` 
 
 ### Why Immutability Is Important {#why-immutability-is-important}
 
-In the previous code example, we suggested that you use the `.slice()` method to create a copy of the `squares` array to copy instead of modifying the existing array. We'll now discuss immutability and why immutability is important to learn.
+In the previous code example, we suggested that you create a copy of the `squares` array using the `slice()` method instead of modifying the existing array. We'll now discuss immutability and why immutability is important to learn.
 
 There are generally two approaches to changing data. The first approach is to *mutate* the data by directly changing the data's values. The second approach is to replace the data with a new copy which has the desired changes.
 


### PR DESCRIPTION
The explanation in the "Why Immutability..." section was some what odd and contained a redundant/unnecessary word. In the previous section to this, it was suggested to create a copy of the array and in this instance, `slice()` was the method that was used to do that. IINM, the main point is that a copy should be made, not that the `slice()` method should be used. Hence the proposed change in this PR. 