### PR TITLE
Beta Website Example: Clear interval before stopwatch is starting again

### DIFF
--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -137,6 +137,9 @@ export default function Stopwatch() {
   function handleStart() {
     setStartTime(Date.now());
     setNow(Date.now());
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
     intervalRef.current = setInterval(() => {
       setNow(Date.now());
     }, 10);


### PR DESCRIPTION
This PR is fixing a bug that is referenced here: #4096 
It makes sure the interval is cleared before setting the next interval; stop is only able to clear the current interval.