### PR TITLE
edit sandpack style overrides to also cover 'dirty' case

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -140,11 +140,11 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
   font-size: 16px !important;
   line-height: 24px !important;
 }
-.sp-cm.sp-pristine .cm-scroller {
+.sp-cm.sp-pristine .cm-scroller, .sp-cm.sp-dirty .cm-scroller {
   overflow: auto !important;
   padding: 18px 0 !important;
 }
-.sp-cm.sp-pristine .cm-gutters {
+.sp-cm.sp-pristine .cm-gutters, .sp-cm.sp-dirty .cm-gutters {
   background-color: var(--sp-colors-bg-default);
   z-index: 1;
 }


### PR DESCRIPTION
Piggybacking off of [https://github.com/reactjs/reactjs.org/pull/4055](https://github.com/reactjs/reactjs.org/pull/4055):

Example page - https://beta.reactjs.org/learn/managing-state#sharing-state-between-components

I noticed the bug fix in the above PR does not persist when you click on the file tab. Clicking the file tab applies a `.sp-dirty` class that reverts the line number gutter's background color back to transparent and resets the top and bottom padding within the editor space back to zero.

See the below screenshots for a better illustration:

`.sp-cm.sp-pristine .cm-scroller` `.sp-cm.sp-pristine .cm-gutters` (not having clicked on the file tab)
<img width="878" alt="Screen Shot 2021-11-06 at 4 40 05 PM" src="https://user-images.githubusercontent.com/32604062/140627089-7231f03c-b5f1-40b6-83ba-4cff63264312.png">

`.sp-cm.sp-dirty .cm-scroller` `.sp-cm.sp-dirty .cm-gutters` (having clicked on the file tab)
<img width="878" alt="Screen Shot 2021-11-06 at 4 40 46 PM" src="https://user-images.githubusercontent.com/32604062/140627161-81ea1507-a0d7-419e-b3bb-e18bf4b31ae2.png">

 