### PR TITLE
Remove Spectrum from community support page

### DIFF
--- a/content/community/support.md
+++ b/content/community/support.md
@@ -28,7 +28,6 @@ Each community consists of many thousands of React users.
 * [Hashnode's React community](https://hashnode.com/n/reactjs)
 * [Reactiflux online chat](https://discord.gg/reactiflux)
 * [Reddit's React community](https://www.reddit.com/r/reactjs/)
-* [Spectrum's React community](https://spectrum.chat/react)
 
 ## News {#news}
 


### PR DESCRIPTION
## Discussion

As of August 24, 2021 Spectrum is [read-only](https://spectrum.chat/spectrum/general/join-us-on-our-new-journey~e4ca0386-f15c-4ba8-8184-21cf5fa39cf5) to allow the team to focus on developing GitHub discussions. This should be removed to improve UX, allowing users to select only from active and vibrant communities.

## Related issue
None
