### PR TITLE
Added closing tags for li and img

### DIFF
--- a/src/pages/learn/describing-the-ui.md
+++ b/src/pages/learn/describing-the-ui.md
@@ -133,11 +133,11 @@ export default function TodoList() {
       src="https://i.imgur.com/yXOvdOSs.jpg"
       alt="Hedy Lamarr"
       class="photo"
-    >
+    />
     <ul>
-      <li>Invent new traffic lights
-      <li>Rehearse a movie scene
-      <li>Improve spectrum technology
+      <li>Invent new traffic lights</li>
+      <li>Rehearse a movie scene</li>
+      <li>Improve spectrum technology</li>
     </ul>
   );
 }


### PR DESCRIPTION
Added missing closing tag for li in https://beta.reactjs.org/learn/writing-markup-with-jsx page


<img width="1032" alt="Screenshot 2021-10-28 at 11 37 14 AM" src="https://user-images.githubusercontent.com/32865581/139198678-add5d406-56e6-4bdc-8f67-086aa89fb17c.png">

Added closing tags for image and list item alone 😄 