### PR TITLE
[beta] fix(sandpack): do not translate code blocks

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -17,7 +17,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "^0.1.15",
+    "@codesandbox/sandpack-react": "^0.1.16",
     "@docsearch/react": "3.0.0-alpha.41",
     "@docsearch/css": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -588,18 +588,18 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
-"@codesandbox/sandpack-client@0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.1.15.tgz#baee9e78ebe01919d455d52e238622102b8e16b9"
-  integrity sha512-/qZX+AeiHrbxu+cEMmbHYpEsgy1MDV/pBaHs2V37bJFg11RJ6fTGiruHEMYi8ai4hszdeBskQoz5gc1TON1u+w==
+"@codesandbox/sandpack-client@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.1.16.tgz#047b3306a0fae66128ad79fd95c37ac6878869f5"
+  integrity sha512-r6ZbJV0b2MNGZ2+27k3IAs9dPQK95jqYkG+lGChSfuj/LhBozR4VUxJTZ7JJwTsqinROmeG/WmmpKeUuo3LJ2w==
   dependencies:
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@^0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.1.15.tgz#53b0fe76796c69608c9e7d5a2b2ad17284c17233"
-  integrity sha512-ru++Drt1LuDQv8NitKH9uCCsSzLgsAIyeaCVNCP9sl/J+SImpB1TEZnmi4z+t4LpI9E0a5w/BAEt1LgkASeA4Q==
+"@codesandbox/sandpack-react@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.1.16.tgz#b7291ccc33dd83670244d9cdacf671048d94e144"
+  integrity sha512-hVQGCvWLE4OWszUt3OOQ7k/SfRfpCv3hnp5RFn0r4P21z+9mPTJUKR/mVp7CKej2kqKLqPaVhLbsWti2lnUxBg==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.18.0"
@@ -615,7 +615,7 @@
     "@codemirror/matchbrackets" "^0.18.0"
     "@codemirror/state" "^0.18.0"
     "@codemirror/view" "^0.18.0"
-    "@codesandbox/sandpack-client" "0.1.15"
+    "@codesandbox/sandpack-client" "^0.1.16"
     codesandbox-import-util-types "^2.2.3"
     codesandbox-import-utils "^2.2.3"
 


### PR DESCRIPTION
Sandpack has introduced a new HTML attribute to avoid Google Translate translating the code editor and the preview layer, but still translating the action buttons. 

Solve #3977

![Screenshot 2021-11-03 at 11 34 17](https://user-images.githubusercontent.com/4838076/140053316-8642acd2-01c3-489c-ab47-fbe9289e77f8.png)
![Screenshot 2021-11-03 at 11 34 25](https://user-images.githubusercontent.com/4838076/140053321-558dae1e-ef74-4ae8-b269-4fd48b7eba09.png)

