### PR TITLE
Hide navigation for one challenge and recipes

### DIFF
--- a/beta/src/components/MDX/Challenges/Challenges.tsx
+++ b/beta/src/components/MDX/Challenges/Challenges.tsx
@@ -119,12 +119,14 @@ export function Challenges({children, isRecipes}: ChallengesProps) {
             )}>
             {isRecipes ? 'Try out some recipes' : 'Try out some challenges'}
           </H2>
-          <Navigation
-            activeChallenge={activeChallenge}
-            challenges={challenges}
-            handleChange={handleChallengeChange}
-            isRecipes={isRecipes}
-          />
+          {challenges.length > 1 && (
+            <Navigation
+              activeChallenge={activeChallenge}
+              challenges={challenges}
+              handleChange={handleChallengeChange}
+              isRecipes={isRecipes}
+            />
+          )}
         </div>
         <div className="p-5 sm:py-8 sm:px-8">
           <div key={activeChallenge}>


### PR DESCRIPTION
When we have only one challenge we can hide the navigation button ? 

Page with one challenge: https://beta.reactjs.org/learn/importing-and-exporting-components

<img width="1055" alt="Screenshot 2021-11-05 at 2 09 04 PM" src="https://user-images.githubusercontent.com/32865581/140482290-96ed56c3-e07f-4bba-9613-fadaa7409b98.png">
