### PR TITLE
docs: remove cancelled conference

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -17,11 +17,6 @@ September 13-15, 2021. Atlanta, GA, USA
 
 [Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
 
-### React Conference Live 2021 {#react-conference-live-2021} 
-October 7-8, 2021. In-person in Amsterdam, Netherlands + remote (hybrid event)
-
-[Website](https://reactlive.nl/) - [Twitter](https://twitter.com/reactlivenl) - [LinkedIn](https://www.linkedin.com/company/frontendlove/)
-
 ### React Brussels 2021 {#react-brussels-2021} 
 October 15, 2021 - remote event
 


### PR DESCRIPTION
https://reactlive.nl/ has been cancelled completely so removing from the conference page.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
