### PR TITLE
Update algolia.css

### DIFF
--- a/beta/src/styles/algolia.css
+++ b/beta/src/styles/algolia.css
@@ -86,6 +86,7 @@ html.dark .DocSearch-Footer {
   @apply text-sm;
   @apply leading-tight;
   @apply text-primary;
+  @apply appearance-none !important;
 }
 html.dark .DocSearch-Input {
   @apply text-primary-dark;


### PR DESCRIPTION
Device: Iphone 12 mini 
Browser: Chrome
The search box is visible and is clearly off our design. 
It seems like the appearance-none by algolia css is getting overridden by tailwind's 
` [type='search'] {
    -webkit-appearance: textfield;
    outline-offset: -2px;
}  `

Before:
<p><img width="300px" src="https://user-images.githubusercontent.com/32865581/141430585-5f12f3dd-e764-4be9-90be-37560b365449.PNG" >

<img width="300px" src="https://user-images.githubusercontent.com/32865581/141430594-f70e4faf-b0ab-43d1-b1d6-a851a569edab.PNG" >
</p>
After:
<p>
<img width="300px" src="https://user-images.githubusercontent.com/32865581/141430600-c83e9a3b-df95-4e9f-a0fd-c9b55c182cde.PNG" >
<img width="300px" src="https://user-images.githubusercontent.com/32865581/141430607-e726832e-b6b9-4c7b-bea6-00cfb6d0c269.PNG" >
</p>
