### PR TITLE
Update hooks-reference.md

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -365,7 +365,7 @@ Returns a [memoized](https://en.wikipedia.org/wiki/Memoization) callback.
 
 Pass an inline callback and an array of dependencies. `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed. This is useful when passing callbacks to optimized child components that rely on reference equality to prevent unnecessary renders (e.g. `shouldComponentUpdate`).
 
-`useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)`.
+`useCallback(fn, deps)` is equivalent to `useCallback(() => fn(), deps)`.
 
 > Note
 >


### PR DESCRIPTION
It seems that call useСallback is not equivalent to call useMemo. The first returns a function, and the second returns a value.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
