### PR TITLE
[Not for merge] Perf investigation

### DIFF
--- a/beta/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -38,11 +38,11 @@ export function SidebarLink({
 
   React.useEffect(() => {
     if (ref && ref.current && !!selected && !isMobile) {
-      scrollIntoView(ref.current, {
-        scrollMode: 'if-needed',
-        block: 'center',
-        inline: 'nearest',
-      });
+      // scrollIntoView(ref.current, {
+      //   scrollMode: 'if-needed',
+      //   block: 'center',
+      //   inline: 'nearest',
+      // });
     }
   }, [ref, selected, isMobile]);
 

--- a/beta/src/components/Layout/useTocHighlight.tsx
+++ b/beta/src/components/Layout/useTocHighlight.tsx
@@ -28,6 +28,7 @@ export function useTocHighlight() {
   const timeoutRef = React.useRef<number | null>(null);
 
   React.useEffect(() => {
+    return;
     function updateActiveLink() {
       const pageHeight = document.body.scrollHeight;
       const scrollPosition = window.scrollY + window.innerHeight;

--- a/beta/src/components/MDX/Challenges/Navigation.tsx
+++ b/beta/src/components/MDX/Challenges/Navigation.tsx
@@ -76,7 +76,7 @@ export function Navigation({
   }, [containerRef, challengesNavRef, scrollPos]);
 
   React.useEffect(() => {
-    handleResize();
+    //handleResize();
     window.addEventListener('resize', debounce(handleResize, 200));
     return () => {
       window.removeEventListener('resize', handleResize);

--- a/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
+++ b/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
@@ -38,6 +38,7 @@ const CodeBlock = React.forwardRef(
     },
     ref?: React.Ref<HTMLDivElement>
   ) => {
+    return <pre>lol</pre>
     const getDecoratedLineInfo = () => {
       if (!metastring) {
         return [];

--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -64,6 +64,7 @@ ul {
 `.trim();
 
 function Sandpack(props: SandpackProps) {
+  return <pre>lol</pre>
   let {children, setup, autorun = true} = props;
   let [resetKey, setResetKey] = React.useState(0);
   let codeSnippets = React.Children.toArray(children) as React.ReactElement[];


### PR DESCRIPTION
I spent a bit of time in DevTools to see why switching pages is so slow. Commented out the biggest offenders:

- Sandboxes mount synchronously on route load
  - This runs a bunch of CodeMirror calculations which seem to be slow
  - Not sure what our strategy should even be here, but there's clearly a lot that could be optimized
- Don't forget code blocks are also full-blown code viewers
  - This doesn't make sense to process at runtime. We should really do this AOT somehow. Though we should also see if there's something in particular making CodeMirror slow or creating issues here.
- The polyfill we're using for scrollIntoView for nav items does a bunch of DOM reads that cause style recalc
- We also do a bit of DOM reading for TOC, could probably cache something

There are also other things we can investigate later, like

- We can use memo in a few places
- Can we make Next.js route changes use startTransition?

This PR is just as a reference for future changes.