### PR TITLE
Show sidebar scroll bar only when necessary

### DIFF
--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -18,7 +18,7 @@ export function Page({routeTree, children}: PageProps) {
     <MenuProvider>
       <SidebarContext.Provider value={routeTree}>
         <div className="h-auto lg:h-screen flex flex-row">
-          <div className="h-auto lg:h-full overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
+          <div className="h-auto lg:h-full overflow-y-auto fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
             <Nav />
             <Sidebar />
           </div>


### PR DESCRIPTION
Currently, the sidebar scroll bar is always displayed, even when it is not needed (this applies to Windows/Linux)

![image](https://user-images.githubusercontent.com/4408379/140570455-3c503dfd-9fa4-42fe-b5e1-8589bb0c6c70.png)
