### PR TITLE
Fixed typing mdxc components

### DIFF
--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -44,14 +44,14 @@ const UL = (p: JSX.IntrinsicElements['ul']) => (
   <ul className="ml-6 my-3 list-disc" {...p} />
 );
 
-const Divider = () => (
+const Divider = (): React.FC => (
   <hr className="my-6 block border-b border-border dark:border-border-dark" />
 );
 
-const Gotcha = ({children}: {children: React.ReactNode}) => (
+const Gotcha = ({children}: React.FC) => (
   <ExpandableCallout type="gotcha">{children}</ExpandableCallout>
 );
-const Note = ({children}: {children: React.ReactNode}) => (
+const Note = ({children}: React.FC) => (
   <ExpandableCallout type="note">{children}</ExpandableCallout>
 );
 
@@ -81,11 +81,10 @@ const Blockquote = ({
 function LearnMore({
   children,
   path,
-}: {
+}: React.FC<{
   title: string;
   path?: string;
-  children: any;
-}) {
+}>) {
   return (
     <>
       <section className="p-8 mt-16 mb-16 flex flex-row shadow-inner justify-between items-center bg-card dark:bg-card-dark rounded-lg">
@@ -94,7 +93,7 @@ function LearnMore({
             Ready to learn this topic?
           </h2>
           {children}
-          {path ? (
+          {path && (
             <ButtonLink
               className="mt-1"
               label="Read More"
@@ -103,7 +102,7 @@ function LearnMore({
               Read More
               <IconNavArrow displayDirection="right" className="inline ml-1" />
             </ButtonLink>
-          ) : null}
+          )}
         </div>
       </section>
       <hr className="border-border dark:border-border-dark mb-14" />
@@ -111,7 +110,7 @@ function LearnMore({
   );
 }
 
-function Math({children}: {children: any}) {
+function Math({children}: React.FC) {
   return (
     <span
       style={{
@@ -123,7 +122,7 @@ function Math({children}: {children: any}) {
   );
 }
 
-function MathI({children}: {children: any}) {
+function MathI({children}: React.FC) {
   return (
     <span
       style={{
@@ -135,7 +134,7 @@ function MathI({children}: {children: any}) {
   );
 }
 
-function YouWillLearn({children}: {children: any}) {
+function YouWillLearn({children}: React.FC) {
   return <SimpleCallout title="You will learn">{children}</SimpleCallout>;
 }
 
@@ -173,15 +172,14 @@ function Illustration({
   alt,
   author,
   authorLink,
-  children,
-}: {
+}: React.FC<{
   caption: string;
   src: string;
   alt: string;
   author: string;
   authorLink: string;
   children: any;
-}) {
+}>) {
   return (
     <div className="my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
       <figure className="my-8 flex justify-center">
@@ -197,32 +195,39 @@ function Illustration({
   );
 }
 
+interface ImageInfo {
+  title:string; 
+  caption: string; 
+  alt:string; 
+  src:string; 
+  height: string
+}
+
 function IllustrationBlock({
   title,
   sequential,
   author,
   authorLink,
   children,
-}: {
+}: React.FC<{
   title: string;
   author: string;
   authorLink: string;
   sequential: boolean;
-  children: any;
-}) {
-  const imageInfos = React.Children.toArray(children).map(
-    (child: any) => child.props
+}>) {
+  const imageInfos: ImageInfo[] = React.Children.toArray(children).map(
+    (child: React.ReactNode) => child.props
   );
-  const images = imageInfos.map((info, index) => (
+  const images = imageInfos.map(({src, alt, height, caption}, index: number) => (
     <figure key={index}>
       <div className="flex-1 flex p-0 xl:px-6 justify-center items-center my-4">
-        <img src={info.src} alt={info.alt} height={info.height} />
+        <img src={src} alt={alt} height={height} />
       </div>
-      {info.caption ? (
+      {caption && (
         <figcaption className="text-secondary dark:text-secondary-dark text-center leading-tight mt-4">
-          {info.caption}
+          {caption}
         </figcaption>
-      ) : null}
+      )}
     </figure>
   ));
   return (
@@ -241,7 +246,7 @@ function IllustrationBlock({
       ) : (
         <div className="mdx-illustration-block">{images}</div>
       )}
-      {author ? <AuthorCredit author={author} authorLink={authorLink} /> : null}
+      {author && <AuthorCredit author={author} authorLink={authorLink} />}
       <style jsx global>{`
         .mdx-illustration-block {
           display: flex;

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -26,32 +26,32 @@ import {Challenges, Hint, Solution} from './Challenges';
 import {IconNavArrow} from '../Icon/IconNavArrow';
 import ButtonLink from 'components/ButtonLink';
 
-const P = (p: JSX.IntrinsicElements['p']) => (
+const P: React.FC<{p: JSX.IntrinsicElements['p']}> = (p) => (
   <p className="whitespace-pre-wrap my-4" {...p} />
 );
 
-const Strong = (strong: JSX.IntrinsicElements['strong']) => (
+const Strong: React.FC<{strong: JSX.IntrinsicElements['strong']}> = (strong) => (
   <strong className="font-bold" {...strong} />
 );
 
-const OL = (p: JSX.IntrinsicElements['ol']) => (
-  <ol className="ml-6 my-3 list-decimal" {...p} />
+const OL: React.FC<{ol: JSX.IntrinsicElements['ol']}> = (ol) => (
+  <ol className="ml-6 my-3 list-decimal" {...ol} />
 );
-const LI = (p: JSX.IntrinsicElements['li']) => (
-  <li className="leading-relaxed mb-1" {...p} />
+const LI: React.FC<{li: JSX.IntrinsicElements['li']}> = (li) => (
+  <li className="leading-relaxed mb-1" {...li} />
 );
-const UL = (p: JSX.IntrinsicElements['ul']) => (
-  <ul className="ml-6 my-3 list-disc" {...p} />
+const UL: React.FC<{ul: JSX.IntrinsicElements['ul']}> = (ul) => (
+  <ul className="ml-6 my-3 list-disc" {...ul} />
 );
 
-const Divider = (): React.FC => (
+const Divider: React.FC = () => (
   <hr className="my-6 block border-b border-border dark:border-border-dark" />
 );
 
-const Gotcha = ({children}: React.FC) => (
+const Gotcha: React.FC = ({children}) => (
   <ExpandableCallout type="gotcha">{children}</ExpandableCallout>
 );
-const Note = ({children}: React.FC) => (
+const Note: React.FC = ({children}) => (
   <ExpandableCallout type="note">{children}</ExpandableCallout>
 );
 
@@ -78,13 +78,13 @@ const Blockquote = ({
   );
 };
 
-function LearnMore({
-  children,
-  path,
-}: React.FC<{
+const LearnMore: React.FC<{
   title: string;
   path?: string;
-}>) {
+}> = ({
+  children,
+  path,
+}) => {
   return (
     <>
       <section className="p-8 mt-16 mb-16 flex flex-row shadow-inner justify-between items-center bg-card dark:bg-card-dark rounded-lg">
@@ -110,7 +110,7 @@ function LearnMore({
   );
 }
 
-function Math({children}: React.FC) {
+const Math: React.FC = ({children}) => {
   return (
     <span
       style={{
@@ -122,7 +122,7 @@ function Math({children}: React.FC) {
   );
 }
 
-function MathI({children}: React.FC) {
+const MathI: React.FC = ({children}) => {
   return (
     <span
       style={{
@@ -134,7 +134,7 @@ function MathI({children}: React.FC) {
   );
 }
 
-function YouWillLearn({children}: React.FC) {
+const YouWillLearn: React.FC = ({children}) => {
   return <SimpleCallout title="You will learn">{children}</SimpleCallout>;
 }
 
@@ -166,20 +166,20 @@ function AuthorCredit({
   );
 }
 
-function Illustration({
-  caption,
-  src,
-  alt,
-  author,
-  authorLink,
-}: React.FC<{
+const Illustration: React.FC<{
   caption: string;
   src: string;
   alt: string;
   author: string;
   authorLink: string;
   children: any;
-}>) {
+}> = ({
+  caption,
+  src,
+  alt,
+  author,
+  authorLink,
+}) => {
   return (
     <div className="my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
       <figure className="my-8 flex justify-center">
@@ -203,20 +203,20 @@ interface ImageInfo {
   height: string
 }
 
-function IllustrationBlock({
+const IllustrationBlock: React.FC<{
+  title: string;
+  author: string;
+  authorLink: string;
+  sequential: boolean;
+}> = ({
   title,
   sequential,
   author,
   authorLink,
   children,
-}: React.FC<{
-  title: string;
-  author: string;
-  authorLink: string;
-  sequential: boolean;
-}>) {
+}) => {
   const imageInfos: ImageInfo[] = React.Children.toArray(children).map(
-    (child: React.ReactNode) => child.props
+    (child: any) => child.props
   );
   const images = imageInfos.map(({src, alt, height, caption}, index: number) => (
     <figure key={index}>
@@ -239,7 +239,7 @@ function IllustrationBlock({
       ) : null}
       {sequential ? (
         <ol className="mdx-illustration-block flex">
-          {images.map((x: any) => (
+          {images.map((x: React.ReactNode) => (
             <li className="flex-1">{x}</li>
           ))}
         </ol>

--- a/beta/src/components/MDX/SimpleCallout.tsx
+++ b/beta/src/components/MDX/SimpleCallout.tsx
@@ -10,7 +10,7 @@ interface SimpleCalloutProps {
   title: string;
   className?: string;
 }
-function SimpleCallout({title, children, className}: React.FC<SimpleCalloutProps>) {
+const SimpleCallout: React.FC<SimpleCalloutProps> = ({title, children, className}) => {
   return (
     <div
       className={cn(

--- a/beta/src/components/MDX/SimpleCallout.tsx
+++ b/beta/src/components/MDX/SimpleCallout.tsx
@@ -8,10 +8,9 @@ import {H3} from './Heading';
 
 interface SimpleCalloutProps {
   title: string;
-  children: React.ReactNode;
   className?: string;
 }
-function SimpleCallout({title, children, className}: SimpleCalloutProps) {
+function SimpleCallout({title, children, className}: React.FC<SimpleCalloutProps>) {
   return (
     <div
       className={cn(


### PR DESCRIPTION
This is my first time opening a pull request, so sorry if im doing something wrong.

I saw a type error in mdxc components, this error happens when you send children to copmponent like this:

```
<SimpleCallout title="You will learn">{children}</SimpleCallout>
```
And in the SimpleCallout component you distrcture the props {title, children} and specify their types.

When using the SimpleCallout it doesn't understand that this is a children prop and it says that you miss a a children prop.

We can get around this by defining the type of the component as React.FC which includes the type of the children inside and you don't have to specify the children type, and therefore you don't get that error.

Generally, its better to define every component with the type React.FC because it saves us defning some types that every functional component has like children or the returned type.

On the fly I added some types in that file, and refactored a small parts.