### PR TITLE
Enable dark mode in browser UI

### DIFF
--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -17,8 +17,14 @@
 
   /* Write your own custom base styles here */
   html {
+    color-scheme: light;
+    
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-tap-highlight-color: transparent;
+  }
+
+  html.dark {
+    color-scheme: dark;
   }
 
   html,

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -3,6 +3,8 @@
  */
 
 html .sp-wrapper {
+  color-scheme: inherit;
+  
   /* palette */
   --sp-colors-fg-active: #24292e !important;
   --sp-colors-fg-default: #959da5 !important;


### PR DESCRIPTION
We can change a browser's color scheme in according with used dark mode on website. For example, then scrollbars will use dark colors.


Before:

![image](https://user-images.githubusercontent.com/4408379/141370926-c8cf97cf-96d8-4913-98cb-0c97f76f7602.png)


After:

![image](https://user-images.githubusercontent.com/4408379/141370844-fb2aff1f-9f7b-45a8-9eed-85a0bc07138f.png)
