### PR TITLE
Only show sidebar scrollbars when needed

### DIFF
--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -18,7 +18,7 @@ export function Page({routeTree, children}: PageProps) {
     <MenuProvider>
       <SidebarContext.Provider value={routeTree}>
         <div className="h-auto lg:h-screen flex flex-row">
-          <div className="h-auto lg:h-full overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
+          <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-0 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
             <Nav />
             <Sidebar />
           </div>

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -105,6 +105,55 @@
     from { opacity: 0.5; }
     to   { opacity: 1; }
   }
+
+  /*
+   * Hopefully when scrollbar-color lands everywhere,
+   * (and not just in FF), we'll be able to keep just this.
+   */
+  html .no-bg-scrollbar {
+    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+  }
+  html.dark .no-bg-scrollbar {
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+  }
+  /*
+   * Until then, we have ... this.
+   * If you're changing this, make sure you've tested:
+   * - Different browsers (Chrome, Safari, FF)
+   * - Dark and light modes
+   * - System scrollbar settings ("always on" vs "when scrolling")
+   * - Switching between modes should never jump width
+   * - When you interact with a sidebar, it should always be visible
+   * - For each combination, test overflowing and non-overflowing sidebar
+   * I've spent hours picking these so I expect no less diligence from you.
+   */
+  html .no-bg-scrollbar::-webkit-scrollbar,
+  html .no-bg-scrollbar::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  html .no-bg-scrollbar:hover::-webkit-scrollbar-thumb,
+  html .no-bg-scrollbar:focus::-webkit-scrollbar-thumb,
+  html .no-bg-scrollbar:focus-within::-webkit-scrollbar-thumb,
+  html .no-bg-scrollbar:active::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 3px solid transparent;
+    background-clip: content-box;
+    border-radius: 10px;
+  }
+  html .no-bg-scrollbar::-webkit-scrollbar-thumb:hover,
+  html .no-bg-scrollbar::-webkit-scrollbar-thumb:active {
+    background-color: rgba(0, 0, 0, 0.35) !important;
+  }
+  html.dark .no-bg-scrollbar:hover::-webkit-scrollbar-thumb,
+  html.dark .no-bg-scrollbar:focus::-webkit-scrollbar-thumb,
+  html.dark .no-bg-scrollbar:focus-within::-webkit-scrollbar-thumb,
+  html.dark .no-bg-scrollbar:active::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+  html.dark .no-bg-scrollbar::-webkit-scrollbar-thumb:hover,
+  html.dark .no-bg-scrollbar::-webkit-scrollbar-thumb:active {
+    background-color: rgba(255, 255, 255, 0.35) !important;
+  }
 }
 
 #_hj_feedback_container > div > button:not([aria-label="Close"]) {

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -136,7 +136,7 @@
   html .no-bg-scrollbar:focus-within::-webkit-scrollbar-thumb,
   html .no-bg-scrollbar:active::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.2);
-    border: 3px solid transparent;
+    border: 4px solid transparent;
     background-clip: content-box;
     border-radius: 10px;
   }


### PR DESCRIPTION
Alternative to https://github.com/reactjs/reactjs.org/pull/4049.

Basically, this will hide the sidebar scrollbar _background_ but the actual scrollbar will still show up when needed. This way, expanding/collapsing sections won't jump width (which is an issue in https://github.com/reactjs/reactjs.org/pull/4049). To make background transparent, we need to style them, which disables macOS "hide the thumb unless scrolling" thing. This is annoying but we can more or less approximate the native behavior by only showing the sidebar trumb when the container is hovered or has focus within.

Note that unlike https://github.com/reactjs/reactjs.org/pull/4049, this is supposed to also make them look decent when they _are_ shown (i.e. when the sidebar content doesn’t fit). Especially in dark mode where the default was too jarring. 

Haven't tested this on Windows. Would appreciate someone having a look.