### PR TITLE
Update wrong sentence

### DIFF
--- a/beta/src/pages/learn/updating-arrays-in-state.md
+++ b/beta/src/pages/learn/updating-arrays-in-state.md
@@ -152,7 +152,7 @@ setArtists([
 ]);
 ```
 
-In this way, spread can do the job of both `push()` by adding to the beginning of an array and `unshift()` by adding to the end of an array. Try it in the sandbox above!
+In this way, spread can do the job of both `push()` by adding to the end of an array and `unshift()` by adding to the beginning of an array. Try it in the sandbox above!
 
 ### Removing from an array
 


### PR DESCRIPTION
Before:
In this way, spread can do the job of both `push()` by adding to the beginning of an array and `unshift()` by adding to the end of an array. Try it in the sandbox above!
After:
In this way, spread can do the job of both `push()` by adding to the end of an array and `unshift()` by adding to the beginning of an array. Try it in the sandbox above!

Page: https://beta.reactjs.org/learn/updating-arrays-in-state#adding-to-an-array