### PR TITLE
Fix 404 page for "/link/switch-to-createroot"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -39,6 +39,7 @@
     { "source": "/link/uselayouteffect-ssr", "destination": "https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85", "permanent": false },
     { "source": "/link/react-devtools-faq", "destination": "https://github.com/facebook/react/tree/main/packages/react-devtools#faq", "permanent": false },
     { "source": "/link/setstate-in-render", "destination": "https://github.com/facebook/react/issues/18178#issuecomment-595846312", "permanent": false },
+    { "source": "/link/switch-to-createroot", "destination": "https://github.com/reactwg/react-18/discussions/5", "permanent": false },
     { "source": "/version/15.6", "destination": "https://react-legacy.netlify.app", "permanent": false }
   ]
 }


### PR DESCRIPTION
Hello, I was testing react 18 alpha and I found a guide for using new api.

![image](https://user-images.githubusercontent.com/11723334/135124092-8143a1eb-8a2a-494f-b509-47f25c654ed9.png)

But the link https://reactjs.org/link/switch-to-createroot seems to be empty.

![image](https://user-images.githubusercontent.com/11723334/135124275-35ea6ce3-25e2-44bc-a393-e4b28932f9a1.png)

I guess the vercel config is missing the redirection url.
So I added the link to `vercel.json`.

Thanks.

