### PR TITLE
Update jsx-in-depth.md

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -388,7 +388,7 @@ Normally, JavaScript expressions inserted in JSX will evaluate to a string, a Re
 function Repeat(props) {
   let items = [];
   for (let i = 0; i < props.numTimes; i++) {
-    items.push(props.children(i));
+    items.push(props.children[0](i));
   }
   return <div>{items}</div>;
 }


### PR DESCRIPTION
The example in section "Functions as Children" works only with "0" index in props.children, because props.children is an array-like object, where the function is the value of the first property.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
