### PR TITLE
[Beta] Fix preconnect link to target search cluster

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -46,7 +46,6 @@ const options = {
 };
 let DocSearchModal: any = null;
 export const Search: React.FC<SearchProps> = ({
-  appId,
   searchParameters = {
     hitsPerPage: 5,
   },
@@ -93,7 +92,7 @@ export const Search: React.FC<SearchProps> = ({
       <Head>
         <link
           rel="preconnect"
-          href={`https://${appId}-dsn.algolia.net`}
+          href={`https://${options.appId}-dsn.algolia.net`}
           crossOrigin="true"
         />
       </Head>


### PR DESCRIPTION
The `appId` was retrieved from props but the `<Search>` component is never instantiated with props. So the preconnect link targeted an unknown search cluster:

```html
<link rel="preconnect" href="https://undefined-dsn.algolia.net" crossorigin="true">
```

This fixes the preconnect link by getting the `appId` from the website config.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
