### PR TITLE
Add linefeed in the mdx and handle it

### DIFF
--- a/beta/src/components/MDX/TerminalBlock.tsx
+++ b/beta/src/components/MDX/TerminalBlock.tsx
@@ -28,7 +28,8 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
   if (typeof children === 'string') {
     message = children;
   } else if (
-    React.isValidElement(children) 
+    React.isValidElement(children) &&
+    typeof children.props.children === 'string'
   ) {
     message = children.props.children;
   }
@@ -42,7 +43,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
           <IconTerminal className="inline-flex mr-2 self-center" /> Terminal
         </div>
       </div>
-      <div className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code">
+      <div className="px-8 pt-4 pb-6 text-primary-dark dark:text-primary-dark font-mono text-code whitespace-pre">
         <LevelText type={level} />
         {message}
       </div>

--- a/beta/src/components/MDX/TerminalBlock.tsx
+++ b/beta/src/components/MDX/TerminalBlock.tsx
@@ -28,8 +28,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
   if (typeof children === 'string') {
     message = children;
   } else if (
-    React.isValidElement(children) &&
-    typeof children.props.children === 'string'
+    React.isValidElement(children) 
   ) {
     message = children.props.children;
   }

--- a/beta/src/pages/learn/start-a-new-react-project.md
+++ b/beta/src/pages/learn/start-a-new-react-project.md
@@ -39,7 +39,7 @@ Now you can run your app with:
 
 <TerminalBlock>
 
-cd my-app
+cd my-app  
 npm start
 
 </TerminalBlock>

--- a/beta/src/pages/learn/start-a-new-react-project.md
+++ b/beta/src/pages/learn/start-a-new-react-project.md
@@ -39,7 +39,7 @@ Now you can run your app with:
 
 <TerminalBlock>
 
-cd my-app  
+cd my-app
 npm start
 
 </TerminalBlock>


### PR DESCRIPTION
Problem:
Multiple commands are displayed in the same line with line feed missing. 
page: https://beta.reactjs.org/learn/start-a-new-react-project
Solution: 
- Add preserve whitespace to classes
- ~~We can use 2 trailing empty spaces or `<br/>` to add new line feed~~
- ~~when we have multiple lines `typeof children.props.children` is not string but an object. So use children.props.children directly when it is a string or an object (`typeof children.props.children === 'string'` )~~


Before:
<img width="229" alt="Screenshot 2021-11-04 at 11 20 52 PM" src="https://user-images.githubusercontent.com/32865581/140392747-735156f9-f7ff-47a2-abd3-ab815681cca7.png">
After:
<img width="152" alt="Screenshot 2021-11-04 at 11 21 04 PM" src="https://user-images.githubusercontent.com/32865581/140392778-4a0fa451-b010-4975-9db8-3dcb041e9017.png">

