### PR TITLE
Stop zooming for search input

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -200,5 +200,8 @@ html.dark .sp-loading {
     .cm-content {
       font-size: initial;
     }
+    .DocSearch-Input {
+      font-size: initial;
+    }
   } 
 }


### PR DESCRIPTION
Disable zoom while clicking on the search field.

We actually stopped sandpack from zooming. So we do the same thing for that search field too.

https://github.com/reactjs/reactjs.org/pull/4082
Before:

https://user-images.githubusercontent.com/32865581/141474243-945e406f-a858-499c-bdb8-d914b1d09e93.mov



