### PR TITLE
Fix scroll to last scroll position after close modal search

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -42,7 +42,6 @@ const options = {
   appId: siteConfig.algolia.appId,
   apiKey: siteConfig.algolia.apiKey,
   indexName: siteConfig.algolia.indexName,
-  rednerModal: true,
 };
 let DocSearchModal: any = null;
 export const Search: React.FC<SearchProps> = ({
@@ -120,6 +119,7 @@ export const Search: React.FC<SearchProps> = ({
         createPortal(
           <DocSearchModal
             {...options}
+            initialScrollY={window.scrollY}
             searchParameters={searchParameters}
             onClose={onClose}
             navigator={{


### PR DESCRIPTION
Currently, after closing Algolia search modal, the current page scrolls to top, so it is necessary to preserve the last scroll position, for this there is an option `initialScrollY`.