### PR TITLE
Fix alternative solution to add and remove a CSS class (#4027)

### DIFF
--- a/beta/src/pages/learn/reacting-to-input-with-state.md
+++ b/beta/src/pages/learn/reacting-to-input-with-state.md
@@ -633,7 +633,7 @@ export default function Picture() {
           className="picture picture--active"
           alt="Rainbow houses in Kampung Pelangi, Indonesia"
           src="https://i.imgur.com/5qwVYb1.jpeg"
-          onClick={(e) => e.stopPropagation()}
+          onClick={e => e.stopPropagation()}
         />
       </div>
     );

--- a/beta/src/pages/learn/reacting-to-input-with-state.md
+++ b/beta/src/pages/learn/reacting-to-input-with-state.md
@@ -633,6 +633,7 @@ export default function Picture() {
           className="picture picture--active"
           alt="Rainbow houses in Kampung Pelangi, Indonesia"
           src="https://i.imgur.com/5qwVYb1.jpeg"
+          onClick={(e) => e.stopPropagation()}
         />
       </div>
     );


### PR DESCRIPTION
Fix provided for #4027 

There is no lint(or prettier) rules for markdown, hope this style meet your convention!

@gaearon 