### PR TITLE
[beta] Use "Ctrl" instead of ⌘ for shortcut key for non-macos computers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "parse-numeric-range": "^1.2.0",
     "react": "18.0.0-alpha-930c9e7ee-20211015",
     "react-collapsed": "3.1.0",
+    "react-device-detect": "^2.0.1",
     "react-dom": "18.0.0-alpha-930c9e7ee-20211015",
     "scroll-into-view-if-needed": "^2.2.25"
   },

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,6 +9,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Router from 'next/router';
 import * as React from 'react';
+import {isMacOs} from 'react-device-detect';
 import {createPortal} from 'react-dom';
 import {siteConfig} from 'siteConfig';
 
@@ -31,8 +32,8 @@ function Hit({hit, children}: any) {
 function Kbd(props: {children?: React.ReactNode}) {
   return (
     <kbd
-      className="border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center  text-xs text-center rounded"
-      style={{width: '2.25em', height: '2.25em'}}
+      className="border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center text-xs text-center rounded"
+      style={{minWidth: '2.25em', height: '2.25em'}}
       {...props}
     />
   );
@@ -112,7 +113,7 @@ export const Search: React.FC<SearchProps> = ({
         <IconSearch className="mr-3 align-middle text-gray-30 flex-shrink-0 group-betterhover:hover:text-gray-70" />
         Search
         <span className="ml-auto hidden sm:flex item-center">
-          <Kbd>⌘</Kbd>
+          {isMacOs ? <Kbd>⌘</Kbd> : <Kbd>Ctrl</Kbd>}
           <Kbd>K</Kbd>
         </span>
       </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5323,6 +5323,13 @@ react-collapsed@3.1.0:
     raf "^3.4.1"
     tiny-warning "^1.0.3"
 
+react-device-detect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.0.1.tgz#663530bafe1dad333b67eae4252556244f45c2fc"
+  integrity sha512-DrDKiKky/L/DSEJUw5CL2I38s/18zCLIoKP4pE4CyO1FyL6XhQZMIjHmv0pbYQBlfdKB+ZUXP53tWeLkt0eqJw==
+  dependencies:
+    ua-parser-js "^0.7.28"
+
 react-dom@18.0.0-alpha-930c9e7ee-20211015:
   version "18.0.0-alpha-930c9e7ee-20211015"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-930c9e7ee-20211015.tgz#32648ee7ab0f00550bb74d501373911110619949"
@@ -6465,6 +6472,11 @@ typescript@^4.0.2:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+
+ua-parser-js@^0.7.28:
+  version "0.7.29"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.29.tgz#aad8d679f15a721ed79454d553e3473f9f0536f1"
+  integrity sha512-EdEWUP3Dk9oyycRzMBbVHYW3GLbq5KPWHLKpXSNwD5F6u0s1x12mmP4KIzqSSzpngv8/8pE3f49/qGBG8VgqCg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- adds [react-device-detect](https://www.npmjs.com/package/react-device-detect) to detect operating system
- Uses "Ctrl" instead of ⌘ for non-macos computers in the search bar
- changes min-width of the `Kbd` component so it expands to fit "Ctrl"

Search bar on windows:
![image](https://user-images.githubusercontent.com/18731800/138524908-9b25c8be-586b-4d50-be6b-52920915686d.png)