### PR TITLE
Fixed a typo in  jsx-in-depth.md

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -388,7 +388,7 @@ Normally, JavaScript expressions inserted in JSX will evaluate to a string, a Re
 function Repeat(props) {
   let items = [];
   for (let i = 0; i < props.numTimes; i++) {
-    items.push(props.children(i));
+    items.push(props.children[i]);
   }
   return <div>{items}</div>;
 }


### PR DESCRIPTION
Line 391: 
    items.push(props.children(i)); // WRONG
     items.push(props.children[i]); // CORRECT

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
