### PR TITLE
📄 Note about Promises for `React.lazy`

### DIFF
--- a/content/docs/reference-javascript-environment-requirements.md
+++ b/content/docs/reference-javascript-environment-requirements.md
@@ -6,13 +6,14 @@ category: Reference
 permalink: docs/javascript-environment-requirements.html
 ---
 
-React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js).
+React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). Also using [React.lazy](/docs/react-api.html#reactlazy) with dynamic import requires [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) to be available in the JS environment. If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11) or which have non-compliant implementations (e.g. IE 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js).
 
 A polyfilled environment for React 16 using core-js to support older browsers might look like:
 
 ```js
 import 'core-js/es/map';
 import 'core-js/es/set';
+import 'core-js/es/promise';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
According to the note section of [`React.lazy`](https://reactjs.org/docs/react-api.html#reactlazy)

> Using `React.lazy` with dynamic import requires Promises to be available in the JS environment. This requires a polyfill on IE11 and below.

From my perspective, it is worth noting here about polyfilling Promises as well as import it in the example.