### PR TITLE
Adjust code line numbers background

### DIFF
--- a/beta/src/components/MDX/Sandpack/Themes.tsx
+++ b/beta/src/components/MDX/Sandpack/Themes.tsx
@@ -10,7 +10,7 @@ export const CustomTheme = {
     defaultText: 'inherit',
     inactiveText: 'inherit',
     activeBackground: 'inherit',
-    defaultBackground: 'var(--sp-colors-bg-default)',
+    defaultBackground: 'inherit',
     inputBackground: 'inherit',
     accent: 'inherit',
     errorBackground: 'inherit',

--- a/beta/src/components/MDX/Sandpack/Themes.tsx
+++ b/beta/src/components/MDX/Sandpack/Themes.tsx
@@ -10,7 +10,7 @@ export const CustomTheme = {
     defaultText: 'inherit',
     inactiveText: 'inherit',
     activeBackground: 'inherit',
-    defaultBackground: 'inherit',
+    defaultBackground: 'var(--sp-colors-bg-default)',
     inputBackground: 'inherit',
     accent: 'inherit',
     errorBackground: 'inherit',

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -145,6 +145,7 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
   padding: 18px 0 !important;
 }
 .sp-cm.sp-pristine .cm-gutters {
+  background-color: var(--sp-colors-bg-default);
   z-index: 1;
 }
 .sp-layout {

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -144,6 +144,9 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
   overflow: auto !important;
   padding: 18px 0 !important;
 }
+.sp-cm.sp-pristine .cm-gutters {
+  z-index: 1;
+}
 .sp-layout {
   overflow: initial !important;
   border: 0px solid transparent !important;


### PR DESCRIPTION
Currently because of the code line numbers background is transparent, it is difficult to read the long code line. And generally it  looks not good. 

Example page - https://beta.reactjs.org/learn/managing-state#sharing-state-between-components

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/140612853-b06e941a-3bc9-473b-aef3-5e170cc4a2ff.png) | ![image](https://user-images.githubusercontent.com/4408379/140612870-44e5e4d1-8ad2-420a-9644-38be0e18e39a.png) |