### PR TITLE
Enable streaming SSR

### DIFF
--- a/beta/next.config.js
+++ b/beta/next.config.js
@@ -10,8 +10,7 @@ module.exports = {
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx', 'md'],
   experimental: {
     plugins: true,
-    // TODO: this doesn't work because https://github.com/vercel/next.js/issues/30714
-    // concurrentFeatures: true,
+    concurrentFeatures: true,
     scrollRestoration: true,
   },
   async redirects() {

--- a/beta/package.json
+++ b/beta/package.json
@@ -34,11 +34,11 @@
     "debounce": "^1.2.1",
     "github-slugger": "^1.3.0",
     "hex2rgba": "^0.0.1",
-    "next": "^12.0.3-canary.2",
+    "next": "^12.0.3-canary.10",
     "parse-numeric-range": "^1.2.0",
-    "react": "18.0.0-alpha-930c9e7ee-20211015",
+    "react": "18.0.0-alpha-ee069065d-20211105",
     "react-collapsed": "3.1.0",
-    "react-dom": "18.0.0-alpha-930c9e7ee-20211015",
+    "react-dom": "18.0.0-alpha-ee069065d-20211105",
     "scroll-into-view-if-needed": "^2.2.25"
   },
   "devDependencies": {

--- a/beta/src/pages/_document.tsx
+++ b/beta/src/pages/_document.tsx
@@ -3,64 +3,60 @@
  */
 
 import * as React from 'react';
-import Document, {Html, Head, Main, NextScript} from 'next/document';
+import {Html, Head, Main, NextScript} from 'next/document';
 
-class MyDocument extends Document {
-  render() {
-    //  @todo specify language in HTML?
-    return (
-      <Html lang="en">
-        <Head />
-        <body className="font-sans antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-                (function () {
-                  function setTheme(newTheme) {
-                    window.__theme = newTheme;
-                    if (newTheme === 'dark') {
-                      document.documentElement.classList.add('dark');
-                    } else if (newTheme === 'light') {
-                      document.documentElement.classList.remove('dark');
-                    }
+export default function Document() {
+  //  @todo specify language in HTML?
+  return (
+    <Html lang="en">
+      <Head />
+      <body className="font-sans antialiased text-lg bg-wash dark:bg-wash-dark text-secondary dark:text-secondary-dark leading-base">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function () {
+                function setTheme(newTheme) {
+                  window.__theme = newTheme;
+                  if (newTheme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                  } else if (newTheme === 'light') {
+                    document.documentElement.classList.remove('dark');
                   }
+                }
 
-                  var preferredTheme;
+                var preferredTheme;
+                try {
+                  preferredTheme = localStorage.getItem('theme');
+                } catch (err) { }
+
+                window.__setPreferredTheme = function(newTheme) {
+                  preferredTheme = newTheme;
+                  setTheme(newTheme);
                   try {
-                    preferredTheme = localStorage.getItem('theme');
+                    localStorage.setItem('theme', newTheme);
                   } catch (err) { }
+                };
 
-                  window.__setPreferredTheme = function(newTheme) {
-                    preferredTheme = newTheme;
-                    setTheme(newTheme);
-                    try {
-                      localStorage.setItem('theme', newTheme);
-                    } catch (err) { }
-                  };
+                var initialTheme = preferredTheme;
+                var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-                  var initialTheme = preferredTheme;
-                  var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+                if (!initialTheme) {
+                  initialTheme = darkQuery.matches ? 'dark' : 'light';
+                }
+                setTheme(initialTheme);
 
-                  if (!initialTheme) {
-                    initialTheme = darkQuery.matches ? 'dark' : 'light';
+                darkQuery.addListener(function (e) {
+                  if (!preferredTheme) {
+                    setTheme(e.matches ? 'dark' : 'light');
                   }
-                  setTheme(initialTheme);
-
-                  darkQuery.addListener(function (e) {
-                    if (!preferredTheme) {
-                      setTheme(e.matches ? 'dark' : 'light');
-                    }
-                  });
-                })();
-              `,
-            }}
-          />
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
+                });
+              })();
+            `,
+          }}
+        />
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
 }
-
-export default MyDocument;

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -718,25 +718,25 @@
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
   integrity sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA==
 
-"@next/env@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.0.3-canary.5.tgz#33f628e24e745da25fe80a7fe849ebd65dfc41d2"
-  integrity sha512-6mR7IXUlKvb6/xVfKQyoK6O+S/E8nXB6QlUOVAETgiH3XWUEEk5rVbubzv+X4U77H37WiBuTKKePdRZf/DR8FA==
+"@next/env@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.0.3-canary.10.tgz#921d71794eea626443b04b0d4f83793fa2ebba3e"
+  integrity sha512-crVTRVYagub5TptTvfT+pSMqsqrJDYpuFe4h63LXvjgfFyDOs/cKlcLmys24OmnkFNCEix6m0ExLO5sAxqmyXw==
 
 "@next/plugin-google-analytics@^10.0.6":
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/@next/plugin-google-analytics/-/plugin-google-analytics-10.0.7.tgz#721a9e6c544033a0f35a758dffd17c17d3e730f7"
   integrity sha512-tv4Ljcfbu50esPPbG7tFAmb7GCKfFde3AtYi7HiYHijp50SaREfdBBg3vQ8DjBtRX8ZJp5ddxROKtt9JERi2/w==
 
-"@next/polyfill-module@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-12.0.3-canary.5.tgz#c597fefd76c8406abf708bb32965ada5ee3a8ee3"
-  integrity sha512-KtQUZpsRtF5mRn3F9ZzhBQPhDQ4CTa/cbcM+ZYtSMyCjtl/mImv82gzaqcYxBWICbPyKunBHT7hn5Xcc7z6sJA==
+"@next/polyfill-module@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-12.0.3-canary.10.tgz#01eb16506233a00ce679f99dbaf7d8898052e192"
+  integrity sha512-iFEIfsMelUriGlfAO2HzKuK1IExW/UQUo7/8i72O7PO2tBU6atBHWUxTbuaqtsB8TdO+tvcIpDR+ID3pq+YMiQ==
 
-"@next/react-dev-overlay@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-12.0.3-canary.5.tgz#8ec3da09b068030e0a45df56dea6a1544cb86d9b"
-  integrity sha512-2HQPCiRXDC8ND7u1rUaWOsqvQuSBA53ZnHJTuw9JkBZIP3/+imTrg+j+VqnDVxQvZtruu3H0beJvp3glo/ViEQ==
+"@next/react-dev-overlay@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-12.0.3-canary.10.tgz#1836ed6e27a10dd877d3cc483339a264baf51df1"
+  integrity sha512-x7bLVQRe6HUCGEeMIzIa/psNrwbnYf5W3L8aCeBZynz6zpJaM0QyVAFPXHissQd1Cp5PnR0e9gTxgiMYr/Vg3w==
   dependencies:
     "@babel/code-frame" "7.12.11"
     anser "1.4.9"
@@ -750,65 +750,65 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.1"
 
-"@next/react-refresh-utils@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-12.0.3-canary.5.tgz#8e1810391c4960a27775ed1bab220e1fd7384fd5"
-  integrity sha512-vw/FYNz0jwtmZVa49jQ8SgNrgp8wT+UHR6nzyXZdunL03mnt1A79uv9IQT/6JokcbvZfKXApB/4YGHRffy85zA==
+"@next/react-refresh-utils@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-12.0.3-canary.10.tgz#8ae982ccd1b913af831d9017923ea71c5f393b52"
+  integrity sha512-X4CMyiL+iX4/lSrUdBYSbF9TvxIgGsbCuoioHHQU9ZEAT3ECML86Em7v2z8qAlMBpUymLxykOHEA0cNtyVjrdw==
 
-"@next/swc-android-arm64@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.0.3-canary.5.tgz#30c73b4b969ea2d630374a37f187ee5467027b91"
-  integrity sha512-Z+oRW73j3UA2WU0UHdzzqGDWWEoIyOm6xkXgf4KyTAfcGdjENbi0d3oNOKuap4CL1KY0zsJx0xmfib7Q/pVvJg==
+"@next/swc-android-arm64@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.0.3-canary.10.tgz#f0983e1fdef6c5acbc027845a950cb21a9746b04"
+  integrity sha512-DL52/85Yv6dgwkYJF3bS/aJobfNNWEycFwq0o1EHNAgqY3wyxSKTxgXBhhTIcuwvD5+WXVmZXOyGOGx4aUsdiA==
 
-"@next/swc-darwin-arm64@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.3-canary.5.tgz#9ee56ba250e559d03e7d17080f5bda7b9ee8dec1"
-  integrity sha512-F2GobrRruAiK45gQB0c1untuu7MbBgjNocH3oxpX2ooWCDR5/+zLjwOmdewl8D75kg3anT2R06cnhU6ny2GlMg==
+"@next/swc-darwin-arm64@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.3-canary.10.tgz#fc8b62794bff98676cb67953ab38402a3d9d8415"
+  integrity sha512-FHuSFSpKFyaWWDmspFFwiP0ZOkRxQlukeSsz9NWuEDdodwMGkHPv5euONZyMrkgE7IUwx5Y08So3wNAYRcVXBg==
 
-"@next/swc-darwin-x64@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.3-canary.5.tgz#899f26f74d2a16083782020b5207bc37c2b22401"
-  integrity sha512-clb7CFRqtk4hSAYoABNKfLu0XzTT4kICMYIVT34semmZgxl0eeHVGJ3tfGQqL7qlEvl6drQuvmndqPzQLVdmWA==
+"@next/swc-darwin-x64@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.3-canary.10.tgz#fc014a0bf6ee49d7d9524186662ead3f4a478958"
+  integrity sha512-56pO8IjeXZNmtZ3bx9LPzgR9ImxEuZUWA7vZj/9/0/bpU9938gP/Pb3E7WtXUt38dmZX8jrd05Xa5XE8xOpMpQ==
 
-"@next/swc-linux-arm-gnueabihf@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.3-canary.5.tgz#6a8d93deba15965b64334ea966aab4e54441eaeb"
-  integrity sha512-xw475bvcLz6tOkMcjrCs4kSrYI9gRGejt2qTLofcy9V7Vv2gd1jfrB78ZRUomrA2p8WjvFUWi+t5MRUajRZj5w==
+"@next/swc-linux-arm-gnueabihf@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.3-canary.10.tgz#3056c1c37cae5be77b7d150524c6ba96355a7893"
+  integrity sha512-HgsPwlL4PoAcDxe/7jZyv8/lZABF6YFn55drwNPYnqLJjX7ZwMu5tWYgTLcZT1NQxcjNuJyQODwHho2spErYPw==
 
-"@next/swc-linux-arm64-gnu@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.3-canary.5.tgz#1ca696f5a542af18c5c97a42d164720f320b00f5"
-  integrity sha512-FFmRdFA/53jhtiUcg8secZ2DirITVKpqBKoWzIR3lLApdzvix978a4xXL1/+SBF2F+UUFRVv8iawcmQnn02nxw==
+"@next/swc-linux-arm64-gnu@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.3-canary.10.tgz#5d34536a99c50c639c1b1e838ec364c50dda0214"
+  integrity sha512-LkO2Te+kegkv6qQbxTBj7zQxx1OOBJlPjRi1rEF9Z2YuEZgeNtWp9ptHCD52MYtkk4LoipKqJwsx+NY1XRKbsQ==
 
-"@next/swc-linux-arm64-musl@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.3-canary.5.tgz#d4f07b4f53b38efa54a1ba478532a31b96f74abc"
-  integrity sha512-O7Qs+b21zPuqrIvE1GlSIZXWJOUMpZ9JCqtFHqqjPkVIigEGs+OMR6QOilVfKm/w0TwFaSxOtyyO9CpwjPf3pg==
+"@next/swc-linux-arm64-musl@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.3-canary.10.tgz#5b1ca3b11439d690950dcb2a736cbf0626fc251d"
+  integrity sha512-ca1oR1LQjRQTMJCbMtLjY3GfrRP1KDti4mpARONK1bb+8g8MGe1zuRaV8qwsJxIModshTWwIQOLwiplPFLOfdA==
 
-"@next/swc-linux-x64-gnu@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.3-canary.5.tgz#92f65ed28869fd504c689086d5f0e04e500fcb0c"
-  integrity sha512-ZyImKMivc7DMr1PjGbijMS+t+7R3VH2mSX4/axhG0u2VuFgC2Q50UyL3dBfgwGOUUDYIpt38wvU0XPHDWFaAvg==
+"@next/swc-linux-x64-gnu@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.3-canary.10.tgz#6404630e54d63b037c1c850287668978d8118a51"
+  integrity sha512-ahKHtlF6CEkx3/kRIf3qCcdytuLN7zQI9HSM6fVeUo+EB6ILykahJm9heX6Ht5TuIstJJgK58fohuPvixyZLEg==
 
-"@next/swc-linux-x64-musl@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.3-canary.5.tgz#cea3b3d3bfca35f5c777f589c09cc471bddcdc82"
-  integrity sha512-ymbH8W/UvAi80uYLx8Z+CruF8EhdymfIMjLaQT6T1QEIR0EhDbb5m0NGEO0v4G2+XGamgLZN3SbW6gUVIpkmCA==
+"@next/swc-linux-x64-musl@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.3-canary.10.tgz#a1b75f679a2198ab7e63e0978a9a8e20814d02c5"
+  integrity sha512-6GS66z5EWBywTwLFpOUtIJeqV1NRDIeqBFF1LEz9VdiSIfbVGXt6RLii5oYL3rQNkixl1nJ704EgDubCJ64tVQ==
 
-"@next/swc-win32-arm64-msvc@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.3-canary.5.tgz#55e63953de2b879aa1e592d9a1a48439fe914df6"
-  integrity sha512-EroOTr+VtssXBKyjdqkDhjhNr1kwfR6p7NuIdPWNwdnXydiWsXVs9j5DF3q6CCaVWV6jthGPRZc9C8Bi4Vuh6w==
+"@next/swc-win32-arm64-msvc@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.3-canary.10.tgz#9c725bf04aff1c9ed007dd53e113927a07766a53"
+  integrity sha512-BxoxcC62EW+j0d3QgvyC2TPvEoGSnlQleSstfP8NbtQkIQ2KcZkszGUG9ELrSaFxac0//T68S9E93MlhvNQ+KQ==
 
-"@next/swc-win32-ia32-msvc@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.3-canary.5.tgz#02bcc374897882811bf54a775551d3e4133cbdc2"
-  integrity sha512-HmJqwuyXOD3jRjfpBPx3I5uu8yyh0LYLQ8GMauHD3RWP74qawCkBKTJI4TTYhoefdNaImPspVStfOF30rgNxJA==
+"@next/swc-win32-ia32-msvc@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.3-canary.10.tgz#8330c19c0e236e1899438e01c9293ce43b1fd4be"
+  integrity sha512-Z++8Jv0+xByMS+F0SqFboS0hK5D37/en9Mhzt3Uaj6fWDMYDgm5ciitAcinbAz+ycjZZDTm0xr6Cz4hJjdHfyg==
 
-"@next/swc-win32-x64-msvc@12.0.3-canary.5":
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.3-canary.5.tgz#05afb7bb49af6d2192d7fb2b2ff608e78c0dabd4"
-  integrity sha512-Cf4xQzigoMBmTXMNQIYPOf6MM/Ai+5AzcR9+V4OLwft9Zl7Q4FOmReO1Sxp/oOTHi69Dj0wdOxuzgFZ/+SGRzA==
+"@next/swc-win32-x64-msvc@12.0.3-canary.10":
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.3-canary.10.tgz#58347ca146bbb224401f32cd082c591fd6ddb482"
+  integrity sha512-Td79lmkNLmbAIIATQO+eZYa6ajzj7UTrQy/BbgNEYWt+C2PT2UYCvGLhntc2NzZJt6c6wvvFCNHomf7yWhUb9g==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -4230,18 +4230,18 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-next@^12.0.3-canary.2:
-  version "12.0.3-canary.5"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.0.3-canary.5.tgz#9b58bd490ac347895125f42d398b3676e9c7ab87"
-  integrity sha512-IhDiZ/hMaddvh2etH9WA8jNNTojG62wG46XAD7qNBnjQ1/Kz4M9PthRCNcb30Az9RESLcGX0/VnUIvipngwbqg==
+next@^12.0.3-canary.10:
+  version "12.0.3-canary.10"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.0.3-canary.10.tgz#de7fa898efeaa186dc1a462f02eeb2dfb74a4937"
+  integrity sha512-VW2t/eQog2clY8wvQLk727b6Ebf9Y/tBxoQ7yD8ebqnnJ1v2Wp+pvzT602dIsJ1cSmM0tUV7s98ZeySiFuUDqA==
   dependencies:
     "@babel/runtime" "7.15.4"
     "@hapi/accept" "5.0.2"
     "@napi-rs/triples" "1.0.3"
-    "@next/env" "12.0.3-canary.5"
-    "@next/polyfill-module" "12.0.3-canary.5"
-    "@next/react-dev-overlay" "12.0.3-canary.5"
-    "@next/react-refresh-utils" "12.0.3-canary.5"
+    "@next/env" "12.0.3-canary.10"
+    "@next/polyfill-module" "12.0.3-canary.10"
+    "@next/react-dev-overlay" "12.0.3-canary.10"
+    "@next/react-refresh-utils" "12.0.3-canary.10"
     acorn "8.5.0"
     assert "2.0.0"
     browserify-zlib "0.2.0"
@@ -4285,17 +4285,17 @@ next@^12.0.3-canary.2:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
   optionalDependencies:
-    "@next/swc-android-arm64" "12.0.3-canary.5"
-    "@next/swc-darwin-arm64" "12.0.3-canary.5"
-    "@next/swc-darwin-x64" "12.0.3-canary.5"
-    "@next/swc-linux-arm-gnueabihf" "12.0.3-canary.5"
-    "@next/swc-linux-arm64-gnu" "12.0.3-canary.5"
-    "@next/swc-linux-arm64-musl" "12.0.3-canary.5"
-    "@next/swc-linux-x64-gnu" "12.0.3-canary.5"
-    "@next/swc-linux-x64-musl" "12.0.3-canary.5"
-    "@next/swc-win32-arm64-msvc" "12.0.3-canary.5"
-    "@next/swc-win32-ia32-msvc" "12.0.3-canary.5"
-    "@next/swc-win32-x64-msvc" "12.0.3-canary.5"
+    "@next/swc-android-arm64" "12.0.3-canary.10"
+    "@next/swc-darwin-arm64" "12.0.3-canary.10"
+    "@next/swc-darwin-x64" "12.0.3-canary.10"
+    "@next/swc-linux-arm-gnueabihf" "12.0.3-canary.10"
+    "@next/swc-linux-arm64-gnu" "12.0.3-canary.10"
+    "@next/swc-linux-arm64-musl" "12.0.3-canary.10"
+    "@next/swc-linux-x64-gnu" "12.0.3-canary.10"
+    "@next/swc-linux-x64-musl" "12.0.3-canary.10"
+    "@next/swc-win32-arm64-msvc" "12.0.3-canary.10"
+    "@next/swc-win32-ia32-msvc" "12.0.3-canary.10"
+    "@next/swc-win32-x64-msvc" "12.0.3-canary.10"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -5284,14 +5284,14 @@ react-collapsed@3.1.0:
     raf "^3.4.1"
     tiny-warning "^1.0.3"
 
-react-dom@18.0.0-alpha-930c9e7ee-20211015:
-  version "18.0.0-alpha-930c9e7ee-20211015"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-930c9e7ee-20211015.tgz#32648ee7ab0f00550bb74d501373911110619949"
-  integrity sha512-UN1DP4BkME7bEc25uSf7eRfnu5I3HkRY0ghZ6TN59+hk+NbZ5CB1z+Eis0psiLgFE0Dg+9UP+7OwyrCcVxushA==
+react-dom@18.0.0-alpha-ee069065d-20211105:
+  version "18.0.0-alpha-ee069065d-20211105"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-ee069065d-20211105.tgz#2cb872f85b919a7b2c1ae7f508359f15a61b3170"
+  integrity sha512-6bqmd7MM/RHWODaP5OEEqUtrXofzeBWHrlj8jzPFHFURtEXf5/IyIm7q6XHHB/pYSwhlWT9A24PGdvJAN0s33g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.21.0-alpha-930c9e7ee-20211015"
+    scheduler "0.21.0-alpha-ee069065d-20211105"
 
 react-is@17.0.2:
   version "17.0.2"
@@ -5308,10 +5308,10 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react@18.0.0-alpha-930c9e7ee-20211015:
-  version "18.0.0-alpha-930c9e7ee-20211015"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-alpha-930c9e7ee-20211015.tgz#20611ebd6fb54fcf982d5d70097ceb94aaae93ec"
-  integrity sha512-x8uF81YkpWtx8V8ynOd3mE4LNIaLyI5HmUVwjTHsxqd8nv/NE/e4k5GT+3S4sWxEPdLOoK7PPr47LZdB6FZmhA==
+react@18.0.0-alpha-ee069065d-20211105:
+  version "18.0.0-alpha-ee069065d-20211105"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-alpha-ee069065d-20211105.tgz#f95d14d20bc345f8ec6ac62e00e8a7f252461445"
+  integrity sha512-xc+k1bflCqK1gXuYsjCxT6fES8KLlsI/L82fqSUODvivu7IGoWkzmQpUbx9fhRqJlc0ljKRzJ3qjYZnIvGwVXg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -5690,10 +5690,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@0.21.0-alpha-930c9e7ee-20211015:
-  version "0.21.0-alpha-930c9e7ee-20211015"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-alpha-930c9e7ee-20211015.tgz#4e6a6c8cbe9f8c46e5628b8f9df53c7f45854e33"
-  integrity sha512-wnxCQ+pGMsuB1Y5zeUgLb5wZKICVlk2rMGo394Gg3a4AtEvPcoAlUdVe7JInzFa3FNW1gPU7qZADPGEfp2jEew==
+scheduler@0.21.0-alpha-ee069065d-20211105:
+  version "0.21.0-alpha-ee069065d-20211105"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-alpha-ee069065d-20211105.tgz#49967d972d1560e6b3011f1184cad1d55a0a2b6a"
+  integrity sha512-Zh8T6Hi2ekOG5rV5pk5cyCuqRYyJMLY/PCV7IgDeW7DzhnhxgEPgtyQH9NclRdvZPV5l18Gl/RNCs8Mw9Ob3Ew==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This should enable the new streaming renderer, which will let use Suspense for code splitting. (https://github.com/reactwg/react-18/discussions/37)

https://nextjs.org/blog/next-12#server-side-streaming

Note this also opts us into using the Edge Runtime. (It's confusing that it's coupled in Next.js but the options will likely be decoupled later.)

Let's give it a spin! Might be nice if we find some SSR bugs with this.