### PR TITLE
[fix]: add-listner is deprecated, switched those to add-event-listner

### DIFF
--- a/beta/src/components/Layout/useMediaQuery.tsx
+++ b/beta/src/components/Layout/useMediaQuery.tsx
@@ -17,14 +17,14 @@ const useMediaQuery = (width: number) => {
 
   useEffect(() => {
     const media = window.matchMedia(`(max-width: ${width}px)`);
-    media.addListener(updateTarget);
+    media.addEventListener('change', updateTarget);
 
     // Check on mount (callback is not called until a change occurs)
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeListener(updateTarget);
+    return () => media.removeEventListener('change', updateTarget);
   }, [updateTarget, width]);
 
   return targetReached;

--- a/beta/src/pages/_document.tsx
+++ b/beta/src/pages/_document.tsx
@@ -46,7 +46,7 @@ class MyDocument extends Document {
                   }
                   setTheme(initialTheme);
 
-                  darkQuery.addListener(function (e) {
+                  darkQuery.addEventListener('change', function (e) {
                     if (!preferredTheme) {
                       setTheme(e.matches ? 'dark' : 'light');
                     }


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener `addListener` and `removeListener` are deprecated.

Switched them with `addEventListener` and `removeEventListener`.

Also i saw the whole app uses `addEventListener`  and `removeEventListener` so now it matches the standart.