### PR TITLE
Remove invalid crossorigin attribute

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -93,7 +93,6 @@ export const Search: React.FC<SearchProps> = ({
         <link
           rel="preconnect"
           href={`https://${options.appId}-dsn.algolia.net`}
-          crossOrigin="true"
         />
       </Head>
 


### PR DESCRIPTION
"true" is not a valid value for [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin), and in general it might be omit for the Algolia tag.