### PR TITLE
Added dates for Render-Atlanta 2022

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -43,6 +43,11 @@ November 12-14, 2021 - remote event
 
 [Website](https://www.reactindia.io) - [Twitter](https://twitter.com/react_india) - [Facebook](https://www.facebook.com/ReactJSIndia/) - [LinkedIn](https://www.linkedin.com/showcase/14545585) - [YouTube](https://www.youtube.com/channel/UCaFbHCBkPvVv1bWs_jwYt3w/videos)
 
+### render(ATL) 2022 {#render-atlanta-2022} 
+June 2-4, 2022. Atlanta, GA, USA
+
+[Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
+
 ## Past Conferences {#past-conferences}
 
 ### render(ATL) 2021 {#render-atlanta-2021} 


### PR DESCRIPTION
June 2-4, 2022. Render-Atlanta 2022

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
