### PR TITLE
Updating history in jumpTo method

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1138,6 +1138,7 @@ Next, we'll define the `jumpTo` method in Game to update that `stepNumber`. We a
 
   jumpTo(step) {
     this.setState({
+      history: this.state.history.concat(),
       stepNumber: step,
       xIsNext: (step % 2) === 0,
     });


### PR DESCRIPTION
Not many beginners will know that state changes are merged. In jumpTo method, we are not updating the history property. This may lead to confusion, especially for beginners. Thanks for the tutorial.

Another workaround would be adding some explanation about the state changes are merged. I have created another PR with that change https://github.com/reactjs/reactjs.org/pull/3956 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
