### PR TITLE
Set action key for search depending on OS

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -32,7 +32,7 @@ function Kbd(props: {children?: React.ReactNode}) {
   return (
     <kbd
       className="border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center  text-xs text-center rounded"
-      style={{width: '2.25em', height: '2.25em'}}
+      style={{minWidth: '2.25em', height: '2.25em'}}
       {...props}
     />
   );
@@ -51,6 +51,12 @@ export const Search: React.FC<SearchProps> = ({
 }) => {
   const [isLoaded] = React.useState(true);
   const [isShowing, setIsShowing] = React.useState(false);
+  const actionKey = React.useMemo<string | null>(() => {
+    if (typeof navigator !== 'undefined') {
+      return /(Mac|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl';
+    }
+    return null;
+  }, []);
 
   const importDocSearchModalIfNeeded = React.useCallback(
     function importDocSearchModalIfNeeded() {
@@ -108,10 +114,12 @@ export const Search: React.FC<SearchProps> = ({
         onClick={onOpen}>
         <IconSearch className="mr-3 align-middle text-gray-30 flex-shrink-0 group-betterhover:hover:text-gray-70" />
         Search
-        <span className="ml-auto hidden sm:flex item-center">
-          <Kbd>⌘</Kbd>
-          <Kbd>K</Kbd>
-        </span>
+        {actionKey && (
+          <span className="ml-auto hidden sm:flex item-center">
+            <Kbd>{actionKey}</Kbd>
+            <Kbd>K</Kbd>
+          </span>
+        )}
       </button>
 
       {isLoaded &&


### PR DESCRIPTION
Probably not everyone uses macOS, so they might be confused by the Command key instead of the Ctrl one in the search shortcut.

![image](https://user-images.githubusercontent.com/4408379/141373816-ba65f7b0-669f-43f6-8cb3-d15d76721819.png)


![image](https://user-images.githubusercontent.com/4408379/141373782-2ffdd7fc-1d4b-4c43-bbe9-d485ea155d66.png)
