### PR TITLE
Restyle logo width to make translations easier [issue #1817]

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -77,9 +77,6 @@ const Header = ({location}: {location: Location}) => (
               color: colors.white,
             },
 
-            [media.greaterThan('small')]: {
-              width: 'calc(100% / 6)',
-            },
             [media.lessThan('small')]: {
               flex: '0 0 auto',
             },
@@ -143,14 +140,22 @@ const Header = ({location}: {location: Location}) => (
                 'linear-gradient(to right, transparent, black 20px, black 90%, transparent)',
             },
           }}>
-          {navHeader.items.map(link => (
-            <HeaderLink
-              key={link.title}
-              isActive={location.pathname.includes(link.activeSelector)}
-              title={link.title}
-              to={link.to}
-            />
-          ))}
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'row',
+              marginLeft: 'auto',
+              marginRight: 'auto',
+            }}>
+            {navHeader.items.map(link => (
+              <HeaderLink
+                key={link.title}
+                isActive={location.pathname.includes(link.activeSelector)}
+                title={link.title}
+                to={link.to}
+              />
+            ))}
+          </div>
         </nav>
 
         <DocSearch />


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

### About:
This PR fixes #1817.
Currently, when translated into Vietnamese, the nav link has two lines with a screen width between 1280px and 1290px.
To solve this problem,  I fix two points
- Unfix the width of the logo at calc(100% / 6)
- Centers the nav bar between the logo and search bar

This also helps to solve the problem of cut-offs in translation without hard coding of the logo width.

### Visuals:
**Before Changes:**
![スクリーンショット 2021-10-05 18 11 12](https://user-images.githubusercontent.com/63572812/135994881-0206c175-25c5-45d7-9826-5fdbce4e391e.png)

**After Changes:**
![スクリーンショット 2021-10-05 18 11 52](https://user-images.githubusercontent.com/63572812/135994912-e26f4954-3407-46ad-89fb-dc1ae35ebcd2.png)


