### PR TITLE
explanation about "state updates are merged"

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1147,6 +1147,7 @@ Next, we'll define the `jumpTo` method in Game to update that `stepNumber`. We a
     // this method has not changed
   }
 ```
+Notice in `jumpTo` method, we haven't updated history property of the state. That is because state updates are merged or in more simple words react will update only the properties mentioned in `setState` method leaving the remaining state as that is. For more info **[see the documentation](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-are-merged)**
 
 We will now make a few changes to the Game's `handleClick` method which fires when you click on a square.
 


### PR DESCRIPTION
The tutorial used the concept of "state updates are merged" in "jumpTo" method. For beginners, this might be confusing, So I added some info about it and a link to the documentation. 

If we don't want to give overhead to users by explaining this new concept we can update history in the "jumpTo" method. so that nobody scratch their heads thinking why history is not updated in setState. I created https://github.com/reactjs/reactjs.org/pull/3957 PR for that change. Thanks for the tutorial.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
