### PR TITLE
Fixed invalid JSON example.

### DIFF
--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -20,7 +20,7 @@ Imagine that we already have a JSON API and a mock from our designer. The mock l
 
 Our JSON API returns some data that looks like this:
 
-```
+```json
 [
     {"category": "Sporting Goods", "price": "$49.99", "stocked": true, "name": "Football"},
     {"category": "Sporting Goods", "price": "$9.99", "stocked": true, "name": "Baseball"},


### PR DESCRIPTION
**TDLR:** Fixed invalid JSON formatting and added syntax highlighting.

I found that the JSON on this page was invalid when I tried to use it in vscode. I also checked a JSON validator and it did not validate it. It told me "property names must be double quoted" so I did just that.

I also saw that there was no syntax highlighting for the JSON so I added that as well.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
