### PR TITLE
Use custom ID format that works better with MDX 2

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -35,6 +35,7 @@
     "react": "18.0.0-alpha-930c9e7ee-20211015",
     "react-collapsed": "3.1.0",
     "react-dom": "18.0.0-alpha-930c9e7ee-20211015",
+    "remark-slug": "^7.0.0",
     "scroll-into-view-if-needed": "^2.2.25"
   },
   "devDependencies": {

--- a/beta/package.json
+++ b/beta/package.json
@@ -35,7 +35,6 @@
     "react": "18.0.0-alpha-930c9e7ee-20211015",
     "react-collapsed": "3.1.0",
     "react-dom": "18.0.0-alpha-930c9e7ee-20211015",
-    "remark-slug": "^7.0.0",
     "scroll-into-view-if-needed": "^2.2.25"
   },
   "devDependencies": {
@@ -77,6 +76,7 @@
     "remark-external-links": "^7.0.0",
     "remark-html": "^12.0.0",
     "remark-images": "^2.0.0",
+    "remark-slug": "^7.0.0",
     "remark-unwrap-images": "^2.0.0",
     "retext": "^7.0.1",
     "retext-smartypants": "^4.0.0",

--- a/beta/scripts/generateHeadingIDs.js
+++ b/beta/scripts/generateHeadingIDs.js
@@ -39,7 +39,7 @@ function addHeaderID(line, slugger) {
     return line;
   }
 
-  const match = /^(#+\s+)(.+?)(\s*\{(?:\/\*|#)([a-z0-9\-_]+?)(?:\*\/)?\}\s*)?$/.exec(line);
+  const match = /^(#+\s+)(.+?)(\s*\{(?:\/\*|#)([^\}\*\/]+)(?:\*\/)?\}\s*)?$/.exec(line);
   const before = match[1] + match[2]
   const proc = modules.unified().use(modules.remarkParse).use(modules.remarkSlug)
   const tree = proc.runSync(proc.parse(before))

--- a/beta/scripts/generateHeadingIDs.js
+++ b/beta/scripts/generateHeadingIDs.js
@@ -2,8 +2,15 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
+// To do: Make this ESM.
+// To do: properly check heading numbers (headings with the same text get
+// numbered, this script doesn’t check that).
+
+const assert = require('assert');
 const fs = require('fs');
 const GithubSlugger = require('github-slugger');
+
+let modules
 
 function walk(dir) {
   let results = [];
@@ -31,15 +38,25 @@ function addHeaderID(line, slugger) {
   if (!line.startsWith('#')) {
     return line;
   }
-  // check if it already has an id
-  if (/\{#[^}]+\}/.test(line)) {
-    return line;
+
+  const match = /^(#+\s+)(.+?)(\s*\{(?:\/\*|#)([a-z0-9\-_]+?)(?:\*\/)?\}\s*)?$/.exec(line);
+  const before = match[1] + match[2]
+  const proc = modules.unified().use(modules.remarkParse).use(modules.remarkSlug)
+  const tree = proc.runSync(proc.parse(before))
+  const head = tree.children[0]
+  assert(head && head.type === 'heading', 'expected `' + before + '` to be a heading, is it using a normal space after `#`?')
+  const autoId = head.data.id
+  const existingId = match[4]
+  const id = existingId || autoId
+  // Ignore numbers:
+  const cleanExisting = existingId ? existingId.replace(/-\d+$/, '') : undefined
+  const cleanAuto = autoId.replace(/-\d+$/, '')
+
+  if (cleanExisting && cleanExisting !== cleanAuto) {
+    console.log('Note: heading `%s` has a different ID (`%s`) than what GH generates for it: `%s`:', before, existingId, autoId)
   }
-  const headingText = line.slice(line.indexOf(' ')).trim();
-  const headingLevel = line.slice(0, line.indexOf(' '));
-  return `${headingLevel} ${headingText} {#${slugger.slug(
-    stripLinks(headingText)
-  )}}`;
+
+  return match[1] + match[2] + ' {/*' + id + '*/}';
 }
 
 function addHeaderIDs(lines) {
@@ -66,14 +83,26 @@ function addHeaderIDs(lines) {
 
 const [path] = process.argv.slice(2);
 
-const files = walk(path);
-files.forEach((file) => {
-  if (!(file.endsWith('.md') || file.endsWith('.mdx'))) {
-    return;
-  }
+main()
 
-  const content = fs.readFileSync(file, 'utf8');
-  const lines = content.split('\n');
-  const updatedLines = addHeaderIDs(lines);
-  fs.writeFileSync(file, updatedLines.join('\n'));
-});
+async function main() {
+  const [unifiedMod, remarkParseMod, remarkSlugMod] = await Promise.all([import('unified'), import('remark-parse'), import('remark-slug')])
+  const unified = unifiedMod.default
+  const remarkParse = remarkParseMod.default
+  const remarkSlug = remarkSlugMod.default
+  modules = {unified, remarkParse, remarkSlug}
+
+  const files = walk(path);
+
+  files.forEach((file) => {
+    if (!(file.endsWith('.md') || file.endsWith('.mdx'))) {
+      return;
+    }
+
+    const content = fs.readFileSync(file, 'utf8');
+    const lines = content.split('\n');
+    const updatedLines = addHeaderIDs(lines);
+    fs.writeFileSync(file, updatedLines.join('\n'));
+  });
+
+}

--- a/beta/src/pages/blog/2013/06/05/why-react.md
+++ b/beta/src/pages/blog/2013/06/05/why-react.md
@@ -6,13 +6,13 @@ author: [petehunt]
 There are a lot of JavaScript MVC frameworks out there. Why did we build React
 and why would you want to use it?
 
-## React isn't an MVC framework. {#react-isnt-an-mvc-framework}
+## React isn't an MVC framework. {/*react-isnt-an-mvc-framework*/}
 
 React is a library for building composable user interfaces. It encourages
 the creation of reusable UI components which present data that changes over
 time.
 
-## React doesn't use templates. {#react-doesnt-use-templates}
+## React doesn't use templates. {/*react-doesnt-use-templates*/}
 
 Traditionally, web application UIs are built using templates or HTML directives.
 These templates dictate the full set of abstractions that you are allowed to use
@@ -33,7 +33,7 @@ to render views, which we see as an advantage over templates for a few reasons:
 We've also created [JSX](/docs/jsx-in-depth.html), an optional syntax
 extension, in case you prefer the readability of HTML to raw JavaScript.
 
-## Reactive updates are dead simple. {#reactive-updates-are-dead-simple}
+## Reactive updates are dead simple. {/*reactive-updates-are-dead-simple*/}
 
 React really shines when your data changes over time.
 
@@ -63,7 +63,7 @@ Because this re-render is so fast (around 1ms for TodoMVC), the developer
 doesn't need to explicitly specify data bindings. We've found this approach
 makes it easier to build apps.
 
-## HTML is just the beginning. {#html-is-just-the-beginning}
+## HTML is just the beginning. {/*html-is-just-the-beginning*/}
 
 Because React has its own lightweight representation of the document, we can do
 some pretty cool things with it:

--- a/beta/src/pages/blog/2013/06/12/community-roundup.md
+++ b/beta/src/pages/blog/2013/06/12/community-roundup.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 React was open sourced two weeks ago and it's time for a little round-up of what has been going on.
 
-## Khan Academy Question Editor {#khan-academy-question-editor}
+## Khan Academy Question Editor {/*khan-academy-question-editor*/}
 
 It looks like [Sophie Alpert](http://sophiebits.com/) is the first person outside of Facebook and Instagram to push React code to production. We are very grateful for her contributions in form of pull requests, bug reports and presence on IRC ([#reactjs on Freenode](irc://chat.freenode.net/reactjs)). Sophie wrote about her experience using React:
 
@@ -17,7 +17,7 @@ It looks like [Sophie Alpert](http://sophiebits.com/) is the first person outsid
 >
 > [Read the full post...](http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html)
 
-## Pimp my Backbone.View (by replacing it with React) {#pimp-my-backboneview-by-replacing-it-with-react}
+## Pimp my Backbone.View (by replacing it with React) {/*pimp-my-backboneview-by-replacing-it-with-react*/}
 
 [Paul Seiffert](https://blog.mayflower.de/) wrote a blog post that explains how to integrate React into Backbone applications.
 
@@ -29,7 +29,7 @@ It looks like [Sophie Alpert](http://sophiebits.com/) is the first person outsid
 >
 > [Read the full post...](https://blog.mayflower.de/3937-Backbone-React.html)
 
-## Using facebook's React with require.js {#using-facebooks-react-with-requirejs}
+## Using facebook's React with require.js {/*using-facebooks-react-with-requirejs*/}
 
 [Mario Mueller](http://blog.xenji.com/) wrote a menu component in React and was able to easily integrate it with require.js, EventEmitter2 and bower.
 
@@ -37,7 +37,7 @@ It looks like [Sophie Alpert](http://sophiebits.com/) is the first person outsid
 >
 > [Read the full post...](http://blog.xenji.com/2013/06/facebooks-react-require-js.html)
 
-## Origins of React {#origins-of-react}
+## Origins of React {/*origins-of-react*/}
 
 [Pete Hunt](http://www.petehunt.net/blog/) explained what differentiates React from other JavaScript libraries in [a previous blog post](/blog/2013/06/05/why-react.html). [Lee Byron](http://leebyron.com/) gives another perspective on Quora:
 

--- a/beta/src/pages/blog/2013/06/19/community-roundup-2.md
+++ b/beta/src/pages/blog/2013/06/19/community-roundup-2.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 Since the launch we have received a lot of feedback and are actively working on React 0.4. In the meantime, here are the highlights of this week.
 
-## Some quick thoughts on React {#some-quick-thoughts-on-react}
+## Some quick thoughts on React {/*some-quick-thoughts-on-react*/}
 
 [Andrew Greig](http://www.andrewgreig.com/) made a blog post that gives a high level description of what React is.
 
@@ -19,7 +19,7 @@ Since the launch we have received a lot of feedback and are actively working on 
 >
 > [Read the full post...](http://www.andrewgreig.com/637/)
 
-## React and Socket.IO Chat Application {#react-and-socketio-chat-application}
+## React and Socket.IO Chat Application {/*react-and-socketio-chat-application*/}
 
 [Danial Khosravi](https://danialk.github.io/) made a real-time chat application that interacts with the back-end using Socket.IO.
 
@@ -29,7 +29,7 @@ Since the launch we have received a lot of feedback and are actively working on 
 >
 > [Read the full post...](https://danialk.github.io/blog/2013/06/16/reactjs-and-socket-dot-io-chat-application/)
 
-## React and Other Frameworks {#react-and-other-frameworks}
+## React and Other Frameworks {/*react-and-other-frameworks*/}
 
 [Pete Hunt](http://www.petehunt.net/blog/) wrote an answer on Quora comparing React and Angular directives. At the end, he explains how you can make an Angular directive that is in fact being rendered with React.
 
@@ -41,7 +41,7 @@ Since the launch we have received a lot of feedback and are actively working on 
 
 In the same vein, [Markov Twain](https://twitter.com/markov_twain/status/345702941845499906) re-implemented the examples on the front-page [with Ember](http://jsbin.com/azihiw/2/edit) and [Vlad Yazhbin](https://twitter.com/vla) re-implemented the tutorial [with Angular](http://jsfiddle.net/vla/Cdrse/).
 
-## Web Components: React & x-tags {#web-components-react--x-tags}
+## Web Components: React & x-tags {/*web-components-react--x-tags*/}
 
 Mozilla and Google are actively working on Web Components. [Vjeux](http://blog.vjeux.com/) wrote a proof of concept that shows how to implement them using React.
 
@@ -51,7 +51,7 @@ Mozilla and Google are actively working on Web Components. [Vjeux](http://blog.v
 >
 > [Read the full post...](http://blog.vjeux.com/2013/javascript/custom-components-react-x-tags.html)
 
-## React TodoMVC Example {#react-todomvc-example}
+## React TodoMVC Example {/*react-todomvc-example*/}
 
 [TodoMVC.com](http://todomvc.com/) is a website that collects various implementations of the same basic Todo app. [Pete Hunt](http://www.petehunt.net/blog/) wrote an idiomatic React version.
 
@@ -63,7 +63,7 @@ Mozilla and Google are actively working on Web Components. [Vjeux](http://blog.v
 >
 > [Read the source code...](https://github.com/tastejs/todomvc/tree/gh-pages/labs/architecture-examples/react)
 
-## JSX is not HTML {#jsx-is-not-html}
+## JSX is not HTML {/*jsx-is-not-html*/}
 
 Many of you pointed out differences between JSX and HTML. In order to clear up some confusion, we have added some documentation that covers the four main differences:
 

--- a/beta/src/pages/blog/2013/06/21/react-v0-3-3.md
+++ b/beta/src/pages/blog/2013/06/21/react-v0-3-3.md
@@ -5,16 +5,16 @@ author: [zpao]
 
 We have a ton of great stuff coming in v0.4, but in the meantime we're releasing v0.3.3. This release addresses some small issues people were having and simplifies our tools to make them easier to use.
 
-## react-tools {#react-tools}
+## react-tools {/*react-tools*/}
 
 - Upgrade Commoner so `require` statements are no longer relativized when passing through the transformer. This was a feature needed when building React, but doesn't translate well for other consumers of `bin/jsx`.
 - Upgraded our dependencies on Commoner and Recast so they use a different directory for their cache.
 - Freeze our esprima dependency.
 
-## React {#react}
+## React {/*react*/}
 
 - Allow reusing the same DOM node to render different components. e.g. `React.renderComponent(<div/>, domNode); React.renderComponent(<span/>, domNode);` will work now.
 
-## JSXTransformer {#jsxtransformer}
+## JSXTransformer {/*jsxtransformer*/}
 
 - Improved the in-browser transformer so that transformed scripts will execute in the expected scope. The allows components to be defined and used from separate files.

--- a/beta/src/pages/blog/2013/06/27/community-roundup-3.md
+++ b/beta/src/pages/blog/2013/06/27/community-roundup-3.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 The highlight of this week is that an interaction-heavy app has been ported to React. React components are solving issues they had with nested views.
 
-## Moving From Backbone To React {#moving-from-backbone-to-react}
+## Moving From Backbone To React {/*moving-from-backbone-to-react*/}
 
 [Clay Allsopp](https://twitter.com/clayallsopp) successfully ported [Propeller](http://usepropeller.com/blog/posts/from-backbone-to-react/), a fairly big, interaction-heavy JavaScript app, to React.
 
@@ -17,7 +17,7 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 >
 > [Read the full post...](http://usepropeller.com/blog/posts/from-backbone-to-react/)
 
-## Grunt Task for JSX {#grunt-task-for-jsx}
+## Grunt Task for JSX {/*grunt-task-for-jsx*/}
 
 [Eric Clemmons](https://ericclemmons.github.io/) wrote a task for [Grunt](http://gruntjs.com/) that applies the JSX transformation to your JavaScript files. It also works with [Browserify](http://browserify.org/) if you want all your files to be concatenated and minified together.
 
@@ -45,7 +45,7 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 >
 > [Check out the project ...](https://github.com/ericclemmons/grunt-react)
 
-## Backbone/Handlebars Nested Views {#backbonehandlebars-nested-views}
+## Backbone/Handlebars Nested Views {/*backbonehandlebars-nested-views*/}
 
 [Joel Burget](http://joelburget.com/) wrote a blog post talking about the way we would write React-like components in Backbone and Handlebars.
 
@@ -57,13 +57,13 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 >
 > [Read the full post...](http://joelburget.com/react/)
 
-## JSRomandie Meetup {#jsromandie-meetup}
+## JSRomandie Meetup {/*jsromandie-meetup*/}
 
 [Renault John Lecoultre](https://twitter.com/renajohn/) from [BugBuster](http://www.bugbuster.com) did a React introduction talk at a JS meetup called [JS Romandie](https://twitter.com/jsromandie) last week.
 
 <script async class="speakerdeck-embed" data-id="888a9d50c01b01300df36658d0894ac1" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
 
-## CoffeeScript integration {#coffeescript-integration}
+## CoffeeScript integration {/*coffeescript-integration*/}
 
 [Vjeux](http://blog.vjeux.com/) used the fact that JSX is just a syntactic sugar on-top of regular JS to rewrite the React front-page examples in CoffeeScript.
 
@@ -81,7 +81,7 @@ The highlight of this week is that an interaction-heavy app has been ported to R
 >
 > [Read the full post...](http://blog.vjeux.com/2013/javascript/react-coffeescript.html)
 
-## Tutorial in Plain JavaScript {#tutorial-in-plain-javascript}
+## Tutorial in Plain JavaScript {/*tutorial-in-plain-javascript*/}
 
 We've seen a lot of people comparing React with various frameworks. [Ricardo Tomasi](http://ricardo.cc/) decided to re-implement the tutorial without any framework, just plain JavaScript.
 

--- a/beta/src/pages/blog/2013/07/02/react-v0-4-autobind-by-default.md
+++ b/beta/src/pages/blog/2013/07/02/react-v0-4-autobind-by-default.md
@@ -6,7 +6,7 @@ author: [zpao]
 React v0.4 is very close to completion. As we finish it off, we'd like to share with you some of the major changes we've made since v0.3. This is the first of several posts we'll be making over the next week.
 
 
-## What is React.autoBind? {#what-is-reactautobind}
+## What is React.autoBind? {/*what-is-reactautobind*/}
 
 If you take a look at most of our current examples, you'll see us using `React.autoBind` for event handlers. This is used in place of `Function.prototype.bind`. Remember that in JS, [function calls are late-bound](https://bonsaiden.github.io/JavaScript-Garden/#function.this). That means that if you simply pass a function around, the `this` used inside won't necessarily be the `this` you expect. `Function.prototype.bind` creates a new, properly bound, function so that when called, `this` is exactly what you expect it to be.
 
@@ -33,7 +33,7 @@ React.createClass({
 ```
 
 
-## What's Changing in v0.4? {#whats-changing-in-v04}
+## What's Changing in v0.4? {/*whats-changing-in-v04*/}
 
 After using `React.autoBind` for a few weeks, we realized that there were very few times that we didn't want that behavior. So we made it the default! Now all methods defined within `React.createClass` will already be bound to the correct instance.
 

--- a/beta/src/pages/blog/2013/07/03/community-roundup-4.md
+++ b/beta/src/pages/blog/2013/07/03/community-roundup-4.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 React reconciliation process appears to be very well suited to implement a text editor with a live preview as people at Khan Academy show us.
 
-## Khan Academy {#khan-academy}
+## Khan Academy {/*khan-academy*/}
 
 [Ben Kamens](http://bjk5.com/) explains how [Sophie Alpert](http://sophiebits.com/) and [Joel Burget](http://joelburget.com/) are promoting React inside of [Khan Academy](https://www.khanacademy.org/). They now have three projects in the works using React.
 
@@ -21,7 +21,7 @@ The best part is the demo of how React reconciliation process makes live editing
 
 [![](/images/blog/monkeys.gif)](http://bjk5.com/post/53742233351/getting-your-team-to-adopt-new-technology)
 
-## React Snippets {#react-snippets}
+## React Snippets {/*react-snippets*/}
 
 Over the past several weeks, members of our team, [Pete Hunt](http://www.petehunt.net/) and [Paul O'Shannessy](http://zpao.com/), answered many questions that were asked in the [React group](https://groups.google.com/forum/#!forum/reactjs). They give a good overview of how to integrate React with other libraries and APIs through the use of [Mixins](/docs/reusable-components.html) and [Lifecycle Methods](/docs/working-with-the-browser.html).
 
@@ -44,13 +44,13 @@ Over the past several weeks, members of our team, [Pete Hunt](http://www.petehun
 >
 > - [JSFiddle](http://jsfiddle.net/LQxy7/): Your React component simply render empty divs, and then in componentDidMount() you call React.renderComponent() on each of those divs to set up a new root React tree. Be sure to explicitly unmountAndReleaseReactRootNode() for each component in componentWillUnmount().
 
-## Introduction to React Screencast {#introduction-to-react-screencast}
+## Introduction to React Screencast {/*introduction-to-react-screencast*/}
 
 [Pete Hunt](http://www.petehunt.net/) recorded himself implementing a simple `<Blink>` tag in React.
 
 <figure><iframe src="https://player.vimeo.com/video/67248575" width="100%" height="340" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></figure>
 
-## Snake in React {#snake-in-react}
+## Snake in React {/*snake-in-react*/}
 
 [Tom Occhino](http://tomocchino.com/) implemented Snake in 150 lines with React.
 

--- a/beta/src/pages/blog/2013/07/11/react-v0-4-prop-validation-and-default-values.md
+++ b/beta/src/pages/blog/2013/07/11/react-v0-4-prop-validation-and-default-values.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 Many of the questions we got following the public launch of React revolved around `props`, specifically that people wanted to do validation and to make sure their components had sensible defaults.
 
-## Validation {#validation}
+## Validation {/*validation*/}
 
 Oftentimes you want to validate your `props` before you use them. Perhaps you want to ensure they are a specific type. Or maybe you want to restrict your prop to specific values. Or maybe you want to make a specific prop required. This was always possible — you could have written validations in your `render` or `componentWillReceiveProps` functions, but that gets clunky fast.
 
@@ -27,7 +27,7 @@ React.createClass({
 });
 ```
 
-## Default Values {#default-values}
+## Default Values {/*default-values*/}
 
 One common pattern we've seen with our React code is to do something like this:
 

--- a/beta/src/pages/blog/2013/07/17/react-v0-4-0.md
+++ b/beta/src/pages/blog/2013/07/17/react-v0-4-0.md
@@ -11,7 +11,7 @@ React v0.4 has some big changes. We've also restructured the documentation to be
 
 When you're ready, [go download it](/docs/installation.html)!
 
-### React {#react}
+### React {/*react*/}
 
 - Switch from using `id` attribute to `data-reactid` to track DOM nodes. This allows you to integrate with other JS and CSS libraries more easily.
 - Support for more DOM elements and attributes (e.g., `<canvas>`)
@@ -23,7 +23,7 @@ When you're ready, [go download it](/docs/installation.html)!
 - We've implemented an improved synthetic event system that conforms to the W3C spec.
 - Updates to your component are batched now, which may result in a significantly faster re-render of components. `this.setState` now takes an optional callback as its second parameter. If you were using `onClick={this.setState.bind(this, state)}` previously, you'll want to make sure you add a third parameter so that the event is not treated as the callback.
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
 - Support for comment nodes `<div>{/* this is a comment and won't be rendered */}</div>`
 - Children are now transformed directly into arguments instead of being wrapped in an array
@@ -31,7 +31,7 @@ When you're ready, [go download it](/docs/installation.html)!
   Previously this would be transformed into `React.DOM.div(null, [Component1(null), Component2(null)])`.
   If you were using React without JSX previously, your code should still work.
 
-### react-tools {#react-tools}
+### react-tools {/*react-tools*/}
 
 - Fixed a number of bugs when transforming directories
 - No longer re-write `require()`s to be relative unless specified

--- a/beta/src/pages/blog/2013/07/23/community-roundup-5.md
+++ b/beta/src/pages/blog/2013/07/23/community-roundup-5.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 We launched the [React Facebook Page](https://www.facebook.com/react) along with the React v0.4 launch. 700 people already liked it to get updated on the project :)
 
-## Cross-browser onChange {#cross-browser-onchange}
+## Cross-browser onChange {/*cross-browser-onchange*/}
 
 [Sophie Alpert](http://sophiebits.com/) from [Khan Academy](https://www.khanacademy.org/) worked on a cross-browser implementation of `onChange` event that landed in v0.4. She wrote a blog post explaining the various browser quirks she had to deal with.
 
@@ -15,7 +15,7 @@ We launched the [React Facebook Page](https://www.facebook.com/react) along with
 >
 > [Read the full post...](http://sophiebits.com/2013/06/18/a-near-perfect-oninput-shim-for-ie-8-and-9.html)
 
-## React Samples {#react-samples}
+## React Samples {/*react-samples*/}
 
 Learning a new library is always easier when you have working examples you can play with. [jwh](https://github.com/jhw) put many of them on his [react-samples GitHub repo](https://github.com/jhw/react-samples).
 
@@ -48,7 +48,7 @@ Learning a new library is always easier when you have working examples you can p
 >   [#4](https://rawgithub.com/jhw/react-samples/master/html/simpletabs4.html)
 > - Toggle [#1](https://rawgithub.com/jhw/react-samples/master/html/toggle.html)
 
-## React Chosen Wrapper {#react-chosen-wrapper}
+## React Chosen Wrapper {/*react-chosen-wrapper*/}
 
 [Cheng Lou](https://github.com/chenglou) wrote a wrapper for the [Chosen](https://harvesthq.github.io/chosen/) input library called [react-chosen](https://github.com/chenglou/react-chosen). It took just 25 lines to be able to use jQuery component as a React one.
 
@@ -62,19 +62,19 @@ React.renderComponent(
 );
 ```
 
-## JSX and ES6 Template Strings {#jsx-and-es6-template-strings}
+## JSX and ES6 Template Strings {/*jsx-and-es6-template-strings*/}
 
 [Domenic Denicola](http://domenicdenicola.com/) wrote a slide deck about the great applications of ES6 features and one slide shows how we could use Template Strings to compile JSX at run-time without the need for a pre-processing phase.
 
 <figure><iframe src="https://www.slideshare.net/slideshow/embed_code/24187146?rel=0&startSlide=36" width="100%" height={356} frameBorder={0} marginWidth={0} marginHeight={0} scrolling="no" style={{border: '1px solid #CCC', borderWidth: '1px 1px 0', marginBottom: 5}} allowFullScreen webkitallowfullscreen mozallowfullscreen> </iframe></figure>
 
-## React Presentation {#react-presentation}
+## React Presentation {/*react-presentation*/}
 
 [Tom Occhino](http://tomocchino.com/) and [Jordan Walke](https://github.com/jordwalke), React developers, did a presentation of React at Facebook Seattle's office. Check out the first 25 minutes for the presentation and the remaining 45 for a Q&A. I highly recommend you watching this video.
 
 <figure><iframe width={650} height={400} src="//www.youtube-nocookie.com/embed/XxVg_s8xAms" frameBorder={0} allowFullScreen /></figure>
 
-## Docs {#docs}
+## Docs {/*docs*/}
 
 [Pete Hunt](http://www.petehunt.net/) rewrote the entirety of the docs for v0.4. The goal was to add more explanation about why we built React and what the best practices are.
 

--- a/beta/src/pages/blog/2013/07/26/react-v0-4-1.md
+++ b/beta/src/pages/blog/2013/07/26/react-v0-4-1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 React v0.4.1 is a small update, mostly containing correctness fixes. Some code has been restructured internally but those changes do not impact any of our public APIs.
 
-## React {#react}
+## React {/*react*/}
 
 - `setState` callbacks are now executed in the scope of your component.
 - `click` events now work on Mobile Safari.
@@ -14,7 +14,7 @@ React v0.4.1 is a small update, mostly containing correctness fixes. Some code h
 - Improved support for `<iframe>` attributes.
 - Added checksums to detect and correct cases where server-side rendering markup mismatches what React expects client-side.
 
-## JSXTransformer {#jsxtransformer}
+## JSXTransformer {/*jsxtransformer*/}
 
 - Improved environment detection so it can be run in a non-browser environment.
 

--- a/beta/src/pages/blog/2013/07/30/use-react-and-jsx-in-ruby-on-rails.md
+++ b/beta/src/pages/blog/2013/07/30/use-react-and-jsx-in-ruby-on-rails.md
@@ -10,7 +10,7 @@ This gem has 2 primary purposes:
 1. To package `react.js` in a way that's easy to use and easy to update.
 2. To allow you to write JSX without an external build step to transform that into JS.
 
-## Packaging react.js {#packaging-reactjs}
+## Packaging react.js {/*packaging-reactjs*/}
 
 To make `react.js` available for use client-side, simply add `react` to your manifest, and declare the variant you'd like to use in your environment. When you use `:production`, the minified and optimized `react.min.js` will be used instead of the development version. For example:
 
@@ -29,7 +29,7 @@ end
 //= require react
 ```
 
-## Writing JSX {#writing-jsx}
+## Writing JSX {/*writing-jsx*/}
 
 When you name your file with `myfile.js.jsx`, `react-rails` will automatically try to transform that file. For the time being, we still require that you include the docblock at the beginning of the file. For example, this file will get transformed on request.
 
@@ -38,10 +38,10 @@ When you name your file with `myfile.js.jsx`, `react-rails` will automatically t
 React.renderComponent(<MyComponent />, document.getElementById('example'));
 ```
 
-## Asset Pipeline {#asset-pipeline}
+## Asset Pipeline {/*asset-pipeline*/}
 
 `react-rails` takes advantage of the [asset pipeline](http://guides.rubyonrails.org/asset_pipeline.html) that was introduced in Rails 3.1. A very important part of that pipeline is the `assets:precompile` Rake task. `react-rails` will ensure that your JSX files will be transformed into regular JS before all of your assets are minified and packaged.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 Installation follows the same process you're familiar with. You can install it globally with `gem install react-rails`, though we suggest you add the dependency to your `Gemfile` directly.

--- a/beta/src/pages/blog/2013/08/05/community-roundup-6.md
+++ b/beta/src/pages/blog/2013/08/05/community-roundup-6.md
@@ -5,13 +5,13 @@ author: [vjeux]
 
 This is the first Community Round-up where none of the items are from Facebook/Instagram employees. It's great to see the adoption of React growing.
 
-## React Game Tutorial {#react-game-tutorial}
+## React Game Tutorial {/*react-game-tutorial*/}
 
 [Caleb Cassel](https://twitter.com/CalebCassel) wrote a [step-by-step tutorial](https://rawgithub.com/calebcassel/react-demo/master/part1.html) about making a small game. It covers JSX, State and Events, Embedded Components and Integration with Backbone.
 
 <figure><a href="https://rawgithub.com/calebcassel/react-demo/master/part1.html"><img src="/images/blog/dog-tutorial.png"/></a></figure>
 
-## Reactify {#reactify}
+## Reactify {/*reactify*/}
 
 [Andrey Popp](http://andreypopp.com/) created a [Browserify](http://browserify.org/) helper to compile JSX files.
 
@@ -25,7 +25,7 @@ This is the first Community Round-up where none of the items are from Facebook/I
 >
 > [Check it out on GitHub...](https://github.com/andreypopp/reactify)
 
-## React Integration with Este {#react-integration-with-este}
+## React Integration with Este {/*react-integration-with-este*/}
 
 [Daniel Steigerwald](http://daniel.steigerwald.cz/) is now using React within [Este](https://github.com/steida/este), which is a development stack for web apps in CoffeeScript that are statically typed using the Closure Library.
 
@@ -49,7 +49,7 @@ este.demos.react.todoApp = este.react.create (`/** @lends {React.ReactComponent.
 
 [Check it out on GitHub...](https://github.com/steida/este-library/blob/master/este/demos/thirdparty/react/start.coffee)
 
-## React Stylus Boilerplate {#react-stylus-boilerplate}
+## React Stylus Boilerplate {/*react-stylus-boilerplate*/}
 
 [Zaim Bakar](https://zaim.github.io/) shared his boilerplate to get started with Stylus CSS processor.
 
@@ -63,7 +63,7 @@ este.demos.react.todoApp = este.react.create (`/** @lends {React.ReactComponent.
 >
 > [Check it out on GitHub...](https://github.com/zaim/react-stylus-boilerplate)
 
-## WebFUI {#webfui}
+## WebFUI {/*webfui*/}
 
 [Conrad Barski](http://lisperati.com/), author of the popular book [Land of Lisp](http://landoflisp.com/), wants to use React for his ClojureScript library called [WebFUI](https://github.com/drcode/webfui).
 

--- a/beta/src/pages/blog/2013/08/19/use-react-and-jsx-in-python-applications.md
+++ b/beta/src/pages/blog/2013/08/19/use-react-and-jsx-in-python-applications.md
@@ -5,7 +5,7 @@ author: [kmeht]
 
 Today we're happy to announce the initial release of [PyReact](https://github.com/facebook/react-python), which makes it easier to use React and JSX in your Python applications. It's designed to provide an API to transform your JSX files into JavaScript, as well as provide access to the latest React source files.
 
-## Usage {#usage}
+## Usage {/*usage*/}
 
 Transform your JSX files via the provided `jsx` module:
 
@@ -30,7 +30,7 @@ from react import source
 react_js = source.path_for('react.min.js')
 ```
 
-## Django {#django}
+## Django {/*django*/}
 
 PyReact includes a JSX compiler for [django-pipeline](https://github.com/cyberdelia/django-pipeline). Add it to your project's pipeline settings like this:
 
@@ -40,7 +40,7 @@ PIPELINE_COMPILERS = (
 )
 ```
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 PyReact is hosted on PyPI, and can be installed with `pip`:
 

--- a/beta/src/pages/blog/2013/08/26/community-roundup-7.md
+++ b/beta/src/pages/blog/2013/08/26/community-roundup-7.md
@@ -13,13 +13,13 @@ It's been three months since we open sourced React and it is going well. Some st
 - [15 blog posts](/blog/)
 - 2 early adopters: [Khan Academy](http://sophiebits.com/2013/06/09/using-react-to-speed-up-khan-academy.html) and [Propeller](http://usepropeller.com/blog/posts/from-backbone-to-react/)
 
-## Wolfenstein Rendering Engine Ported to React {#wolfenstein-rendering-engine-ported-to-react}
+## Wolfenstein Rendering Engine Ported to React {/*wolfenstein-rendering-engine-ported-to-react*/}
 
 [Pete Hunt](http://www.petehunt.net/) ported the render code of the web version of Wolfenstein 3D to React. Check out [the demo](http://www.petehunt.net/wolfenstein3D-react/wolf3d.html) and [render.js](https://github.com/petehunt/wolfenstein3D-react/blob/master/js/renderer.js#L183) file for the implementation.
 
 <figure><a href="http://www.petehunt.net/wolfenstein3D-react/wolf3d.html"><img src="/images/blog/wolfenstein_react.png"/></a></figure>
 
-## React & Meteor {#react--meteor}
+## React & Meteor {/*react--meteor*/}
 
 [Ben Newman](https://twitter.com/benjamn) made a [13-lines wrapper](https://github.com/benjamn/meteor-react/blob/master/lib/mixin.js) to use React and Meteor together. [Meteor](http://www.meteor.com/) handles the real-time data synchronization between client and server. React provides the declarative way to write the interface and only updates the parts of the UI that changed.
 
@@ -45,7 +45,7 @@ It's been three months since we open sourced React and it is going well. Some st
 >
 > [Read more ...](https://github.com/benjamn/meteor-react)
 
-## React Page {#react-page}
+## React Page {/*react-page*/}
 
 [Jordan Walke](https://github.com/jordwalke) implemented a complete React project creator called [react-page](https://github.com/facebook/react-page/). It supports both server-side and client-side rendering, source transform and packaging JSX files using CommonJS modules, and instant reload.
 

--- a/beta/src/pages/blog/2013/09/24/community-roundup-8.md
+++ b/beta/src/pages/blog/2013/09/24/community-roundup-8.md
@@ -9,7 +9,7 @@ First, we are organizing a [React Hackathon](http://reactjshack-a-thon.splashtha
 
 We've also reached a point where there are too many questions for us to handle directly. We're encouraging people to ask questions on [StackOverflow](http://stackoverflow.com/questions/tagged/reactjs) using the tag [[reactjs]](http://stackoverflow.com/questions/tagged/reactjs). Many members of the team and community have subscribed to the tag, so feel free to ask questions there. We think these will be more discoverable than Google Groups archives or IRC logs.
 
-## JavaScript Jabber {#javascript-jabber}
+## JavaScript Jabber {/*javascript-jabber*/}
 
 [Pete Hunt](http://www.petehunt.net/) and [Jordan Walke](https://github.com/jordwalke) were interviewed on [JavaScript Jabber](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/) for an hour. They go over many aspects of React such as 60 FPS, Data binding, Performance, Diffing Algorithm, DOM Manipulation, Node.js support, server-side rendering, JSX, requestAnimationFrame and the community. This is a gold mine of information about React.
 
@@ -23,13 +23,13 @@ We've also reached a point where there are too many questions for us to handle d
 >
 > [Read the full conversation ...](http://javascriptjabber.com/073-jsj-react-with-pete-hunt-and-jordan-walke/)
 
-## JSXTransformer Trick {#jsxtransformer-trick}
+## JSXTransformer Trick {/*jsxtransformer-trick*/}
 
 While this is not going to work for all the attributes since they are camelCased in React, this is a pretty cool trick.
 
 <div style={{marginLeft: 74}}><blockquote className="twitter-tweet"><p>Turn any DOM element into a React.js function: JSXTransformer.transform("/** <a href="https://twitter.com/jsx">@jsx</a> React.DOM */" + element.innerHTML).code</p>— Ross Allen (@ssorallen) <a href="https://twitter.com/ssorallen/statuses/377105575441489920">September 9, 2013</a></blockquote></div>
 
-## Remarkable React {#remarkable-react}
+## Remarkable React {/*remarkable-react*/}
 
 [Stoyan Stefanov](http://www.phpied.com/) gave a talk at [BrazilJS](http://braziljs.com.br/) about React and wrote an article with the content of the presentation. He goes through the difficulties of writing _active apps_ using the DOM API and shows how React handles it.
 
@@ -47,19 +47,19 @@ While this is not going to work for all the attributes since they are camelCased
 >
 > [Read More ...](http://www.phpied.com/remarkable-react/)
 
-## Markdown in React {#markdown-in-react}
+## Markdown in React {/*markdown-in-react*/}
 
 [Sophie Alpert](http://sophiebits.com/) converted [marked](https://github.com/chjj/marked), a Markdown JavaScript implementation, in React: [marked-react](https://github.com/sophiebits/marked-react). Even without using JSX, the HTML generation is now a lot cleaner. It is also safer as forgetting a call to `escape` will not introduce an XSS vulnerability.
 
 <figure><a href="https://github.com/sophiebits/marked-react/commit/cb70c9df6542c7c34ede9efe16f9b6580692a457"><img src="/images/blog/markdown_refactor.png"/></a></figure>
 
-## Unite from BugBusters {#unite-from-bugbusters}
+## Unite from BugBusters {/*unite-from-bugbusters*/}
 
 [Renault John Lecoultre](https://twitter.com/renajohn) wrote [Unite](https://www.bugbuster.com/), an interactive tool for analyzing code dynamically using React. It integrates with CodeMirror.
 
 <figure><a href="https://unite.bugbuster.com/"><img src="/images/blog/unite.png"/></a></figure>
 
-## #reactjs IRC Logs {#reactjs-irc-logs}
+## #reactjs IRC Logs {/*reactjs-irc-logs*/}
 
 [Vjeux](http://blog.vjeux.com/) re-implemented the display part of the IRC logger in React. Just 130 lines are needed for a performant infinite scroll with timestamps and color-coded author names.
 

--- a/beta/src/pages/blog/2013/10/03/community-roundup-9.md
+++ b/beta/src/pages/blog/2013/10/03/community-roundup-9.md
@@ -7,7 +7,7 @@ We organized a React hackathon last week-end in the Facebook Seattle office. 50 
 
 ![](/images/blog/react-hackathon.jpg)
 
-## React Hackathon Winner {#react-hackathon-winner}
+## React Hackathon Winner {/*react-hackathon-winner*/}
 
 [Alex Swan](http://bold-it.com/) implemented [Qu.izti.me](http://qu.izti.me/), a multi-player quiz game. It is real-time via Web Socket and mobile friendly.
 
@@ -19,7 +19,7 @@ We organized a React hackathon last week-end in the Facebook Seattle office. 50 
 >
 > [Read More...](http://bold-it.com/javascript/facebook-react-example/)
 
-## JSConf EU Talk: Rethinking Best Practices {#jsconf-eu-talk-rethinking-best-practices}
+## JSConf EU Talk: Rethinking Best Practices {/*jsconf-eu-talk-rethinking-best-practices*/}
 
 [Pete Hunt](http://www.petehunt.net/) presented React at JSConf EU. He covers three controversial design decisions of React:
 
@@ -31,7 +31,7 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 
 <figure><iframe src="https://www.slideshare.net/slideshow/embed_code/26589373" width="100%" height="450" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen></iframe></figure>
 
-## Pump - Clojure bindings for React {#pump---clojure-bindings-for-react}
+## Pump - Clojure bindings for React {/*pump---clojure-bindings-for-react*/}
 
 [Alexander Solovyov](http://solovyov.net/) has been working on React bindings for ClojureScript. This is really exciting as it is using "native" ClojureScript data structures.
 
@@ -50,7 +50,7 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 
 [Check it out on GitHub...](https://github.com/piranha/pump)
 
-## JSXHint {#jsxhint}
+## JSXHint {/*jsxhint*/}
 
 [Todd Kennedy](http://blog.selfassembled.org/) working at [Cond&eacute; Nast](http://www.condenast.com/) implemented a wrapper on-top of [JSHint](http://www.jshint.com/) that first converts JSX files to JS.
 
@@ -62,7 +62,7 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 >
 > [Check it out on GitHub...](https://github.com/CondeNast/JSXHint)
 
-## Turbo React {#turbo-react}
+## Turbo React {/*turbo-react*/}
 
 [Ross Allen](https://twitter.com/ssorallen) working at [Mesosphere](http://mesosphere.io/) combined [Turbolinks](https://github.com/rails/turbolinks/), a library used by Ruby on Rails to speed up page transition, and React.
 
@@ -76,7 +76,7 @@ The video will be available soon on the [JSConf EU website](http://2013.jsconf.e
 >
 > [Check out the demo...](https://turbo-react.herokuapp.com/)
 
-## Reactive Table {#reactive-table}
+## Reactive Table {/*reactive-table*/}
 
 [Stoyan Stefanov](http://www.phpied.com/) continues his series of blog posts about React. This one is an introduction tutorial on rendering a simple table with React.
 

--- a/beta/src/pages/blog/2013/10/16/react-v0.5.0.md
+++ b/beta/src/pages/blog/2013/10/16/react-v0.5.0.md
@@ -9,15 +9,15 @@ The biggest change you'll notice as a developer is that we no longer support `cl
 
 The other major change in v0.5 is that we've added an additional build - `react-with-addons` - which adds support for some extras that we've been working on including animations and two-way binding. [Read more about these addons in the docs](/docs/addons.html).
 
-## Thanks to Our Community {#thanks-to-our-community}
+## Thanks to Our Community {/*thanks-to-our-community*/}
 
 We added _22 new people_ to the list of authors since we launched React v0.4.1 nearly 3 months ago. With a total of 48 names in our `AUTHORS` file, that means we've nearly doubled the number of contributors in that time period. We've seen the number of people contributing to discussion on IRC, mailing lists, Stack Overflow, and GitHub continue rising. We've also had people tell us about talks they've given in their local community about React.
 
 It's been awesome to see the things that people are building with React, and we can't wait to see what you come up with next!
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Memory usage improvements - reduced allocations in core which will help with GC pauses
 - Performance improvements - in addition to speeding things up, we made some tweaks to stay out of slow path code in V8 and Nitro.
@@ -38,11 +38,11 @@ It's been awesome to see the things that people are building with React, and we 
 - Better support for server-side rendering - [react-page](https://github.com/facebook/react-page) has helped improve the stability for server-side rendering.
 - Made it possible to use React in environments enforcing a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Security/CSP/Introducing_Content_Security_Policy). This also makes it possible to use React to build Chrome extensions.
 
-### React with Addons (New!) {#react-with-addons-new}
+### React with Addons (New!) {/*react-with-addons-new*/}
 
 - Introduced a separate build with several "addons" which we think can help improve the React experience. We plan to deprecate this in the long-term, instead shipping each as standalone pieces. [Read more in the docs](/docs/addons.html).
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
 - No longer transform `class` to `className` as part of the transform! This is a breaking change - if you were using `class`, you _must_ change this to `className` or your components will be visually broken.
 - Added warnings to the in-browser transformer to make it clear it is not intended for production use.

--- a/beta/src/pages/blog/2013/10/29/react-v0-5-1.md
+++ b/beta/src/pages/blog/2013/10/29/react-v0-5-1.md
@@ -5,16 +5,16 @@ author: [zpao]
 
 This release focuses on fixing some small bugs that have been uncovered over the past two weeks. I would like to thank everybody involved, specifically members of the community who fixed half of the issues found. Thanks to [Sophie Alpert][1], [Andrey Popp][2], and [Laurence Rowe][3] for their contributions!
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Fixed bug with `<input type="range">` and selection events.
 - Fixed bug with selection and focus.
 - Made it possible to unmount components from the document root.
 - Fixed bug for `disabled` attribute handling on non-`<input>` elements.
 
-### React with Addons {#react-with-addons}
+### React with Addons {/*react-with-addons*/}
 
 - Fixed bug with transition and animation event detection.
 

--- a/beta/src/pages/blog/2013/11/06/community-roundup-10.md
+++ b/beta/src/pages/blog/2013/11/06/community-roundup-10.md
@@ -7,7 +7,7 @@ This is the 10th round-up already and React has come quite far since it was open
 
 The best part is that no drastic changes have been required to support all those use cases. Most of the efforts were targeted at polishing edge cases, performance improvements, and documentation.
 
-## Khan Academy - Officially moving to React {#khan-academy---officially-moving-to-react}
+## Khan Academy - Officially moving to React {/*khan-academy---officially-moving-to-react*/}
 
 [Joel Burget](http://joelburget.com/) announced at Hack Reactor that new front-end code at Khan Academy should be written in React!
 
@@ -21,13 +21,13 @@ The best part is that no drastic changes have been required to support all those
 >
 > [Read the full article](http://joelburget.com/backbone-to-react/)
 
-## React: Rethinking best practices {#react-rethinking-best-practices}
+## React: Rethinking best practices {/*react-rethinking-best-practices*/}
 
 [Pete Hunt](http://www.petehunt.net/)'s talk at JSConf EU 2013 is now available in video.
 
 <figure><iframe width="650" height="370" src="//www.youtube-nocookie.com/embed/x7cQ3mrcKaY" frameborder="0" allowfullscreen></iframe></figure>
 
-## Server-side React with PHP {#server-side-react-with-php}
+## Server-side React with PHP {/*server-side-react-with-php*/}
 
 [Stoyan Stefanov](http://www.phpied.com/)'s series of articles on React has two new entries on how to execute React on the server to generate the initial page load.
 
@@ -48,7 +48,7 @@ The best part is that no drastic changes have been required to support all those
 >
 > <figure><a href="http://www.phpied.com/server-side-react-with-php-part-2/"><img src="/images/blog/react-php.png"/></a></figure>
 
-## TodoMVC Benchmarks {#todomvc-benchmarks}
+## TodoMVC Benchmarks {/*todomvc-benchmarks*/}
 
 Webkit has a [TodoMVC Benchmark](https://github.com/WebKit/webkit/tree/master/PerformanceTests/DoYouEvenBench) that compares different frameworks. They recently included React and here are the results (average of 10 runs in Chrome 30):
 
@@ -87,13 +87,13 @@ By default, React "re-renders" all the components when anything changes. This is
 
 The fact that you can control when components are rendered is a very important characteristic of React as it gives you control over its performance. We are going to talk more about performance in the future, stay tuned.
 
-## Guess the filter {#guess-the-filter}
+## Guess the filter {/*guess-the-filter*/}
 
 [Connor McSheffrey](http://conr.me) implemented a small game using React. The goal is to guess which filter has been used to create the Instagram photo.
 
 <figure><a href="http://guessthefilter.com/"><img src="/images/blog/guess_filter.jpg"/></a></figure>
 
-## React vs FruitMachine {#react-vs-fruitmachine}
+## React vs FruitMachine {/*react-vs-fruitmachine*/}
 
 [Andrew Betts](http://trib.tv/), director of the [Financial Times Labs](http://labs.ft.com/), posted an article comparing [FruitMachine](https://github.com/ftlabs/fruitmachine) and React.
 
@@ -103,7 +103,7 @@ The fact that you can control when components are rendered is a very important c
 
 Even though we weren't inspired by FruitMachine (React has been used in production since before FruitMachine was open sourced), it's great to see similar technologies emerging and becoming popular.
 
-## React Brunch {#react-brunch}
+## React Brunch {/*react-brunch*/}
 
 [Matthew McCray](http://elucidata.net/) implemented [react-brunch](https://npmjs.org/package/react-brunch), a JSX compilation step for [Brunch](http://brunch.io/).
 
@@ -115,7 +115,7 @@ Even though we weren't inspired by FruitMachine (React has been used in producti
 >
 > [Read more...](https://npmjs.org/package/react-brunch)
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 I'm going to start adding a tweet at the end of each round-up. We'll start with this one:
 

--- a/beta/src/pages/blog/2013/11/18/community-roundup-11.md
+++ b/beta/src/pages/blog/2013/11/18/community-roundup-11.md
@@ -5,13 +5,13 @@ author: [vjeux]
 
 This round-up is the proof that React has taken off from its Facebook's root: it features three in-depth presentations of React done by external people. This is awesome, keep them coming!
 
-## Super VanJS 2013 Talk {#super-vanjs-2013-talk}
+## Super VanJS 2013 Talk {/*super-vanjs-2013-talk*/}
 
 [Steve Luscher](https://github.com/steveluscher) working at [LeanPub](https://leanpub.com/) made a 30 min talk at [Super VanJS](https://twitter.com/vanjs). He does a remarkable job at explaining why React is so fast with very exciting demos using the HTML5 Audio API.
 
 <figure><iframe width="650" height="338" src="//www.youtube-nocookie.com/embed/1OeXsL5mr4g" frameborder="0" allowfullscreen></iframe></figure>
 
-## React Tips {#react-tips}
+## React Tips {/*react-tips*/}
 
 [Connor McSheffrey](http://connormcsheffrey.com/) and [Cheng Lou](https://github.com/chenglou) added a new section to the documentation. It's a list of small tips that you will probably find useful while working on React. Since each article is very small and focused, we [encourage you to contribute](/tips/introduction.html)!
 
@@ -28,7 +28,7 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 - [Load Initial Data via AJAX](/tips/initial-ajax.html)
 - [False in JSX](/tips/false-in-jsx.html)
 
-## Intro to the React Framework {#intro-to-the-react-framework}
+## Intro to the React Framework {/*intro-to-the-react-framework*/}
 
 [Pavan Podila](http://blog.pixelingene.com/) wrote an in-depth introduction to React on TutsPlus. This is definitively worth reading.
 
@@ -38,20 +38,20 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 >
 > [Read the full article ...](http://dev.tutsplus.com/tutorials/intro-to-the-react-framework--net-35660)
 
-## 140-characters textarea {#140-characters-textarea}
+## 140-characters textarea {/*140-characters-textarea*/}
 
 [Brian Kim](https://github.com/brainkim) wrote a small textarea component that gradually turns red as you reach the 140-characters limit. Because he only changes the background color, React is smart enough not to mess with the text selection.
 
 <p data-height="178" data-theme-id="0" data-slug-hash="FECGb" data-user="brainkim" data-default-tab="result" class='codepen'>See the Pen <a href='http://codepen.io/brainkim/pen/FECGb'>FECGb</a> by Brian Kim (<a href='http://codepen.io/brainkim'>@brainkim</a>) on <a href='http://codepen.io'>CodePen</a></p>
 <script async src="//codepen.io/assets/embed/ei.js"></script>
 
-## Genesis Skeleton {#genesis-skeleton}
+## Genesis Skeleton {/*genesis-skeleton*/}
 
 [Eric Clemmons](https://ericclemmons.github.io/) is working on a "Modern, opinionated, full-stack starter kit for rapid, streamlined application development". The version 0.4.0 has just been released and has first-class support for React.
 
 <figure><a href="http://genesis-skeleton.com/"><img src="/images/blog/genesis_skeleton.png"/></a>a></figure>
 
-## AgFlow Talk {#agflow-talk}
+## AgFlow Talk {/*agflow-talk*/}
 
 [Robert Zaremba](http://rz.scale-it.pl/) working on [AgFlow](http://www.agflow.com/) recently talked in Poland about React.
 
@@ -63,7 +63,7 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 
 <figure><iframe src="https://docs.google.com/presentation/d/1JSFbjCuuexwOHCeHWBMNRIJdyfD2Z0ZQwX65WOWkfaI/embed?start=false" frameborder="0" width="100%" height="468" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"> </iframe></figure>
 
-## JSX {#jsx}
+## JSX {/*jsx*/}
 
 [Todd Kennedy](http://tck.io/) working at Cond&eacute; Nast wrote [JSXHint](https://github.com/CondeNast/JSXHint) and explains in a blog post his perspective on JSX.
 
@@ -74,13 +74,13 @@ This round-up is the proof that React has taken off from its Facebook's root: it
 >
 > [Read the full article...](http://tck.io/posts/jsxhint_and_react.html)
 
-## Photo Gallery {#photo-gallery}
+## Photo Gallery {/*photo-gallery*/}
 
 [Maykel Loomans](http://miekd.com/), designer at Instagram, wrote a gallery for photos he shot using React.
 
 <figure><a href="http://photos.miekd.com/xoxo2013/"><img src="/images/blog/xoxo2013.png"/></a>a></figure>
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <img src="/images/blog/steve_reverse.gif" style={{float: 'right'}} />
 

--- a/beta/src/pages/blog/2013/12/19/react-v0.8.0.md
+++ b/beta/src/pages/blog/2013/12/19/react-v0.8.0.md
@@ -15,9 +15,9 @@ In order to make the transition to 0.8 for our current users as painless as poss
 
 We hope that by releasing `react` on npm, we will enable a new set of uses that have been otherwise difficult. All feedback is welcome!
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Added support for more attributes:
   - `rows` & `cols` for `<textarea>`
@@ -28,16 +28,16 @@ We hope that by releasing `react` on npm, we will enable a new set of uses that 
 - Fixed Selection events in IE11
 - Added `onContextMenu` events
 
-### React with Addons {#react-with-addons}
+### React with Addons {/*react-with-addons*/}
 
 - Fixed bugs with TransitionGroup when children were undefined
 - Added support for `onTransition`
 
-### react-tools {#react-tools}
+### react-tools {/*react-tools*/}
 
 - Upgraded `jstransform` and `esprima-fb`
 
-### JSXTransformer {#jsxtransformer}
+### JSXTransformer {/*jsxtransformer*/}
 
 - Added support for use in IE8
 - Upgraded browserify, which reduced file size by ~65KB (16KB gzipped)

--- a/beta/src/pages/blog/2013/12/23/community-roundup-12.md
+++ b/beta/src/pages/blog/2013/12/23/community-roundup-12.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 React got featured on the front-page of Hacker News thanks to the Om library. If you try it out for the first time, take a look at the [docs](/docs/getting-started.html) and do not hesitate to ask questions on the [Google Group](https://groups.google.com/group/reactjs), [IRC](irc://chat.freenode.net/reactjs) or [Stack Overflow](http://stackoverflow.com/questions/tagged/reactjs). We are trying our best to help you out!
 
-## The Future of JavaScript MVC {#the-future-of-javascript-mvc}
+## The Future of JavaScript MVC {/*the-future-of-javascript-mvc*/}
 
 [David Nolen](https://swannodette.github.io/) announced Om, a thin wrapper on-top of React in ClojureScript. It stands out by only using immutable data structures. This unlocks the ability to write a very efficient [shouldComponentUpdate](/docs/component-specs.html#updating-shouldcomponentupdate) and get huge performance improvements on some tasks.
 
@@ -19,7 +19,7 @@ React got featured on the front-page of Hacker News thanks to the Om library. If
 >
 > [Read the full article...](https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs/)
 
-## Scroll Position with React {#scroll-position-with-react}
+## Scroll Position with React {/*scroll-position-with-react*/}
 
 Managing the scroll position when new content is inserted is usually very tricky to get right. [Vjeux](http://blog.vjeux.com/) discovered that [componentWillUpdate](/docs/component-specs.html#updating-componentwillupdate) and [componentDidUpdate](/docs/component-specs.html#updating-componentdidupdate) were triggered exactly at the right time to manage the scroll position.
 
@@ -41,7 +41,7 @@ Managing the scroll position when new content is inserted is usually very tricky
 >
 > [Check out the blog article...](http://blog.vjeux.com/2013/javascript/scroll-position-with-react.html)
 
-## Lights Out {#lights-out}
+## Lights Out {/*lights-out*/}
 
 React declarative approach is well suited to write games. [Cheng Lou](https://github.com/chenglou) wrote the famous Lights Out game in React. It's a good example of use of [TransitionGroup](/docs/animation.html) to implement animations.
 
@@ -49,7 +49,7 @@ React declarative approach is well suited to write games. [Cheng Lou](https://gi
 
 [Try it out!](https://chenglou.github.io/react-lights-out/)
 
-## Reactive Table Bookmarklet {#reactive-table-bookmarklet}
+## Reactive Table Bookmarklet {/*reactive-table-bookmarklet*/}
 
 [Stoyan Stefanov](http://www.phpied.com/) wrote a bookmarklet to process tables on the internet. It adds a little "pop" button that expands to a full-screen view with sorting, editing and export to csv and json.
 
@@ -57,13 +57,13 @@ React declarative approach is well suited to write games. [Cheng Lou](https://gi
 
 [Check out the blog post...](http://www.phpied.com/reactivetable-bookmarklet/)
 
-## MontageJS Tutorial in React {#montagejs-tutorial-in-react}
+## MontageJS Tutorial in React {/*montagejs-tutorial-in-react*/}
 
 [Ross Allen](https://twitter.com/ssorallen) implemented [MontageJS](http://montagejs.org/)'s [Reddit tutorial](http://montagejs.org/docs/tutorial-reddit-client-with-montagejs.html) in React. This is a good opportunity to compare the philosophies of the two libraries.
 
 [View the source on JSFiddle...](https://jsfiddle.net/ssorallen/fEsYt/)
 
-## Writing Good React Components {#writing-good-react-components}
+## Writing Good React Components {/*writing-good-react-components*/}
 
 [William Högman Rudenmalm](http://blog.whn.se/) wrote an article on how to write good React components. This is full of good advice.
 
@@ -75,7 +75,7 @@ React declarative approach is well suited to write games. [Cheng Lou](https://gi
 >
 > [Read the full article ...](http://blog.whn.se/post/69621609605/writing-good-react-components)
 
-## Hoodie React TodoMVC {#hoodie-react-todomvc}
+## Hoodie React TodoMVC {/*hoodie-react-todomvc*/}
 
 [Sven Lito](http://svenlito.com/) integrated the React TodoMVC example within an [Hoodie](http://hood.ie/) web app environment. This should let you get started using Hoodie and React.
 
@@ -85,7 +85,7 @@ hoodie new todomvc -t "hoodiehq/hoodie-react-todomvc"
 
 [Check out on GitHub...](https://github.com/hoodiehq/hoodie-react-todomvc)
 
-## JSX Compiler {#jsx-compiler}
+## JSX Compiler {/*jsx-compiler*/}
 
 Ever wanted to have a quick way to see what a JSX tag would be converted to? [Tim Yung](http://www.yungsters.com/) made a page for it.
 
@@ -93,6 +93,6 @@ Ever wanted to have a quick way to see what a JSX tag would be converted to? [Ti
 
 [Try it out!](/jsx-compiler.html)
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <center><blockquote class="twitter-tweet" lang="en"><p>.<a href="https://twitter.com/jordwalke">@jordwalke</a> lays down some truth <a href="http://t.co/AXAn0UlUe3">http://t.co/AXAn0UlUe3</a>, optimizing your JS application shouldn&#39;t force you to rewrite so much code <a href="https://twitter.com/search?q=%23reactjs&amp;src=hash">#reactjs</a></p>&mdash; David Nolen (@swannodette) <a href="https://twitter.com/swannodette/statuses/413780079249215488">December 19, 2013</a></blockquote></center>

--- a/beta/src/pages/blog/2013/12/30/community-roundup-13.md
+++ b/beta/src/pages/blog/2013/12/30/community-roundup-13.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 Happy holidays! This blog post is a little-late Christmas present for all the React users. Hopefully it will inspire you to write awesome web apps in 2014!
 
-## React Touch {#react-touch}
+## React Touch {/*react-touch*/}
 
 [Pete Hunt](http://www.petehunt.net/) wrote three demos showing that React can be used to run 60fps native-like experiences on mobile web. A frosted glass effect, an image gallery with 3d animations and an infinite scroll view.
 
@@ -13,13 +13,13 @@ Happy holidays! This blog post is a little-late Christmas present for all the Re
 
 [Try out the demos!](https://petehunt.github.io/react-touch/)
 
-## Introduction to React {#introduction-to-react}
+## Introduction to React {/*introduction-to-react*/}
 
 [Stoyan Stefanov](http://www.phpied.com/) talked at Joe Dev On Tech about React. He goes over all the features of the library and ends with a concrete example.
 
 <figure><iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/SMMRJif5QW0" frameborder="0" allowfullscreen></iframe></figure>
 
-## JSX: E4X The Good Parts {#jsx-e4x-the-good-parts}
+## JSX: E4X The Good Parts {/*jsx-e4x-the-good-parts*/}
 
 JSX is often compared to the now defunct E4X, [Vjeux](http://blog.vjeux.com/) went over all the E4X features and explained how JSX is different and hopefully doesn't repeat the same mistakes.
 
@@ -31,7 +31,7 @@ JSX is often compared to the now defunct E4X, [Vjeux](http://blog.vjeux.com/) we
 >
 > [Continue reading ...](http://blog.vjeux.com/2013/javascript/jsx-e4x-the-good-parts.html)
 
-## React + Socket.io {#react--socketio}
+## React + Socket.io {/*react--socketio*/}
 
 [Geert Pasteels](http://enome.be/nl) made a small experiment with Socket.io. He wrote a very small mixin that synchronizes React state with the server. Just include this mixin to your React component and it is now live!
 
@@ -55,7 +55,7 @@ componentWillUnmount: function () {
 
 [Check it out on GitHub...](https://github.com/Enome/react.io)
 
-## cssobjectify {#cssobjectify}
+## cssobjectify {/*cssobjectify*/}
 
 [Andrey Popp](http://andreypopp.com/) implemented a source transform that takes a CSS file and converts it to JSON. This integrates pretty nicely with React.
 
@@ -83,7 +83,7 @@ var MyComponent = React.createClass({
 
 [Check it out on GitHub...](https://github.com/andreypopp/cssobjectify)
 
-## ngReact {#ngreact}
+## ngReact {/*ngreact*/}
 
 [David Chang](http://davidandsuzi.com/) working at [HasOffer](http://www.hasoffers.com/) wanted to speed up his Angular app and replaced Angular primitives by React at different layers. When using React naively it is 67% faster, but when combining it with angular's transclusion it is 450% slower.
 
@@ -93,7 +93,7 @@ var MyComponent = React.createClass({
 >
 > [Read the full article...](http://davidandsuzi.com/ngreact-react-components-in-angular/)
 
-## vim-jsx {#vim-jsx}
+## vim-jsx {/*vim-jsx*/}
 
 [Max Wang](https://github.com/mxw) made a vim syntax highlighting and indentation plugin for vim.
 
@@ -105,6 +105,6 @@ var MyComponent = React.createClass({
 >
 > [View on GitHub...](https://github.com/mxw/vim-jsx)
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <center><blockquote class="twitter-tweet" lang="en"><p>I may be starting to get annoying with this, but ReactJS is really exciting. I truly feel the virtual DOM is a game changer.</p>&mdash; Eric Florenzano (@ericflo) <a href="https://twitter.com/ericflo/statuses/413842834974732288">December 20, 2013</a></blockquote></center>

--- a/beta/src/pages/blog/2014/01/06/community-roundup-14.md
+++ b/beta/src/pages/blog/2014/01/06/community-roundup-14.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 The theme of this first round-up of 2014 is integration. I've tried to assemble a list of articles and projects that use React in various environments.
 
-## React Baseline {#react-baseline}
+## React Baseline {/*react-baseline*/}
 
 React is only one-piece of your web application stack. [Mark Lussier](https://github.com/intabulas) shared his baseline stack that uses React along with Grunt, Browserify, Bower, Zepto, Director and Sass. This should help you get started using React for a new project.
 
@@ -17,14 +17,14 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 >
 > [Check it out on GitHub...](https://github.com/intabulas/reactjs-baseline)
 
-## Animal Sounds {#animal-sounds}
+## Animal Sounds {/*animal-sounds*/}
 
 [Josh Duck](http://joshduck.com/) used React in order to build a Windows 8 tablet app. This is a good example of a touch app written in React.
 [![](/images/blog/animal-sounds.jpg)](http://apps.microsoft.com/windows/en-us/app/baby-play-animal-sounds/9280825c-2ed9-41c0-ba38-aa9a5b890bb9)
 
 [Download the app...](http://apps.microsoft.com/windows/en-us/app/baby-play-animal-sounds/9280825c-2ed9-41c0-ba38-aa9a5b890bb9)
 
-## React Rails Tutorial {#react-rails-tutorial}
+## React Rails Tutorial {/*react-rails-tutorial*/}
 
 [Selem Delul](http://selem.im) bundled the [React Tutorial](/tutorial/tutorial.html) into a rails app. This is a good example on how to get started with a rails project.
 
@@ -40,7 +40,7 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 >
 > [View on GitHub...](https://github.com/necrodome/react-rails-tutorial)
 
-## Mixing with Backbone {#mixing-with-backbone}
+## Mixing with Backbone {/*mixing-with-backbone*/}
 
 [Eldar Djafarov](http://eldar.djafarov.com/) implemented a mixin to link Backbone models to React state and a small abstraction to write two-way binding on-top.
 
@@ -48,7 +48,7 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 
 [Check out the blog post...](http://eldar.djafarov.com/2013/11/reactjs-mixing-with-backbone/)
 
-## React Infinite Scroll {#react-infinite-scroll}
+## React Infinite Scroll {/*react-infinite-scroll*/}
 
 [Guillaume Rivals](https://twitter.com/guillaumervls) implemented an InfiniteScroll component. This is a good example of a React component that has a simple yet powerful API.
 
@@ -64,13 +64,13 @@ React is only one-piece of your web application stack. [Mark Lussier](https://gi
 
 [Try it out on GitHub!](https://github.com/guillaumervls/react-infinite-scroll)
 
-## Web Components Style {#web-components-style}
+## Web Components Style {/*web-components-style*/}
 
 [Thomas Aylott](http://subtlegradient.com/) implemented an API that looks like Web Components but using React underneath.
 
 [View the source on JSFiddle...](http://jsfiddle.net/SubtleGradient/ue2Aa)
 
-## React vs Angular {#react-vs-angular}
+## React vs Angular {/*react-vs-angular*/}
 
 React is often compared with Angular. [Pete Hunt](http://skulbuny.com/2013/10/31/react-vs-angular/) wrote an opinionated post on the subject.
 
@@ -80,6 +80,6 @@ React is often compared with Angular. [Pete Hunt](http://skulbuny.com/2013/10/31
 >
 > [Read the full post...](http://skulbuny.com/2013/10/31/react-vs-angular/)
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <div><blockquote class="twitter-tweet" lang="en"><p>Really intrigued by React.js. I&#39;ve looked at all JS frameworks, and excepting <a href="https://twitter.com/serenadejs">@serenadejs</a> this is the first one which makes sense to me.</p>&mdash; Jonas Nicklas (@jonicklas) <a href="https://twitter.com/jonicklas/statuses/412640708755869696">December 16, 2013</a></blockquote></div>

--- a/beta/src/pages/blog/2014/02/05/community-roundup-15.md
+++ b/beta/src/pages/blog/2014/02/05/community-roundup-15.md
@@ -7,7 +7,7 @@ Interest in React seems to have surged ever since David Nolen ([@swannodette](ht
 
 In this React Community Round-up, we are taking a closer look at React from a functional programming perspective.
 
-## "React: Another Level of Indirection" {#react-another-level-of-indirection}
+## "React: Another Level of Indirection" {/*react-another-level-of-indirection*/}
 
 To start things off, Eric Normand ([@ericnormand](https://twitter.com/ericnormand)) of [LispCast](http://lispcast.com) makes the case for [React from a general functional programming standpoint](http://www.lispcast.com/react-another-level-of-indirection) and explains how React's "Virtual DOM provides the last piece of the Web Frontend Puzzle for ClojureScript".
 
@@ -15,7 +15,7 @@ To start things off, Eric Normand ([@ericnormand](https://twitter.com/ericnorman
 >
 > [Read the full post...](http://www.lispcast.com/react-another-level-of-indirection)
 
-## Reagent: Minimalistic React for ClojureScript {#reagent-minimalistic-react-for-clojurescript}
+## Reagent: Minimalistic React for ClojureScript {/*reagent-minimalistic-react-for-clojurescript*/}
 
 Dan Holmsand ([@holmsand](https://twitter.com/holmsand)) created [Reagent](https://holmsand.github.io/reagent/), a simplistic ClojureScript API to React.
 
@@ -25,7 +25,7 @@ Dan Holmsand ([@holmsand](https://twitter.com/holmsand)) created [Reagent](https
 >
 > [Check it out on GitHub...](https://holmsand.github.io/reagent/)
 
-## Functional DOM programming {#functional-dom-programming}
+## Functional DOM programming {/*functional-dom-programming*/}
 
 React's one-way data-binding naturally lends itself to a functional programming approach. Facebook's Pete Hunt ([@floydophone](https://twitter.com/floydophone)) explores how one would go about [writing web apps in a functional manner](https://medium.com/p/67d81637d43). Spoiler alert:
 
@@ -37,7 +37,7 @@ Pete also explains this in detail at his #MeteorDevShop talk (about 30 Minutes):
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/Lqcs6hPOcFw?start=2963" frameborder="0" allowfullscreen></iframe>
 
-## Kioo: Separating markup and logic {#kioo-separating-markup-and-logic}
+## Kioo: Separating markup and logic {/*kioo-separating-markup-and-logic*/}
 
 [Creighton Kirkendall](https://github.com/ckirkendall) created [Kioo](https://github.com/ckirkendall/kioo), which adds Enlive-style templating to React. HTML templates are separated from the application logic. Kioo comes with separate examples for both Om and Reagent.
 
@@ -85,7 +85,7 @@ A basic example from github:
 (om/root app-state my-page (.-body js/document))
 ```
 
-## Om {#om}
+## Om {/*om*/}
 
 In an interview with David Nolen, Tom Coupland ([@tcoupland](https://twitter.com/tcoupland)) of InfoQ provides a nice summary of recent developments around Om ("[Om: Enhancing Facebook's React with Immutability](http://www.infoq.com/news/2014/01/om-react)").
 
@@ -93,7 +93,7 @@ In an interview with David Nolen, Tom Coupland ([@tcoupland](https://twitter.com
 >
 > [Read the full interview...](http://www.infoq.com/news/2014/01/om-react)
 
-### A slice of React, ClojureScript and Om {#a-slice-of-react-clojurescript-and-om}
+### A slice of React, ClojureScript and Om {/*a-slice-of-react-clojurescript-and-om*/}
 
 Fredrik Dyrkell ([@lexicallyscoped](https://twitter.com/lexicallyscoped)) rewrote part of the [React tutorial in both ClojureScript and Om](http://www.lexicallyscoped.com/2013/12/25/slice-of-reactjs-and-cljs.html), along with short, helpful explanations.
 
@@ -105,22 +105,22 @@ In a separate post, Dyrkell breaks down [how to build a binary clock component](
 
 [[Demo](http://www.lexicallyscoped.com/demo/binclock/)] [[Code](https://github.com/fredyr/binclock/blob/master/src/binclock/core.cljs)]
 
-### Time Travel: Implementing undo in Om {#time-travel-implementing-undo-in-om}
+### Time Travel: Implementing undo in Om {/*time-travel-implementing-undo-in-om*/}
 
 David Nolen shows how to leverage immutable data structures to [add global undo](https://swannodette.github.io/2013/12/31/time-travel/) functionality to an app – using just 13 lines of ClojureScript.
 
-### A Step-by-Step Om Walkthrough {#a-step-by-step-om-walkthrough}
+### A Step-by-Step Om Walkthrough {/*a-step-by-step-om-walkthrough*/}
 
 [Josh Lehman](http://www.joshlehman.me) took the time to create an extensive [step-by-step walkthrough](http://www.joshlehman.me/rewriting-the-react-tutorial-in-om/) of the React tutorial in Om. The well-documented source is on [github](https://github.com/jalehman/omtut-starter).
 
-### Omkara {#omkara}
+### Omkara {/*omkara*/}
 
 [brendanyounger](https://github.com/brendanyounger) created [omkara](https://github.com/brendanyounger/omkara), a starting point for ClojureScript web apps based on Om/React. It aims to take advantage of server-side rendering and comes with a few tips on getting started with Om/React projects.
 
-### Om Experience Report {#om-experience-report}
+### Om Experience Report {/*om-experience-report*/}
 
 Adam Solove ([@asolove](https://twitter.com/asolove/)) [dives a little deeper into Om, React and ClojureScript](http://adamsolove.com/js/clojure/2014/01/06/om-experience-report.html). He shares some helpful tips he gathered while building his [CartoCrayon](https://github.com/asolove/carto-crayon) prototype.
 
-## Not-so-random Tweet {#not-so-random-tweet}
+## Not-so-random Tweet {/*not-so-random-tweet*/}
 
 <div><blockquote class="twitter-tweet" lang="en"><p>[@swannodette](https://twitter.com/swannodette) No thank you! It's honestly a bit weird because Om is exactly what I didn't know I wanted for doing functional UI work.</p>&mdash; Adam Solove (@asolove) <a href="https://twitter.com/asolove/status/420294067637858304">January 6, 2014</a></blockquote></div>

--- a/beta/src/pages/blog/2014/02/15/community-roundup-16.md
+++ b/beta/src/pages/blog/2014/02/15/community-roundup-16.md
@@ -5,19 +5,19 @@ author: [jgebhardt]
 
 There have been many posts recently covering the <i>why</i> and <i>how</i> of React. This week's community round-up includes a collection of recent articles to help you get started with React, along with a few posts that explain some of the inner workings.
 
-## React in a nutshell {#react-in-a-nutshell}
+## React in a nutshell {/*react-in-a-nutshell*/}
 
 Got five minutes to pitch React to your coworkers? John Lynch ([@johnrlynch](https://twitter.com/johnrlynch)) put together [this excellent and refreshing slideshow](http://slid.es/johnlynch/reactjs):
 
 <iframe src="//slid.es/johnlynch/reactjs/embed" width="100%" height="420" scrolling="no" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-## React's diff algorithm {#reacts-diff-algorithm}
+## React's diff algorithm {/*reacts-diff-algorithm*/}
 
 React core team member Christopher Chedeau ([@vjeux](https://twitter.com/vjeux)) explores the innards of React's tree diffing algorithm in this [extensive and well-illustrated post](http://calendar.perfplanet.com/2013/diff/). <figure>[![](/images/blog/react-diff-tree.png)](http://calendar.perfplanet.com/2013/diff/)</figure>
 
 While we're talking about tree diffing: Matt Esch ([@MatthewEsch](https://twitter.com/MatthewEsch)) created [this project](https://github.com/Matt-Esch/virtual-dom), which aims to implement the virtual DOM and a corresponding diff algorithm as separate modules.
 
-## Many, many new introductions to React! {#many-many-new-introductions-to-react}
+## Many, many new introductions to React! {/*many-many-new-introductions-to-react*/}
 
 James Padosley wrote a short post on the basics (and merits) of React: [What is React?](http://james.padolsey.com/javascript/what-is-react/)
 
@@ -33,23 +33,23 @@ Taylor Lapeyre ([@taylorlapeyre](https://twitter.com/taylorlapeyre)) wrote anoth
 
 [This "Deep explanation for newbies"](http://www.webdesignporto.com/react-js-in-pure-javascript-facebook-library/?utm_source=echojs&utm_medium=post&utm_campaign=echojs) by [@ProJavaScript](https://twitter.com/ProJavaScript) explains how to get started building a React game without using the optional JSX syntax.
 
-### React around the world {#react-around-the-world}
+### React around the world {/*react-around-the-world*/}
 
 It's great to see the React community expand internationally. [This site](http://habrahabr.ru/post/189230/) features a React introduction in Russian.
 
-### React tutorial series {#react-tutorial-series}
+### React tutorial series {/*react-tutorial-series*/}
 
 [Christopher Pitt](https://medium.com/@followchrisp) explains [React Components](https://medium.com/react-tutorials/828c397e3dc8) and [React Properties](https://medium.com/react-tutorials/ef11cd55caa0). The former includes a nice introduction to using JSX, while the latter focuses on adding interactivity and linking multiple components together. Also check out the [other posts in his React Tutorial series](https://medium.com/react-tutorials), e.g. on using [React + Backbone Model](https://medium.com/react-tutorials/8aaec65a546c) and [React + Backbone Router](https://medium.com/react-tutorials/c00be0cf1592).
 
-### Beginner tutorial: Implementing the board game Go {#beginner-tutorial-implementing-the-board-game-go}
+### Beginner tutorial: Implementing the board game Go {/*beginner-tutorial-implementing-the-board-game-go*/}
 
 [Chris LaRose](http://cjlarose.com/) walks through the steps of creating a Go app in React, showing how to separate application logic from the rendered components. Check out his [tutorial](http://cjlarose.com/2014/01/09/react-board-game-tutorial.html) or go straight to the [code](https://github.com/cjlarose/react-go).
 
-### Egghead.io video tutorials {#eggheadio-video-tutorials}
+### Egghead.io video tutorials {/*eggheadio-video-tutorials*/}
 
 Joe Maddalone ([@joemaddalone](https://twitter.com/joemaddalone)) of [egghead.io](https://egghead.io/) created a series of React video tutorials, such as [this](http://www.youtube-nocookie.com/v/rFvZydtmsxM) introduction to React Components. [[part 1](http://www.youtube-nocookie.com/v/rFvZydtmsxM)], [[part 2](http://www.youtube-nocookie.com/v/5yvFLrt7N8M)]
 
-### "React: Finally, a great server/client web stack" {#react-finally-a-great-serverclient-web-stack}
+### "React: Finally, a great server/client web stack" {/*react-finally-a-great-serverclient-web-stack*/}
 
 Eric Florenzano ([@ericflo](https://twitter.com/ericflo)) sheds some light on what makes React perfect for server rendering:
 
@@ -59,11 +59,11 @@ Eric Florenzano ([@ericflo](https://twitter.com/ericflo)) sheds some light on wh
 
 > [Read the full post...](http://eflorenzano.com/blog/2014/01/23/react-finally-server-client/)
 
-## Building a complex React component {#building-a-complex-react-component}
+## Building a complex React component {/*building-a-complex-react-component*/}
 
 [Matt Harrison](http://matt-harrison.com/) walks through the process of [creating an SVG-based Resistance Calculator](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/) using React. <figure>[![](/images/blog/resistance-calculator.png)](http://matt-harrison.com/building-a-complex-web-component-with-facebooks-react-library/)</figure>
 
-## Random Tweets {#random-tweets}
+## Random Tweets {/*random-tweets*/}
 
 <div><blockquote class="twitter-tweet" lang="en"><p>[#reactjs](https://twitter.com/search?q=%23reactjs&src=hash) has very simple API, but it's amazing how much work has been done under the hood to make it blazing fast.</p>&mdash; Anton Astashov (@anton_astashov) <a href="https://twitter.com/anton_astashov/status/417556491646693378">December 30, 2013</a></blockquote></div>
 

--- a/beta/src/pages/blog/2014/02/16/react-v0.9-rc1.md
+++ b/beta/src/pages/blog/2014/02/16/react-v0.9-rc1.md
@@ -20,7 +20,7 @@ We've also published version `0.9.0-rc1` of the `react` and `react-tools` packag
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## Upgrade Notes {#upgrade-notes}
+## Upgrade Notes {/*upgrade-notes*/}
 
 In addition to the changes to React core listed below, we've made a small change to the way JSX interprets whitespace to make things more consistent. With this release, space between two components on the same line will be preserved, while a newline separating a text node from a tag will be eliminated in the output. Consider the code:
 
@@ -46,11 +46,11 @@ We believe this new behavior is more helpful and eliminates cases where unwanted
 
 In cases where you want to preserve the space adjacent to a newline, you can write a JS string like `{"Monkeys: "}` in your JSX source. We've included a script to do an automated codemod of your JSX source tree that preserves the old whitespace behavior by adding and removing spaces appropriately. You can [install jsx_whitespace_transformer from npm](https://github.com/facebook/react/blob/master/npm-jsx_whitespace_transformer/README.md) and run it over your source tree to modify files in place. The transformed JSX files will preserve your code's existing whitespace behavior.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - The lifecycle methods `componentDidMount` and `componentDidUpdate` no longer receive the root node as a parameter; use `this.getDOMNode()` instead
 - Whenever a prop is equal to `undefined`, the default value returned by `getDefaultProps` will now be used instead
@@ -62,7 +62,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - On `input`, `select`, and `textarea` elements, `.getValue()` is no longer supported; use `.getDOMNode().value` instead
 - `this.context` on components is now reserved for internal use by React
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - React now never rethrows errors, so stack traces are more accurate and Chrome's purple break-on-error stop sign now works properly
 - Added a new tool for profiling React components and identifying places where defining `shouldComponentUpdate` can give performance improvements
@@ -85,7 +85,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - Added support for `onReset` on `<form>` elements
 - The `autoFocus` attribute is now polyfilled consistently on `input`, `select`, and `textarea`
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - React no longer adds an `__owner__` property to each component's `props` object; passed-in props are now never mutated
 - When nesting top-level components (e.g., calling `React.renderComponent` within `componentDidMount`), events now properly bubble to the parent component
@@ -105,7 +105,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - `scrollLeft` and `scrollTop` are no longer accessed on document.body, eliminating a warning in Chrome
 - General performance fixes, memory optimizations, improvements to warnings and error messages
 
-### React with Addons {#react-with-addons}
+### React with Addons {/*react-with-addons*/}
 
 - `React.addons.TransitionGroup` was renamed to `React.addons.CSSTransitionGroup`
 - `React.addons.TransitionGroup` was added as a more general animation wrapper
@@ -115,7 +115,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - Performance optimizations for CSSTransitionGroup
 - On checkbox `<input>` elements, `checkedLink` is now supported for two-way binding
 
-### JSX Compiler and react-tools Package {#jsx-compiler-and-react-tools-package}
+### JSX Compiler and react-tools Package {/*jsx-compiler-and-react-tools-package*/}
 
 - Whitespace normalization has changed; now space between two tags on the same line will be preserved, while newlines between two tags will be removed
 - The `react-tools` npm package no longer includes the React core libraries; use the `react` package instead.

--- a/beta/src/pages/blog/2014/02/20/react-v0.9.md
+++ b/beta/src/pages/blog/2014/02/20/react-v0.9.md
@@ -20,7 +20,7 @@ As always, the release is available for download from the CDN:
 
 We've also published version `0.9.0` of the `react` and `react-tools` packages on npm and the `react` package on bower.
 
-## What’s New? {#whats-new}
+## What’s New? {/*whats-new*/}
 
 This version includes better support for normalizing event properties across all supported browsers so that you need to worry even less about cross-browser differences. We've also made many improvements to error messages and have refactored the core to never rethrow errors, so stack traces are more accurate and Chrome's purple break-on-error stop sign now works properly.
 
@@ -28,7 +28,7 @@ We've also added to the add-ons build [React.addons.TestUtils](/docs/test-utils.
 
 We've also made several other improvements and a few breaking changes; the full changelog is provided below.
 
-## JSX Whitespace {#jsx-whitespace}
+## JSX Whitespace {/*jsx-whitespace*/}
 
 In addition to the changes to React core listed below, we've made a small change to the way JSX interprets whitespace to make things more consistent. With this release, space between two components on the same line will be preserved, while a newline separating a text node from a tag will be eliminated in the output. Consider the code:
 
@@ -54,11 +54,11 @@ We believe this new behavior is more helpful and eliminates cases where unwanted
 
 In cases where you want to preserve the space adjacent to a newline, you can write `{'Monkeys: '}` or `Monkeys:{' '}` in your JSX source. We've included a script to do an automated codemod of your JSX source tree that preserves the old whitespace behavior by adding and removing spaces appropriately. You can [install jsx_whitespace_transformer from npm](https://github.com/facebook/react/blob/master/npm-jsx_whitespace_transformer/README.md) and run it over your source tree to modify files in place. The transformed JSX files will preserve your code's existing whitespace behavior.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - The lifecycle methods `componentDidMount` and `componentDidUpdate` no longer receive the root node as a parameter; use `this.getDOMNode()` instead
 - Whenever a prop is equal to `undefined`, the default value returned by `getDefaultProps` will now be used instead
@@ -70,7 +70,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - On `input`, `select`, and `textarea` elements, `.getValue()` is no longer supported; use `.getDOMNode().value` instead
 - `this.context` on components is now reserved for internal use by React
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - React now never rethrows errors, so stack traces are more accurate and Chrome's purple break-on-error stop sign now works properly
 - Added support for SVG tags `defs`, `linearGradient`, `polygon`, `radialGradient`, `stop`
@@ -95,7 +95,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - Added support for `onReset` on `<form>` elements
 - The `autoFocus` attribute is now polyfilled consistently on `input`, `select`, and `textarea`
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - React no longer adds an `__owner__` property to each component's `props` object; passed-in props are now never mutated
 - When nesting top-level components (e.g., calling `React.renderComponent` within `componentDidMount`), events now properly bubble to the parent component
@@ -116,7 +116,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - `scrollLeft` and `scrollTop` are no longer accessed on document.body, eliminating a warning in Chrome
 - General performance fixes, memory optimizations, improvements to warnings and error messages
 
-### React with Addons {#react-with-addons}
+### React with Addons {/*react-with-addons*/}
 
 - `React.addons.TestUtils` was added to help write unit tests
 - `React.addons.TransitionGroup` was renamed to `React.addons.CSSTransitionGroup`
@@ -127,7 +127,7 @@ In cases where you want to preserve the space adjacent to a newline, you can wri
 - Performance optimizations for CSSTransitionGroup
 - On checkbox `<input>` elements, `checkedLink` is now supported for two-way binding
 
-### JSX Compiler and react-tools Package {#jsx-compiler-and-react-tools-package}
+### JSX Compiler and react-tools Package {/*jsx-compiler-and-react-tools-package*/}
 
 - Whitespace normalization has changed; now space between two tags on the same line will be preserved, while newlines between two tags will be removed
 - The `react-tools` npm package no longer includes the React core libraries; use the `react` package instead.

--- a/beta/src/pages/blog/2014/02/24/community-roundup-17.md
+++ b/beta/src/pages/blog/2014/02/24/community-roundup-17.md
@@ -5,51 +5,51 @@ author: [jgebhardt]
 
 It's exciting to see the number of real-world React applications and components skyrocket over the past months! This community round-up features a few examples of inspiring React applications and components.
 
-## React in the Real World {#react-in-the-real-world}
+## React in the Real World {/*react-in-the-real-world*/}
 
-### Facebook Lookback video editor {#facebook-lookback-video-editor}
+### Facebook Lookback video editor {/*facebook-lookback-video-editor*/}
 
 Large parts of Facebook's web frontend are already powered by React. The recently released Facebook [Lookback video and its corresponding editor](https://www.facebook.com/lookback/edit/) are great examples of a complex, real-world React app.
 
-### Russia's largest bank is now powered by React {#russias-largest-bank-is-now-powered-by-react}
+### Russia's largest bank is now powered by React {/*russias-largest-bank-is-now-powered-by-react*/}
 
 Sberbank, Russia's largest bank, recently switched large parts of their site to use React, as detailed in [this post by Vyacheslav Slinko](https://groups.google.com/forum/#!topic/reactjs/Kj6WATX0atg).
 
-### Relato {#relato}
+### Relato {/*relato*/}
 
 [Relato](https://bripkens.github.io/relato/) by [Ben Ripkens](https://github.com/bripkens) shows Open Source Statistics based on npm data. It features a filterable and sortable table built in React. Check it out &ndash; it's super fast!
 
-### Makona Editor {#makona-editor}
+### Makona Editor {/*makona-editor*/}
 
 John Lynch ([@johnrlynch](https://twitter.com/johnrlynch)) created Makona, a block-style document editor for the web. Blocks of different content types comprise documents, authored using plain markup. At the switch of a toggle, block contents are then rendered on the page. While not quite a WYSIWYG editor, Makona uses plain textareas for input. This makes it compatible with a wider range of platforms than traditional rich text editors.
 [![](/images/blog/makona-editor.png)](https://johnthethird.github.io/makona-editor/)
 
-### Create Chrome extensions using React {#create-chrome-extensions-using-react}
+### Create Chrome extensions using React {/*create-chrome-extensions-using-react*/}
 
 React is in no way limited to just web pages. Brandon Tilley ([@BinaryMuse](https://twitter.com/BinaryMuse)) just released a detailed walk-through of [how he built his Chrome extension "Fast Tab Switcher" using React](http://brandontilley.com/2014/02/24/creating-chrome-extensions-with-react.html).
 
-### Twitter Streaming Client {#twitter-streaming-client}
+### Twitter Streaming Client {/*twitter-streaming-client*/}
 
 Javier Aguirre ([@javaguirre](https://twitter.com/javaguirre)) put together a simple [twitter streaming client using node, socket.io and React](http://javaguirre.net/2014/02/11/twitter-streaming-api-with-node-socket-io-and-reactjs/).
 
-### Sproutsheet {#sproutsheet}
+### Sproutsheet {/*sproutsheet*/}
 
 [Sproutsheet](http://sproutsheet.com/) is a gardening calendar. You can use it to track certain events that happen in the life of your plants. It's currently in beta and supports localStorage, and data/image import and export.
 
-### Instant Domain Search {#instant-domain-search}
+### Instant Domain Search {/*instant-domain-search*/}
 
 [Instant Domain Search](https://instantdomainsearch.com/) also uses React. It sure is instant!
 
-### SVG-based graphical node editor {#svg-based-graphical-node-editor}
+### SVG-based graphical node editor {/*svg-based-graphical-node-editor*/}
 
 [NoFlo](http://noflojs.org/) and [Meemoo](http://meemoo.org/) developer [Forresto Oliphant](http://www.forresto.com/) built an awesome SVG-based [node editor](https://forresto.github.io/prototyping/react/) in React.
 [![](/images/blog/react-svg-fbp.png)](https://forresto.github.io/prototyping/react/)
 
-### Ultimate Tic-Tac-Toe Game in React {#ultimate-tic-tac-toe-game-in-react}
+### Ultimate Tic-Tac-Toe Game in React {/*ultimate-tic-tac-toe-game-in-react*/}
 
 Rafał Cieślak ([@Ravicious](https://twitter.com/Ravicious)) wrote a [React version](https://ravicious.github.io/ultimate-ttt/) of [Ultimate Tic Tac Toe](http://mathwithbaddrawings.com/2013/06/16/ultimate-tic-tac-toe/). Find the source [here](https://github.com/ravicious/ultimate-ttt).
 
-### ReactJS Gallery {#reactjs-gallery}
+### ReactJS Gallery {/*reactjs-gallery*/}
 
 [Emanuele Rampichini](https://github.com/lele85)'s [ReactJS Gallery](https://github.com/lele85/ReactGallery) is a cool demo app that shows fullscreen images from a folder on the server. If the folder content changes, the gallery app updates via websockets.
 
@@ -57,34 +57,34 @@ Emanuele shared this awesome demo video with us:
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/jYcpaemt90M" frameborder="0" allowfullscreen></iframe>
 
-## React Components {#react-components}
+## React Components {/*react-components*/}
 
-### Table Sorter {#table-sorter}
+### Table Sorter {/*table-sorter*/}
 
 [Table Sorter](https://bgerm.github.io/react-table-sorter-demo/) by [bgerm](https://github.com/bgerm) [[source](https://github.com/bgerm/react-table-sorter-demo)] is another helpful React component.
 
-### Static-search {#static-search}
+### Static-search {/*static-search*/}
 
 Dmitry Chestnykh [@dchest](https://twitter.com/dchest) wrote a [static search indexer](https://github.com/dchest/static-search) in Go, along with a [React-based web front-end](http://www.codingrobots.com/search/) that consumes search result via JSON.
 
-### Lorem Ipsum component {#lorem-ipsum-component}
+### Lorem Ipsum component {/*lorem-ipsum-component*/}
 
 [Martin Andert](https://github.com/martinandert) created [react-lorem-component](https://github.com/martinandert/react-lorem-component), a simple component for all your placeholding needs.
 
-### Input with placeholder shim {#input-with-placeholder-shim}
+### Input with placeholder shim {/*input-with-placeholder-shim*/}
 
 [react-input-placeholder](enigma-io/react-input-placeholder) by [enigma-io](@enigma-io) is a small wrapper around React.DOM.input that shims in placeholder functionality for browsers that don't natively support it.
 
-### diContainer {#dicontainer}
+### diContainer {/*dicontainer*/}
 
 [dicontainer](https://github.com/SpektrumFM/dicontainer) provides a dependency container that lets you inject Angular-style providers and services as simple React.js Mixins.
 
-## React server rendering {#react-server-rendering}
+## React server rendering {/*react-server-rendering*/}
 
 Ever wonder how to pre-render React components on the server? [react-server-example](https://github.com/mhart/react-server-example) by Michael Hart ([@hichaelmart](https://twitter.com/hichaelmart)) walks through the necessary steps.
 
 Similarly, Alan deLevie ([@adelevie](https://twitter.com/adelevie)) created [react-client-server-starter](https://github.com/adelevie/react-client-server-starter), another detailed walk-through of how to server-render your app.
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <div><blockquote class="twitter-tweet" lang="en"><p>Recent changes: web ui is being upgraded to [#reactjs](https://twitter.com/search?q=%23reactjs&src=hash), HEAD~4 at [https://camlistore.googlesource.com/camlistore/](https://camlistore.googlesource.com/camlistore/)</p>&mdash; Camlistore (@Camlistore) <a href="https://twitter.com/Camlistore/status/423925795820539904">January 16, 2014</a></blockquote></div>

--- a/beta/src/pages/blog/2014/03/14/community-roundup-18.md
+++ b/beta/src/pages/blog/2014/03/14/community-roundup-18.md
@@ -5,11 +5,11 @@ author: [jgebhardt]
 
 In this Round-up, we are taking a few closer looks at React's interplay with different frameworks and architectures.
 
-## "Little framework BIG splash" {#little-framework-big-splash}
+## "Little framework BIG splash" {/*little-framework-big-splash*/}
 
 Let's start with yet another refreshing introduction to React: Craig Savolainen ([@maedhr](https://twitter.com/maedhr)) walks through some first steps, demonstrating [how to build a Google Maps component](http://infinitemonkeys.influitive.com/little-framework-big-splash) using React.
 
-## Architecting your app with react {#architecting-your-app-with-react}
+## Architecting your app with react {/*architecting-your-app-with-react*/}
 
 Brandon Konkle ([@bkonkle](https://twitter.com/bkonkle))
 [Architecting your app with react](http://lincolnloop.com/blog/architecting-your-app-react-part-1/)
@@ -19,11 +19,11 @@ We're looking forward to part 2!
 >
 > [Read the full article...](http://lincolnloop.com/blog/architecting-your-app-react-part-1/)
 
-## React vs. async DOM manipulation {#react-vs-async-dom-manipulation}
+## React vs. async DOM manipulation {/*react-vs-async-dom-manipulation*/}
 
 Eliseu Monar ([@eliseumds](https://twitter.com/eliseumds))'s post "[ReactJS vs async concurrent rendering](http://eliseumds.tumblr.com/post/77843550010/vitalbox-pchr-reactjs-vs-async-concurrent-rendering)" is a great example of how React quite literally renders a whole array of common web development work(arounds) obsolete.
 
-## React, Scala and the Play Framework {#react-scala-and-the-play-framework}
+## React, Scala and the Play Framework {/*react-scala-and-the-play-framework*/}
 
 [Matthias Nehlsen](http://matthiasnehlsen.com/) wrote a detailed introductory piece on [React and the Play Framework](http://matthiasnehlsen.com/blog/2014/01/05/play-framework-and-facebooks-react-library/), including a helpful architectural diagram of a typical React app.
 
@@ -33,16 +33,16 @@ In [another article](http://matthiasnehlsen.com/blog/2014/01/24/scala-dot-js-and
 
 Also check out his [talk](http://m.ustream.tv/recorded/42780242) at Ping Conference 2014, in which he walks through a lot of the previously content in great detail.
 
-## React and Backbone {#react-and-backbone}
+## React and Backbone {/*react-and-backbone*/}
 
 The folks over at [Venmo](https://venmo.com/) are using React in conjunction with Backbone.
 Thomas Boyt ([@thomasaboyt](https://twitter.com/thomasaboyt)) wrote [this detailed piece](http://www.thomasboyt.com/2013/12/17/using-reactjs-as-a-backbone-view.html) about why React and Backbone are "a fantastic pairing".
 
-## React vs. Ember {#react-vs-ember}
+## React vs. Ember {/*react-vs-ember*/}
 
 Eric Berry ([@coderberry](https://twitter.com/coderberry)) developed Ember equivalents for some of the official React examples. Read his post for a side-by-side comparison of the respective implementations: ["Facebook React vs. Ember"](https://instructure.github.io/blog/2013/12/17/facebook-react-vs-ember/).
 
-## React and plain old HTML {#react-and-plain-old-html}
+## React and plain old HTML {/*react-and-plain-old-html*/}
 
 Daniel Lo Nigro ([@Daniel15](https://twitter.com/Daniel15)) created [React-Magic](https://github.com/reactjs/react-magic), which leverages React to ajaxify plain old html pages and even [allows CSS transitions between pageloads](http://stuff.dan.cx/facebook/react-hacks/magic/red.php).
 
@@ -52,15 +52,15 @@ Daniel Lo Nigro ([@Daniel15](https://twitter.com/Daniel15)) created [React-Magic
 
 On a related note, [Reactize](https://turbo-react.herokuapp.com/) by Ross Allen ([@ssorallen](https://twitter.com/ssorallen)) is a similarly awesome project: A wrapper for Rails' [Turbolinks](https://github.com/rails/turbolinks/), which seems to have inspired John Lynch ([@johnrlynch](https://twitter.com/johnrlynch)) to then create [a server-rendered version using the JSX transformer in Rails middleware](http://www.rigelgroupllc.com/blog/2014/01/12/react-jsx-transformer-in-rails-middleware/).
 
-## React and Object.observe {#react-and-objectobserve}
+## React and Object.observe {/*react-and-objectobserve*/}
 
 Check out [François de Campredon](https://github.com/fdecampredon)'s implementation of [TodoMVC based on React and ES6's Object.observe](https://github.com/fdecampredon/react-observe-todomvc/).
 
-## React and Angular {#react-and-angular}
+## React and Angular {/*react-and-angular*/}
 
 Ian Bicking ([@ianbicking](https://twitter.com/ianbicking)) of Mozilla Labs [explains why he "decided to go with React instead of Angular.js"](https://plus.google.com/+IanBicking/posts/Qj8R5SWAsfE).
 
-### ng-React Update {#ng-react-update}
+### ng-React Update {/*ng-react-update*/}
 
 [David Chang](https://github.com/davidchang) works through some performance improvements of his [ngReact](https://github.com/davidchang/ngReact) project. His post ["ng-React Update - React 0.9 and Angular Track By"](http://davidandsuzi.com/ngreact-update/) includes some helpful advice on boosting render performance for Angular components.
 
@@ -74,11 +74,11 @@ React was also recently mentioned at ng-conf, where the Angular team commented o
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/srt3OBP2kGc?start=113" frameborder="0" allowfullscreen></iframe>
 
-## React and Web Components {#react-and-web-components}
+## React and Web Components {/*react-and-web-components*/}
 
 Jonathan Krause ([@jonykrause](https://twitter.com/jonykrause)) offers his thoughts regarding [parallels between React and Web Components](http://jonykrau.se/posts/the-value-of-react), highlighting the value of React's ability to render pages on the server practically for free.
 
-## Immutable React {#immutable-react}
+## Immutable React {/*immutable-react*/}
 
 [Peter Hausel](http://pk11.kinja.com/) shows how to build a Wikipedia auto-complete demo based on immutable data structures (similar to [mori](https://npmjs.org/package/mori)), really taking advantage of the framework's one-way reactive data binding:
 
@@ -86,16 +86,16 @@ Jonathan Krause ([@jonykrause](https://twitter.com/jonykrause)) offers his thoug
 >
 > [Read the full post](http://tech.kinja.com/immutable-react-1495205675)
 
-## D3 and React {#d3-and-react}
+## D3 and React {/*d3-and-react*/}
 
 [Ben Smith](http://10consulting.com/) built some great SVG-based charting components using a little less of D3 and a little more of React: [D3 and React - the future of charting components?](http://10consulting.com/2014/02/19/d3-plus-reactjs-for-charting/)
 
-## Om and React {#om-and-react}
+## Om and React {/*om-and-react*/}
 
 Josh Haberman ([@joshhaberman](https://twitter.com/JoshHaberman)) discusses performance differences between React, Om and traditional MVC frameworks in "[A closer look at OM vs React performance](http://blog.reverberate.org/2014/02/on-future-of-javascript-mvc-frameworks.html)".
 
 Speaking of Om: [Omchaya](https://github.com/sgrove/omchaya) by Sean Grove ([@sgrove](https://twitter.com/sgrove)) is a neat Cljs/Om example project.
 
-## Random Tweets {#random-tweets}
+## Random Tweets {/*random-tweets*/}
 
 <div><blockquote class="twitter-tweet" lang="en"><p>Worked for 2 hours on a [@react_js](https://twitter.com/react_js) app sans internet. Love that I could get stuff done with it without googling every question.</p>&mdash; John Shimek (@varikin) <a href="https://twitter.com/varikin/status/436606891657949185">February 20, 2014</a></blockquote></div>

--- a/beta/src/pages/blog/2014/03/19/react-v0.10-rc1.md
+++ b/beta/src/pages/blog/2014/03/19/react-v0.10-rc1.md
@@ -20,7 +20,7 @@ We've also published version `0.10.0-rc1` of the `react` and `react-tools` packa
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## Clone On Mount {#clone-on-mount}
+## Clone On Mount {/*clone-on-mount*/}
 
 The main purpose of this release is to provide a smooth upgrade path as we evolve some of the implementation of core. In v0.9 we started warning in cases where you called methods on unmounted components. This is part of an effort to enforce the idea that the return value of a component (`React.DOM.div()`, `MyComponent()`) is in fact not a reference to the component instance React uses in the virtual DOM. The return value is instead a light-weight object that React knows how to use. Since the return value currently is a reference to the same object React uses internally, we need to make this transition in stages as many people have come to depend on this implementation detail.
 
@@ -47,11 +47,11 @@ These warnings and method forwarding are only enabled in the development build. 
 
 The plan for v0.11 is that we will go fully to "descriptors". Method calls on the return value of `MyComponent()` will fail hard.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Added warnings to help migrate towards descriptors
 - Made it possible to server render without React-related markup (`data-reactid`, `data-react-checksum`). This DOM will not be mountable by React. [Read the docs for `React.renderComponentToStaticMarkup`](/docs/top-level-api.html#react.rendercomponenttostaticmarkup)
@@ -59,16 +59,16 @@ The plan for v0.11 is that we will go fully to "descriptors". Method calls on th
   - `srcSet` for `<img>` to specify images at different pixel ratios
   - `textAnchor` for SVG
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Ensure all void elements don’t insert a closing tag into the markup.
 - Ensure `className={false}` behaves consistently
 - Ensure `this.refs` is defined, even if no refs are specified.
 
-### Addons {#addons}
+### Addons {/*addons*/}
 
 - `update` function to deal with immutable data. [Read the docs](/docs/update.html)
 
-### react-tools {#react-tools}
+### react-tools {/*react-tools*/}
 
 - Added an option argument to `transform` function. The only option supported is `harmony`, which behaves the same as `jsx --harmony` on the command line. This uses the ES6 transforms from [jstransform](https://github.com/facebook/jstransform).

--- a/beta/src/pages/blog/2014/03/21/react-v0.10.md
+++ b/beta/src/pages/blog/2014/03/21/react-v0.10.md
@@ -20,7 +20,7 @@ We've also published version `0.10.0` of the `react` and `react-tools` packages 
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## Clone On Mount {#clone-on-mount}
+## Clone On Mount {/*clone-on-mount*/}
 
 The main purpose of this release is to provide a smooth upgrade path as we evolve some of the implementation of core. In v0.9 we started warning in cases where you called methods on unmounted components. This is part of an effort to enforce the idea that the return value of a component (`React.DOM.div()`, `MyComponent()`) is in fact not a reference to the component instance React uses in the virtual DOM. The return value is instead a light-weight object that React knows how to use. Since the return value currently is a reference to the same object React uses internally, we need to make this transition in stages as many people have come to depend on this implementation detail.
 
@@ -47,11 +47,11 @@ These warnings and method forwarding are only enabled in the development build. 
 
 The plan for v0.11 is that we will go fully to "descriptors". Method calls on the return value of `MyComponent()` will fail hard.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Added warnings to help migrate towards descriptors
 - Made it possible to server render without React-related markup (`data-reactid`, `data-react-checksum`). This DOM will not be mountable by React. [Read the docs for `React.renderComponentToStaticMarkup`](/docs/top-level-api.html#react.rendercomponenttostaticmarkup)
@@ -59,16 +59,16 @@ The plan for v0.11 is that we will go fully to "descriptors". Method calls on th
   - `srcSet` for `<img>` to specify images at different pixel ratios
   - `textAnchor` for SVG
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Ensure all void elements don’t insert a closing tag into the markup.
 - Ensure `className={false}` behaves consistently
 - Ensure `this.refs` is defined, even if no refs are specified.
 
-### Addons {#addons}
+### Addons {/*addons*/}
 
 - `update` function to deal with immutable data. [Read the docs](/docs/update.html)
 
-### react-tools {#react-tools}
+### react-tools {/*react-tools*/}
 
 - Added an option argument to `transform` function. The only option supported is `harmony`, which behaves the same as `jsx --harmony` on the command line. This uses the ES6 transforms from [jstransform](https://github.com/facebook/jstransform).

--- a/beta/src/pages/blog/2014/03/28/the-road-to-1.0.md
+++ b/beta/src/pages/blog/2014/03/28/the-road-to-1.0.md
@@ -7,17 +7,17 @@ When we launched React last spring, we purposefully decided not to call it 1.0. 
 
 Our primary goal with 1.0 is to clarify our messaging and converge on an API that is aligned with our goals. In order to do that, we want to clean up bad patterns we've seen in use and really help enable developers write good code.
 
-## Descriptors {#descriptors}
+## Descriptors {/*descriptors*/}
 
 The first part of this is what we're calling "descriptors". I talked about this briefly in our [v0.10 announcements][v0.10]. The goal here is to separate our virtual DOM representation from our use of it. Simply, this means the return value of a component (e.g. `React.DOM.div()`, `MyComponent()`) will be a simple object containing the information React needs to render. Currently the object returned is actually linked to React's internal representation of the component and even directly to the DOM element. This has enabled some bad patterns that are quite contrary to how we want people to use React. That's our failure.
 
 We added some warnings in v0.9 to start migrating some of these bad patterns. With v0.10 we'll catch more. You'll see more on this soon as we expect to ship v0.11 with descriptors.
 
-## API Cleanup {#api-cleanup}
+## API Cleanup {/*api-cleanup*/}
 
 This is really connected to everything. We want to keep the API as simple as possible and help developers [fall into the pit of success][pitofsuccess]. Enabling bad patterns with bad APIs is not success.
 
-## ES6 {#es6}
+## ES6 {/*es6*/}
 
 Before we even launched React publicly, members of the team were talking about how we could leverage ES6, namely classes, to improve the experience of creating React components. Calling `React.createClass(...)` isn't great. We don't quite have the right answer here yet, but we're close. We want to make sure we make this as simple as possible. It could look like this:
 
@@ -31,23 +31,23 @@ class MyComponent extends React.Component {
 
 There are other features of ES6 we're already using in core. I'm sure we'll see more of that. The `jsx` executable we ship with `react-tools` already supports transforming many parts of ES6 into code that will run on older browsers.
 
-## Context {#context}
+## Context {/*context*/}
 
 While we haven't documented `context`, it exists in some form in React already. It exists as a way to pass values through a tree without having to use props at every single point. We've seen this need crop up time and time again, so we want to make this as easy as possible. Its use has performance tradeoffs, and there are known weaknesses in our implementation, so we want to make sure this is a solid feature.
 
-## Addons {#addons}
+## Addons {/*addons*/}
 
 As you may know, we ship a separate build of React with some extra features we called "addons". While this has served us fine, it's not great for our users. It's made testing harder, but also results in more cache misses for people using a CDN. The problem we face is that many of these "addons" need access to parts of React that we don't expose publicly. Our goal is to ship each addon on its own and let each hook into React as needed. This would also allow others to write and distribute "addons".
 
-## Browser Support {#browser-support}
+## Browser Support {/*browser-support*/}
 
 As much as we'd all like to stop supporting older browsers, it's not always possible. Facebook still supports IE8. While React won't support IE8 forever, our goal is to have 1.0 support IE8. Hopefully we can continue to abstract some of these rough parts.
 
-## Animations {#animations}
+## Animations {/*animations*/}
 
 Finding a way to define animations in a declarative way is a hard problem. We've been exploring the space for a long time. We've introduced some half-measures to alleviate some use cases, but the larger problem remains. While we'd like to make this a part of 1.0, realistically we don't think we'll have a good solution in place.
 
-## Miscellaneous {#miscellaneous}
+## Miscellaneous {/*miscellaneous*/}
 
 There are several other things I listed on [our projects page][projects] that we're tracking. Some of them are internals and have no obvious outward effect (improve tests, repo separation, updated test runner). I encourage you to take a look.
 

--- a/beta/src/pages/blog/2014/04/04/reactnet.md
+++ b/beta/src/pages/blog/2014/04/04/reactnet.md
@@ -25,7 +25,7 @@ Web Forms applications as well as non-web applications (for example, in build
 scripts). ReactJS.NET currently only works on Microsoft .NET but we are working
 on support for Linux and Mac OS X via Mono as well.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 ReactJS.NET is packaged in NuGet. Simply run `Install-Package React.Mvc4` in the
 package manager console or search NuGet for "React" to install it.

--- a/beta/src/pages/blog/2014/06/27/community-roundup-19.md
+++ b/beta/src/pages/blog/2014/06/27/community-roundup-19.md
@@ -3,13 +3,13 @@ title: 'Community Round-up #19'
 author: [chenglou]
 ---
 
-## React Meetups! {#react-meetups}
+## React Meetups! {/*react-meetups*/}
 
 Ever wanted to find developers who also share the same interest in React than you? Recently, there has been a React Meetup in [San Francisco](http://www.meetup.com/ReactJS-San-Francisco/) (courtesy of [Telmate](http://www.telmate.com)), and one in [London](http://www.meetup.com/London-React-User-Group/) (courtesy of [Stuart Harris](http://www.meetup.com/London-React-User-Group/members/105837542/), [Cain Ullah](http://www.meetup.com/London-React-User-Group/members/15509971/) and [Zoe Merchant](http://www.meetup.com/London-React-User-Group/members/137058242/)). These two events have been big successes; a second one in London is [already planned](http://www.meetup.com/London-React-User-Group/events/191406572/).
 
 If you don't live near San Francisco or London, why not start one in your community?
 
-## Complementary Tools {#complementary-tools}
+## Complementary Tools {/*complementary-tools*/}
 
 In case you haven't seen it, we've consolidated the tooling solution around React on [this wiki page](https://github.com/facebook/react/wiki/Complementary-Tools). Some of the notable recent entries include:
 
@@ -21,7 +21,7 @@ In case you haven't seen it, we've consolidated the tooling solution around Reac
 
 These are some of the links that often pop up on the #reactjs IRC channel. If you made something that you think deserves to be shown on the wiki, feel free to add it!
 
-## React in Interesting Places {#react-in-interesting-places}
+## React in Interesting Places {/*react-in-interesting-places*/}
 
 The core concepts React themselves is something very valuable that the community is exploring and pushing further. A year ago, we wouldn't have imagined something like [Bruce Hauman](http://rigsomelight.com)'s [Flappy Bird ClojureScript port](http://rigsomelight.com/2014/05/01/interactive-programming-flappy-bird-clojurescript.html), whose interactive programming has been made possible through React:
 
@@ -33,28 +33,28 @@ And don't forget [Pete Hunt](https://github.com/petehunt)'s Wolfenstein 3D rende
 
 Give us a shoutout on IRC or [React Google Groups](https://groups.google.com/forum/#!forum/reactjs) if you've used React in some Interesting places.
 
-## Even More People Using React {#even-more-people-using-react}
+## Even More People Using React {/*even-more-people-using-react*/}
 
-### Prismatic {#prismatic}
+### Prismatic {/*prismatic*/}
 
 [Prismatic](http://getprismatic.com/home) recently shrank their codebase fivefold with the help of React and its popular ClojureScript wrapper, [Om](https://github.com/swannodette/om). They detailed their very positive experience [here](http://blog.getprismatic.com/om-sweet-om-high-functional-frontend-engineering-with-clojurescript-and-react/).
 
 > Finally, the state is normalized: each piece of information is represented in a single place. Since React ensures consistency between the DOM and the application data, the programmer can focus on ensuring that the state properly stays up to date in response to user input. If the application state is normalized, then this consistency is guaranteed by definition, completely avoiding the possibility of an entire class of common bugs.
 
-### Adobe Brackets {#adobe-brackets}
+### Adobe Brackets {/*adobe-brackets*/}
 
 [Kevin Dangoor](http://www.kevindangoor.com) works on [Brackets](http://brackets.io/?lang=en), the open-source code editor. After writing [his first impression on React](http://www.kevindangoor.com/2014/05/simplifying-code-with-react/), he followed up with another insightful [article](http://www.kevindangoor.com/2014/05/react-in-brackets/) on how to gradually make the code transition, how to preserve the editor's good parts, and how to tune Brackets' tooling around JSX.
 
 > We don’t need to switch to React everywhere, all at once. It’s not a framework that imposes anything on the application structure. [...] Easy, iterative adoption is definitely something in React’s favor for us.
 
-### Storehouse {#storehouse}
+### Storehouse {/*storehouse*/}
 
 [Storehouse](https://www.storehouse.co) (Apple Design Award 2014)'s web presence is build with React. Here's [an example story](https://www.storehouse.co/stories/y2ad-mexico-city-clouds). Congratulations on the award!
 
-### Vim Awesome {#vim-awesome}
+### Vim Awesome {/*vim-awesome*/}
 
 [Vim Awesome](http://vimawesome.com), an open-source Vim plugins directory built on React, was just launched. Be sure to [check out the source code](https://github.com/divad12/vim-awesome) if you're curious to see an example of how to build a small single-page React app.
 
-## Random Tweets {#random-tweets}
+## Random Tweets {/*random-tweets*/}
 
 <blockquote class="twitter-tweet" lang="en"><p>Spent 12 hours so far with <a href="https://twitter.com/hashtag/reactjs?src=hash">#reactjs</a>. Spent another 2 wondering why we&#39;ve been doing JS frameworks wrong until now. React makes me happy.</p>&mdash; Paul Irwin (@paulirwin) <a href="https://twitter.com/paulirwin/statuses/481263947589242882">June 24, 2014</a></blockquote>

--- a/beta/src/pages/blog/2014/07/13/react-v0.11-rc1.md
+++ b/beta/src/pages/blog/2014/07/13/react-v0.11-rc1.md
@@ -20,11 +20,11 @@ We've also published version `0.11.0-rc1` of the `react` and `react-tools` packa
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## `getDefaultProps` {#getdefaultprops}
+## `getDefaultProps` {/*getdefaultprops*/}
 
 Starting in React 0.11, `getDefaultProps()` is called only once when `React.createClass()` is called, instead of each time a component is rendered. This means that `getDefaultProps()` can no longer vary its return value based on `this.props` and any objects will be shared across all instances. This change improves performance and will make it possible in the future to do PropTypes checks earlier in the rendering process, allowing us to give better error messages.
 
-## Rendering to `null` {#rendering-to-null}
+## Rendering to `null` {/*rendering-to-null*/}
 
 Since React's release, people have been using work arounds to "render nothing". Usually this means returning an empty `<div/>` or `<span/>`. Some people even got clever and started returning `<noscript/>` to avoid extraneous DOM nodes. We finally provided a "blessed" solution that allows developers to write meaningful code. Returning `null` is an explicit indication to React that you do not want anything rendered. Behind the scenes we make this work with a `<noscript>` element, though in the future we hope to not put anything in the document. In the mean time, `<noscript>` elements do not affect layout in any way, so you can feel safe using `null` today!
 
@@ -46,7 +46,7 @@ render: function() {
 }
 ```
 
-## JSX Namespacing {#jsx-namespacing}
+## JSX Namespacing {/*jsx-namespacing*/}
 
 Another feature request we've been hearing for a long time is the ability to have namespaces in JSX. Given that JSX is just JavaScript, we didn't want to use XML namespacing. Instead we opted for a standard JS approach: object property access. Instead of assigning variables to access components stored in an object (such as a component library), you can now use the component directly as `<Namespace.Component/>`.
 
@@ -69,7 +69,7 @@ render: function() {
 }
 ```
 
-## Improved keyboard event normalization {#improved-keyboard-event-normalization}
+## Improved keyboard event normalization {/*improved-keyboard-event-normalization*/}
 
 Keyboard events now contain a normalized `e.key` value according to the [DOM Level 3 Events spec](http://www.w3.org/TR/DOM-Level-3-Events/#keys-special), allowing you to write simpler key handling code that works in all browsers, such as:
 
@@ -87,22 +87,22 @@ handleKeyDown: function(e) {
 
 Keyboard and mouse events also now include a normalized `e.getModifierState()` that works consistently across browsers.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - `getDefaultProps()` is now called once per class and shared across all instances
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Rendering to `null`
 - Keyboard events include normalized `e.key` and `e.getModifierState()` properties
 - New normalized `onBeforeInput` event
 - `React.Children.count` has been added as a helper for counting the number of children
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Re-renders are batched in more cases
 - Events: `e.view` properly normalized
@@ -116,19 +116,19 @@ Keyboard and mouse events also now include a normalized `e.getModifierState()` t
 - `img` event listeners are now unbound properly, preventing the error "Two valid but unequal nodes with the same `data-reactid`"
 - Added explicit warning when missing polyfills
 
-### React With Addons {#react-with-addons}
+### React With Addons {/*react-with-addons*/}
 
 - PureRenderMixin
 - Perf: a new set of tools to help with performance analysis
 - Update: New `$apply` command to transform values
 - TransitionGroup bug fixes with null elements, Android
 
-### React NPM Module {#react-npm-module}
+### React NPM Module {/*react-npm-module*/}
 
 - Now includes the pre-built packages under `dist/`.
 - `envify` is properly listed as a dependency instead of a peer dependency
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
 - Added support for namespaces, eg `<Components.Checkbox />`
 - JSXTransformer
@@ -136,7 +136,7 @@ Keyboard and mouse events also now include a normalized `e.getModifierState()` t
   - Scripts are downloaded in parallel for more speed. They are still executed in order (as you would expect with normal script tags)
   - Fixed a bug preventing sourcemaps from working in Firefox
 
-### React Tools Module {#react-tools-module}
+### React Tools Module {/*react-tools-module*/}
 
 - Improved readme with usage and API information
 - Improved ES6 transforms available with `--harmony` option

--- a/beta/src/pages/blog/2014/07/17/react-v0.11.md
+++ b/beta/src/pages/blog/2014/07/17/react-v0.11.md
@@ -26,11 +26,11 @@ We've also published version `0.11.0` of the `react` and `react-tools` packages 
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## `getDefaultProps` {#getdefaultprops}
+## `getDefaultProps` {/*getdefaultprops*/}
 
 Starting in React 0.11, `getDefaultProps()` is called only once when `React.createClass()` is called, instead of each time a component is rendered. This means that `getDefaultProps()` can no longer vary its return value based on `this.props` and any objects will be shared across all instances. This change improves performance and will make it possible in the future to do PropTypes checks earlier in the rendering process, allowing us to give better error messages.
 
-## Rendering to `null` {#rendering-to-null}
+## Rendering to `null` {/*rendering-to-null*/}
 
 Since React's release, people have been using work arounds to "render nothing". Usually this means returning an empty `<div/>` or `<span/>`. Some people even got clever and started returning `<noscript/>` to avoid extraneous DOM nodes. We finally provided a "blessed" solution that allows developers to write meaningful code. Returning `null` is an explicit indication to React that you do not want anything rendered. Behind the scenes we make this work with a `<noscript>` element, though in the future we hope to not put anything in the document. In the mean time, `<noscript>` elements do not affect layout in any way, so you can feel safe using `null` today!
 
@@ -52,7 +52,7 @@ render: function() {
 }
 ```
 
-## JSX Namespacing {#jsx-namespacing}
+## JSX Namespacing {/*jsx-namespacing*/}
 
 Another feature request we've been hearing for a long time is the ability to have namespaces in JSX. Given that JSX is just JavaScript, we didn't want to use XML namespacing. Instead we opted for a standard JS approach: object property access. Instead of assigning variables to access components stored in an object (such as a component library), you can now use the component directly as `<Namespace.Component/>`.
 
@@ -75,7 +75,7 @@ render: function() {
 }
 ```
 
-## Improved keyboard event normalization {#improved-keyboard-event-normalization}
+## Improved keyboard event normalization {/*improved-keyboard-event-normalization*/}
 
 Keyboard events now contain a normalized `e.key` value according to the [DOM Level 3 Events spec](http://www.w3.org/TR/DOM-Level-3-Events/#keys-special), allowing you to write simpler key handling code that works in all browsers, such as:
 
@@ -93,35 +93,35 @@ handleKeyDown: function(e) {
 
 Keyboard and mouse events also now include a normalized `e.getModifierState()` that works consistently across browsers.
 
-## Descriptors {#descriptors}
+## Descriptors {/*descriptors*/}
 
 In our [v0.10 release notes](/blog/2014/03/21/react-v0.10.html#clone-on-mount), we called out that we were deprecating the existing behavior of the component function call (eg `component = MyComponent(props, ...children)` or `component = <MyComponent prop={...}/>`). Previously that would create an instance and React would modify that internally. You could store that reference and then call functions on it (eg `component.setProps(...)`). This no longer works. `component` in the above examples will be a descriptor and not an instance that can be operated on. The v0.10 release notes provide a complete example along with a migration path. The development builds also provided warnings if you called functions on descriptors.
 
 Along with this change to descriptors, `React.isValidComponent` and `React.PropTypes.component` now actually validate that the value is a descriptor. Overwhelmingly, these functions are used to validate the value of `MyComponent()`, which as mentioned is now a descriptor, not a component instance. We opted to reduce code churn and make the migration to 0.11 as easy as possible. However, we realize this is has caused some confusion and we're working to make sure we are consistent with our terminology.
 
-## Prop Type Validation {#prop-type-validation}
+## Prop Type Validation {/*prop-type-validation*/}
 
 Previously `React.PropTypes` validation worked by simply logging to the console. Internally, each validator was responsible for doing this itself. Additionally, you could write a custom validator and the expectation was that you would also simply `console.log` your error message. Very shortly into the 0.11 cycle we changed this so that our validators return (_not throw_) an `Error` object. We then log the `error.message` property in a central place in ReactCompositeComponent. Overall the result is the same, but this provides a clearer intent in validation. In addition, to better transition into our descriptor factory changes, we also currently run prop type validation twice in development builds. As a result, custom validators doing their own logging result in duplicate messages. To update, simply return an `Error` with your message instead.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - `getDefaultProps()` is now called once per class and shared across all instances
 - `MyComponent()` now returns a descriptor, not an instance
 - `React.isValidComponent` and `React.PropTypes.component` validate _descriptors_, not component instances.
 - Custom `propType` validators should return an `Error` instead of logging directly
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Rendering to `null`
 - Keyboard events include normalized `e.key` and `e.getModifierState()` properties
 - New normalized `onBeforeInput` event
 - `React.Children.count` has been added as a helper for counting the number of children
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Re-renders are batched in more cases
 - Events: `e.view` properly normalized
@@ -135,19 +135,19 @@ Previously `React.PropTypes` validation worked by simply logging to the console.
 - `img` event listeners are now unbound properly, preventing the error "Two valid but unequal nodes with the same `data-reactid`"
 - Added explicit warning when missing polyfills
 
-### React With Addons {#react-with-addons}
+### React With Addons {/*react-with-addons*/}
 
 - PureRenderMixin: a mixin which helps optimize "pure" components
 - Perf: a new set of tools to help with performance analysis
 - Update: New `$apply` command to transform values
 - TransitionGroup bug fixes with null elements, Android
 
-### React NPM Module {#react-npm-module}
+### React NPM Module {/*react-npm-module*/}
 
 - Now includes the pre-built packages under `dist/`.
 - `envify` is properly listed as a dependency instead of a peer dependency
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
 - Added support for namespaces, eg `<Components.Checkbox />`
 - JSXTransformer
@@ -155,7 +155,7 @@ Previously `React.PropTypes` validation worked by simply logging to the console.
   - Scripts are downloaded in parallel for more speed. They are still executed in order (as you would expect with normal script tags)
   - Fixed a bug preventing sourcemaps from working in Firefox
 
-### React Tools Module {#react-tools-module}
+### React Tools Module {/*react-tools-module*/}
 
 - Improved readme with usage and API information
 - Improved ES6 transforms available with `--harmony` option

--- a/beta/src/pages/blog/2014/07/25/react-v0.11.1.md
+++ b/beta/src/pages/blog/2014/07/25/react-v0.11.1.md
@@ -28,11 +28,11 @@ We've also published version `0.11.1` of the `react` and `react-tools` packages 
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - `setState` can be called inside `componentWillMount` in non-DOM environments
 - `SyntheticMouseEvent.getEventModifierState` correctly renamed to `getModifierState`
@@ -40,6 +40,6 @@ Please try these builds out and [file an issue on GitHub](https://github.com/fac
 - `getModifierState` is now correctly case sensitive
 - Empty Text node used in IE8 `innerHTML` workaround is now removed, fixing rerendering in certain cases
 
-### JSXTransformer {#jsxtransformer}
+### JSXTransformer {/*jsxtransformer*/}
 
 - Fix duplicate variable declaration (caused issues in some browsers)

--- a/beta/src/pages/blog/2014/07/28/community-roundup-20.md
+++ b/beta/src/pages/blog/2014/07/28/community-roundup-20.md
@@ -5,25 +5,25 @@ author: [LoukaN]
 
 It's an exciting time for React as there are now more commits from open source contributors than from Facebook engineers! Keep up the good work :)
 
-## Atom moves to React {#atom-moves-to-react}
+## Atom moves to React {/*atom-moves-to-react*/}
 
 [Atom, GitHub's code editor, is now using React](http://blog.atom.io/2014/07/02/moving-atom-to-react.html) to build the editing experience. They made the move in order to improve performance. By default, React helped them eliminate unnecessary reflows, enabling them to focus on architecting the rendering pipeline in order to minimize repaints by using hardware acceleration. This is a testament to the fact that React's architecture is perfect for high performant applications.
 
 [<img src="/images/blog/gpu-cursor-move.gif" style={{width: '100%'}} />](http://blog.atom.io/2014/07/02/moving-atom-to-react.html)
 
-## Why Does React Scale? {#why-does-react-scale}
+## Why Does React Scale? {/*why-does-react-scale*/}
 
 At the last [JSConf.us](http://2014.jsconf.us/), Vjeux talked about the design decisions made in the API that allows it to scale to a large number of developers. If you don't have 20 minutes, take a look at the [annotated slides](https://speakerdeck.com/vjeux/why-does-react-scale-jsconf-2014).
 
 <iframe width={650} height={315} src="//www.youtube-nocookie.com/embed/D-ioDiacTm8" frameBorder={0} allowFullScreen />
 
-## Live Editing {#live-editing}
+## Live Editing {/*live-editing*/}
 
 One of the best features of React is that it provides the foundations to implement concepts that were otherwise extremely difficult, like server-side rendering, undo-redo, rendering to non-DOM environments like canvas... [Dan Abramov](https://twitter.com/dan_abramov) got hot code reloading working with webpack in order to [live edit a React project](https://gaearon.github.io/react-hot-loader/)!
 
 <iframe src="//player.vimeo.com/video/100010922" width="100%" height={315} webkitallowfullscreen mozallowfullscreen allowFullScreen />
 
-## ReactIntl Mixin by Yahoo {#reactintl-mixin-by-yahoo}
+## ReactIntl Mixin by Yahoo {/*reactintl-mixin-by-yahoo*/}
 
 There are a couple of React-related projects that recently appeared on Yahoo's GitHub, the first one being an [internationalization mixin](https://github.com/yahoo/react-intl). It's great to see them getting excited about React and contributing back to the community.
 
@@ -48,11 +48,11 @@ React.renderComponent(
 );
 ```
 
-## Thinking and Learning React {#thinking-and-learning-react}
+## Thinking and Learning React {/*thinking-and-learning-react*/}
 
 Josephine Hall, working at Icelab, used React to write a mobile-focused application. She wrote a blog post [“Thinking and Learning React.js”](http://icelab.com.au/articles/thinking-and-learning-reactjs/) to share her experience with elements they had to use. You'll learn about routing, event dispatch, touchable components, and basic animations.
 
-## London React Meetup {#london-react-meetup}
+## London React Meetup {/*london-react-meetup*/}
 
 If you missed the last [London React Meetup](http://www.meetup.com/London-React-User-Group/events/191406572/), the video is available, with lots of great content.
 
@@ -65,17 +65,17 @@ If you missed the last [London React Meetup](http://www.meetup.com/London-React-
 
 In related news, the next [React SF Meetup](http://www.meetup.com/ReactJS-San-Francisco/events/195518392/) will be from Prezi: [“Immediate Mode on the Web: How We Implemented the Prezi Viewer in JavaScript”](https://medium.com/prezi-engineering/how-and-why-prezi-turned-to-javascript-56e0ca57d135). While not in React, their tech is really awesome and shares a lot of React's design principles and perf optimizations.
 
-## Using React and KendoUI Together {#using-react-and-kendoui-together}
+## Using React and KendoUI Together {/*using-react-and-kendoui-together*/}
 
 One of the strengths of React is that it plays nicely with other libraries. Jim Cowart proved it by writing a tutorial that explains how to write [React component adapters for KendoUI](http://www.ifandelse.com/using-reactjs-and-kendoui-together/).
 
 <figure><a href="http://www.ifandelse.com/using-reactjs-and-kendoui-together/"><img src="/images/blog/kendoui.png" /></a></figure>
 
-## Acorn JSX {#acorn-jsx}
+## Acorn JSX {/*acorn-jsx*/}
 
 Ingvar Stepanyan extended the Acorn JavaScript parser to support JSX. The result is a [JSX parser](https://github.com/RReverser/acorn-jsx) that's 1.5–2.0x faster than the official JSX implementation. It is an experiment and is not meant to be used for serious things, but it's always a good thing to get competition on performance!
 
-## ReactScriptLoader {#reactscriptloader}
+## ReactScriptLoader {/*reactscriptloader*/}
 
 Yariv Sadan created [ReactScriptLoader](https://github.com/yariv/ReactScriptLoader) to make it easier to write components that require an external script.
 
@@ -105,6 +105,6 @@ var Foo = React.createClass({
 });
 ```
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <blockquote class="twitter-tweet" data-conversation="none" lang="en"><p>“<a href="https://twitter.com/apphacker">@apphacker</a>: I take back the mean things I said about <a href="https://twitter.com/reactjs">@reactjs</a> I actually like it.” Summarizing the life of ReactJS in a single tweet.</p>&mdash; Jordan (@jordwalke) <a href="https://twitter.com/jordwalke/statuses/490747339607265280">July 20, 2014</a></blockquote>

--- a/beta/src/pages/blog/2014/07/30/flux-actions-and-the-dispatcher.md
+++ b/beta/src/pages/blog/2014/07/30/flux-actions-and-the-dispatcher.md
@@ -7,11 +7,11 @@ Flux is the application architecture Facebook uses to build JavaScript applicati
 
 Flux is more of a pattern than a full-blown framework, and you can start using it without a lot of new code beyond React. Up until recently, however, we haven't released one crucial piece of our Flux software: the dispatcher. But along with the creation of the new [Flux code repository](https://github.com/facebook/flux) and [Flux website](https://facebook.github.io/flux/), we've now open sourced the same [dispatcher](https://facebook.github.io/flux/docs/dispatcher.html) we use in our production applications.
 
-## Where the Dispatcher Fits in the Flux Data Flow {#where-the-dispatcher-fits-in-the-flux-data-flow}
+## Where the Dispatcher Fits in the Flux Data Flow {/*where-the-dispatcher-fits-in-the-flux-data-flow*/}
 
 The dispatcher is a singleton, and operates as the central hub of data flow in a Flux application. It is essentially a registry of callbacks, and can invoke these callbacks in order. Each _store_ registers a callback with the dispatcher. When new data comes into the dispatcher, it then uses these callbacks to propagate that data to all of the stores. The process of invoking the callbacks is initiated through the dispatch() method, which takes a data payload object as its sole argument.
 
-## Actions and ActionCreators {#actions-and-actioncreators}
+## Actions and ActionCreators {/*actions-and-actioncreators*/}
 
 When new data enters the system, whether through a person interacting with the application or through a web api call, that data is packaged into an _action_ — an object literal containing the new fields of data and a specific action type. We often create a library of helper methods called ActionCreators that not only create the action object, but also pass the action to the dispatcher.
 
@@ -21,7 +21,7 @@ Letting the stores update themselves eliminates many entanglements typically fou
 
 <img src="/images/blog/flux-diagram.png" style={{width: '100%'}} />
 
-## Why We Need a Dispatcher {#why-we-need-a-dispatcher}
+## Why We Need a Dispatcher {/*why-we-need-a-dispatcher*/}
 
 As an application grows, dependencies across different stores are a near certainty. Store A will inevitably need Store B to update itself first, so that Store A can know how to update itself. We need the dispatcher to be able to invoke the callback for Store B, and finish that callback, before moving forward with Store A. To declaratively assert this dependency, a store needs to be able to say to the dispatcher, "I need to wait for Store B to finish processing this action." The dispatcher provides this functionality through its waitFor() method.
 
@@ -31,7 +31,7 @@ Further, the waitFor() method may be used in different ways for different action
 
 Problems arise, however, if we have circular dependencies. That is, if Store A needs to wait for Store B, and Store B needs to wait for Store A, we could wind up in an endless loop. The dispatcher now available in the Flux repo protects against this by throwing an informative error to alert the developer that this problem has occurred. The developer can then create a third store and resolve the circular dependency.
 
-## Example Chat App {#example-chat-app}
+## Example Chat App {/*example-chat-app*/}
 
 Along with the same dispatcher that Facebook uses in its production applications, we've also published a new example [chat app](https://github.com/facebook/flux/tree/master/examples/flux-chat), slightly more complicated than the simplistic TodoMVC, so that engineers can better understand how Flux solves problems like dependencies between stores and calls to a web API.
 

--- a/beta/src/pages/blog/2014/08/03/community-roundup-21.md
+++ b/beta/src/pages/blog/2014/08/03/community-roundup-21.md
@@ -3,7 +3,7 @@ title: 'Community Round-up #21'
 author: [LoukaN]
 ---
 
-## React Router {#react-router}
+## React Router {/*react-router*/}
 
 [Ryan Florence](http://ryanflorence.com/) and [Michael Jackson](https://twitter.com/mjackson) ported Ember's router to React in a project called [React Router](https://github.com/rackt/react-router). This is a very good example of both communities working together to make the web better!
 
@@ -21,7 +21,7 @@ React.renderComponent(
 );
 ```
 
-## Going Big with React {#going-big-with-react}
+## Going Big with React {/*going-big-with-react*/}
 
 Areeb Malik, from Facebook, talks about his experience using React. "On paper, all those JS frameworks look promising: clean implementations, quick code design, flawless execution. But what happens when you stress test JavaScript? What happens when you throw 6 megabytes of code at it? In this talk, we'll investigate how React performs in a high stress situation, and how it has helped our team build safe code on a massive scale"
 
@@ -31,7 +31,7 @@ Areeb Malik, from Facebook, talks about his experience using React. "On paper, a
 <iframe allowfullscreen="" data-progress="true" frameborder="0" height="390" id="vimeo-player" mozallowfullscreen="" src="//player.vimeo.com/video/100245392?api=1&amp;title=0" webkitallowfullscreen="" width="640"></iframe>
 -->
 
-## What is React? {#what-is-react}
+## What is React? {/*what-is-react*/}
 
 [Craig McKeachie](http://www.funnyant.com/author/admin/) author of [JavaScript Framework Guide](http://www.funnyant.com/javascript-framework-guide/) wrote an excellent news named ["What is React.js? Another Template Library?](http://www.funnyant.com/reactjs-what-is-it/)
 
@@ -47,7 +47,7 @@ Areeb Malik, from Facebook, talks about his experience using React. "On paper, a
 - Are components a better way to build an application?
 - Can I build something complex with React?
 
-## Referencing Dynamic Children {#referencing-dynamic-children}
+## Referencing Dynamic Children {/*referencing-dynamic-children*/}
 
 While Matt Zabriskie was working on [react-tabs](https://www.npmjs.com/package/react-tabs) he discovered how to use React.Children.map and React.addons.cloneWithProps in order to [reference dynamic children](http://www.mattzabriskie.com/blog/react-referencing-dynamic-children).
 
@@ -67,25 +67,25 @@ var App = React.createClass({
 });
 ```
 
-## JSX with Sweet.js using Readtables {#jsx-with-sweetjs-using-readtables}
+## JSX with Sweet.js using Readtables {/*jsx-with-sweetjs-using-readtables*/}
 
 Have you ever wondered how JSX was implemented? James Long wrote a very instructive blog post that explains how to [compile JSX with Sweet.js using Readtables](http://jlongster.com/Compiling-JSX-with-Sweet.js-using-Readtables).
 
 [![](/images/blog/sweet-jsx.png)](http://jlongster.com/Compiling-JSX-with-Sweet.js-using-Readtables)
 
-## First Look: Getting Started with React {#first-look-getting-started-with-react}
+## First Look: Getting Started with React {/*first-look-getting-started-with-react*/}
 
 [Kirill Buga](http://modernweb.com/authors/kirill-buga/) wrote an article on Modern Web explaining how [React is different from traditional MVC](http://modernweb.com/2014/07/23/getting-started-reactjs/) used by most JavaScript applications
 
 <figure><a href="http://modernweb.com/2014/07/23/getting-started-reactjs"><img src="/images/blog/first-look.png" /></a></figure>
 
-## React Draggable {#react-draggable}
+## React Draggable {/*react-draggable*/}
 
 [Matt Zabriskie](https://github.com/mzabriskie) released a [project](https://github.com/mzabriskie/react-draggable) to make your react components draggable.
 
 [![](/images/blog/react-draggable.png)](https://mzabriskie.github.io/react-draggable/example/)
 
-## HTML Parser2 React {#html-parser2-react}
+## HTML Parser2 React {/*html-parser2-react*/}
 
 [Jason Brown](https://browniefed.github.io/) adapted htmlparser2 to React: [htmlparser2-react](https://www.npmjs.com/package/htmlparser2-react). That allows you to convert raw HTML to the virtual DOM.
 This is not the intended way to use React but can be useful as last resort if you have an existing piece of HTML.
@@ -99,13 +99,13 @@ var html =
 var parsedComponent = reactParser(html, React);
 ```
 
-## Building UIs with React {#building-uis-with-react}
+## Building UIs with React {/*building-uis-with-react*/}
 
 If you haven't yet tried out React, Jacob Rios did a Hangout where he covers the most important aspects and thankfully he recorded it!
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/lAn7GVoGlKU" frameborder="0" allowfullscreen></iframe>
 
-## Random Tweets {#random-tweets}
+## Random Tweets {/*random-tweets*/}
 
 <blockquote class="twitter-tweet" lang="en"><p>We shipped reddit&#39;s first production <a href="https://twitter.com/reactjs">@reactjs</a> code last week, our checkout process.&#10;&#10;<a href="https://t.co/KUInwsCmAF">https://t.co/KUInwsCmAF</a></p>&mdash; Brian Holt (@holtbt) <a href="https://twitter.com/holtbt/statuses/493852312604254208">July 28, 2014</a></blockquote>
 <blockquote class="twitter-tweet" lang="en"><p>.<a href="https://twitter.com/AirbnbNerds">@AirbnbNerds</a> just launched our first user-facing React.js feature to production! We love it so far. <a href="https://t.co/KtyudemcIW">https://t.co/KtyudemcIW</a> /<a href="https://twitter.com/floydophone">@floydophone</a></p>&mdash; spikebrehm (@spikebrehm) <a href="https://twitter.com/spikebrehm/statuses/491645223643013121">July 22, 2014</a></blockquote>

--- a/beta/src/pages/blog/2014/09/12/community-round-up-22.md
+++ b/beta/src/pages/blog/2014/09/12/community-round-up-22.md
@@ -15,17 +15,17 @@ This has been an exciting summer as four big companies: Yahoo, Mozilla, Airbnb a
 <blockquote width="300" class="twitter-tweet" lang="en"><p>We shipped reddit&#39;s first production <a href="https://twitter.com/reactjs">@reactjs</a> code last week, our checkout process.&#10;&#10;<a href="https://t.co/KUInwsCmAF">https://t.co/KUInwsCmAF</a></p>&mdash; Brian Holt (@holtbt) <a href="https://twitter.com/holtbt/statuses/493852312604254208">July 28, 2014</a></blockquote>
 </td></tr></table>
 
-## React's Architecture {#reacts-architecture}
+## React's Architecture {/*reacts-architecture*/}
 
 [Vjeux](http://blog.vjeux.com/), from the React team, gave a talk at OSCON on the history of React and the various optimizations strategies that are implemented. You can also check out the [annotated slides](https://speakerdeck.com/vjeux/oscon-react-architecture) or [Chris Dawson](http://thenewstack.io/author/chrisdawson/)'s notes titled [JavaScript’s History and How it Led To React](http://thenewstack.io/javascripts-history-and-how-it-led-to-reactjs/).
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/eCf5CquV_Bw" frameborder="0" allowfullscreen></iframe>
 
-## v8 optimizations {#v8-optimizations}
+## v8 optimizations {/*v8-optimizations*/}
 
 Jakob Kummerow landed [two optimizations to V8](http://www.chromium.org/developers/speed-hall-of-fame#TOC-2014-06-18) specifically targeted at optimizing React. That's really exciting to see browser vendors helping out on performance!
 
-## Reusable Components by Khan Academy {#reusable-components-by-khan-academy}
+## Reusable Components by Khan Academy {/*reusable-components-by-khan-academy*/}
 
 [Khan Academy](https://www.khanacademy.org/) released [many high quality standalone components](https://khan.github.io/react-components/) they are using. This is a good opportunity to see what React code used in production look like.
 
@@ -40,13 +40,13 @@ var translated = (
 );
 ```
 
-## React + Browserify + Gulp {#react--browserify--gulp}
+## React + Browserify + Gulp {/*react--browserify--gulp*/}
 
 [Trường](http://truongtx.me/) wrote a little guide to help your [getting started using React, Browserify and Gulp](http://truongtx.me/2014/07/18/using-reactjs-with-browserify-and-gulp/).
 
 <figure><a href="http://truongtx.me/2014/07/18/using-reactjs-with-browserify-and-gulp/"><img src="/images/blog/react-browserify-gulp.jpg" /></a></figure>
 
-## React Style {#react-style}
+## React Style {/*react-style*/}
 
 After React put HTML inside of JavaScript, Sander Spies takes the same approach with CSS: [IntegratedCSS](https://github.com/SanderSpies/react-style). It seems weird at first but this is the direction where React is heading.
 
@@ -70,7 +70,7 @@ var Button = React.createClass({
 });
 ```
 
-## Virtual DOM in Elm {#virtual-dom-in-elm}
+## Virtual DOM in Elm {/*virtual-dom-in-elm*/}
 
 [Evan Czaplicki](http://evan.czaplicki.us) explains how Elm implements the idea of a Virtual DOM and a diffing algorithm. This is great to see React ideas spread to other languages.
 
@@ -78,13 +78,13 @@ var Button = React.createClass({
 >
 > [Read the full article](http://elm-lang.org/blog/Blazing-Fast-Html.elm)
 
-## Components Tutorial {#components-tutorial}
+## Components Tutorial {/*components-tutorial*/}
 
 If you are getting started with React, [Joe Maddalone](http://www.joemaddalone.com/) made a good tutorial on how to build your first component.
 
 <iframe width="650" height="200" src="//www.youtube-nocookie.com/embed/rFvZydtmsxM" frameborder="0" allowfullscreen></iframe>
 
-## Saving time & staying sane? {#saving-time--staying-sane}
+## Saving time & staying sane? {/*saving-time--staying-sane*/}
 
 When [Kent William Innholt](http://http://kentwilliam.com/) who works at [M>Path](http://mpath.com/) summed up his experience using React in an [article](http://kentwilliam.com/articles/saving-time-staying-sane-pros-cons-of-react-js).
 
@@ -97,7 +97,7 @@ When [Kent William Innholt](http://http://kentwilliam.com/) who works at [M>Path
 >
 > [Read the article...](http://kentwilliam.com/articles/saving-time-staying-sane-pros-cons-of-react-js)
 
-## Weather {#weather}
+## Weather {/*weather*/}
 
 To finish this round-up, Andrew Gleave made a page that displays the [Weather](https://github.com/andrewgleave/react-weather). It's great to see that React is also used for small prototypes.
 

--- a/beta/src/pages/blog/2014/09/16/react-v0.11.2.md
+++ b/beta/src/pages/blog/2014/09/16/react-v0.11.2.md
@@ -26,20 +26,20 @@ We've also published version `0.11.2` of the `react` and `react-tools` packages 
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Added support for `<dialog>` element and associated `open` attribute
 - Added support for `<picture>` element and associated `media` and `sizes` attributes
 - Added `React.createElement` API in preparation for React v0.12
   - `React.createDescriptor` has been deprecated as a result
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
 - `<picture>` is now parsed into `React.DOM.picture`
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
 - Update `esprima` and `jstransform` for correctness fixes
 - The `jsx` executable now exposes a `--strip-types` flag which can be used to remove TypeScript-like type annotations

--- a/beta/src/pages/blog/2014/09/24/testing-flux-applications.md
+++ b/beta/src/pages/blog/2014/09/24/testing-flux-applications.md
@@ -7,7 +7,7 @@ author: [fisherwebdev]
 
 [Flux](https://facebook.github.io/flux/) is the application architecture that Facebook uses to build web applications with [React](/). It's based on a unidirectional data flow. In previous blog posts and documentation articles, we've shown the [basic structure and data flow](https://facebook.github.io/flux/docs/overview.html), more closely examined the [dispatcher and action creators](/blog/2014/07/30/flux-actions-and-the-dispatcher.html), and shown how to put it all together with a [tutorial](https://facebook.github.io/flux/docs/todo-list.html). Now let's look at how to do formal unit testing of Flux applications with [Jest](https://facebook.github.io/jest/), Facebook's auto-mocking testing framework.
 
-## Testing with Jest {#testing-with-jest}
+## Testing with Jest {/*testing-with-jest*/}
 
 For a unit test to operate on a truly isolated _unit_ of the application, we need to mock every module except the one we are testing. Jest makes the mocking of other parts of a Flux application trivial. To illustrate testing with Jest, we'll return to our [example TodoMVC application](https://github.com/facebook/flux/tree/master/examples/flux-todomvc).
 
@@ -38,7 +38,7 @@ jest.dontMock('TodoStore');
 
 This tells Jest to let TodoStore be a real object with real, live methods. Jest will mock all other objects involved with the test.
 
-## Testing Stores {#testing-stores}
+## Testing Stores {/*testing-stores*/}
 
 At Facebook, Flux stores often receive a great deal of formal unit test coverage, as this is where the application state and logic lives. Stores are arguably the most important place in a Flux application to provide coverage, but at first glance, it's not entirely obvious how to test them.
 
@@ -81,7 +81,7 @@ var keys = Object.keys(all);
 expect(all[keys[0]].text).toEqual('foo');
 ```
 
-## Putting it All Together {#putting-it-all-together}
+## Putting it All Together {/*putting-it-all-together*/}
 
 The example Flux TodoMVC application has been updated with an example test for the TodoStore, but let's look at an abbreviated version of the entire test. The most important things to notice in this test are how we keep a reference to the store's registered callback in the closure of the test, and how we recreate the store before every test so that we clear the state of the store entirely.
 
@@ -149,7 +149,7 @@ describe('TodoStore', function () {
 
 You can take a look at all this code in the [TodoStore's tests on GitHub](https://github.com/facebook/flux/tree/master/examples/flux-todomvc/js/stores/__tests__/TodoStore-test.js) as well.
 
-## Mocking Data Derived from Other Stores {#mocking-data-derived-from-other-stores}
+## Mocking Data Derived from Other Stores {/*mocking-data-derived-from-other-stores*/}
 
 Sometimes our stores rely on data from other stores. Because all of our modules are mocked, we'll need to simulate the data that comes from the other store. We can do this by retrieving the mock function and adding a custom return value to it.
 
@@ -173,7 +173,7 @@ A brief example of this technique is up on GitHub within the Flux Chat example's
 
 For more information about the `mock` property of mocked methods or Jest's ability to provide custom mock values, see Jest's documentation on [mock functions](https://facebook.github.io/jest/docs/mock-functions.html).
 
-## Moving Logic from React to Stores {#moving-logic-from-react-to-stores}
+## Moving Logic from React to Stores {/*moving-logic-from-react-to-stores*/}
 
 What often starts as a little piece of seemingly benign logic in our React components often presents a problem while creating unit tests. We want to be able to write tests that read like a specification for our application's behavior, and when application logic slips into our view layer, this becomes more difficult.
 
@@ -306,7 +306,7 @@ render: function() {
 
 To learn how to test React components themselves, check out the [Jest tutorial for React](https://facebook.github.io/jest/docs/tutorial-react.html) and the [ReactTestUtils documentation](/docs/test-utils.html).
 
-## Further Reading {#further-reading}
+## Further Reading {/*further-reading*/}
 
 - [Mocks Aren't Stubs](http://martinfowler.com/articles/mocksArentStubs.html) by Martin Fowler
 - [Jest API Reference](https://facebook.github.io/jest/docs/api.html)

--- a/beta/src/pages/blog/2014/10/14/introducing-react-elements.md
+++ b/beta/src/pages/blog/2014/10/14/introducing-react-elements.md
@@ -21,13 +21,13 @@ Everything is backwards compatible for now, and as always React will provide you
 
 Continue reading if you want all the nitty gritty details...
 
-## New Terminology {#new-terminology}
+## New Terminology {/*new-terminology*/}
 
 We wanted to make it easier for new users to see the parallel with the DOM (and why React is different). To align our terminology we now use the term `ReactElement` instead of _descriptor_. Likewise, we use the term `ReactNode` instead of _renderable_.
 
 [See the full React terminology guide.](https://gist.github.com/sebmarkbage/fcb1b6ab493b0c77d589)
 
-## Creating a ReactElement {#creating-a-reactelement}
+## Creating a ReactElement {/*creating-a-reactelement*/}
 
 We now expose an external API for programmatically creating a `ReactElement` object.
 
@@ -42,7 +42,7 @@ var div = React.createFactory('div');
 var reactDivElement = div(props, children);
 ```
 
-## Deprecated: Auto-generated Factories {#deprecated-auto-generated-factories}
+## Deprecated: Auto-generated Factories {/*deprecated-auto-generated-factories*/}
 
 Imagine if `React.createClass` was just a plain JavaScript class. If you call a class as a plain function you would call the component's constructor to create a Component instance, not a `ReactElement`:
 
@@ -66,9 +66,9 @@ In future versions of React, we want to be able to support pure classes without 
 
 This is the biggest change to 0.12. Don't worry though. This functionality continues to work the same for this release, it just warns you if you're using a deprecated API. That way you can upgrade piece-by-piece instead of everything at once.
 
-## Upgrading to 0.12 {#upgrading-to-012}
+## Upgrading to 0.12 {/*upgrading-to-012*/}
 
-### React With JSX {#react-with-jsx}
+### React With JSX {/*react-with-jsx*/}
 
 If you use the React specific [JSX](https://facebook.github.io/jsx/) transform, the upgrade path is simple. Just make sure you have React in scope.
 
@@ -92,7 +92,7 @@ var MyOtherComponent = React.createClass({
 
 _NOTE: React's JSX will not call arbitrary functions in future releases. This restriction is introduced so that it's easier to reason about the output of JSX by both the reader of your code and optimizing compilers. The JSX syntax is not tied to React. Just the transpiler. You can still use [the JSX spec](https://facebook.github.io/jsx/) with a different transpiler for custom purposes._
 
-### React Without JSX {#react-without-jsx}
+### React Without JSX {/*react-without-jsx*/}
 
 If you don't use JSX and just call components as functions, you will need to explicitly create a factory before calling it:
 
@@ -148,7 +148,7 @@ var MyDOMComponent = React.createClass({
 
 We realize that this is noisy. At least it's on the top of the file (out of sight, out of mind). This a tradeoff we had to make to get [the other benefits](https://gist.github.com/sebmarkbage/d7bce729f38730399d28) that this model unlocks.
 
-### Anti-Pattern: Exporting Factories {#anti-pattern-exporting-factories}
+### Anti-Pattern: Exporting Factories {/*anti-pattern-exporting-factories*/}
 
 If you have an isolated project that only you use, then you could create a helper that creates both the class and the factory at once:
 
@@ -165,7 +165,7 @@ It also encourages you to put more logic into these helper functions. Something 
 
 To fit into the React ecosystem we recommend that you always export pure classes from your shared modules and let the consumer decide the best strategy for generating `ReactElement`s.
 
-## Third-party Languages {#third-party-languages}
+## Third-party Languages {/*third-party-languages*/}
 
 The signature of a `ReactElement` is something like this:
 
@@ -180,7 +180,7 @@ The signature of a `ReactElement` is something like this:
 
 Languages with static typing that don't need validation (e.g. [Om in ClojureScript](https://github.com/swannodette/om)), and production level compilers will be able to generate these objects inline instead of going through the validation step. This optimization will allow significant performance improvements in React.
 
-## Your Thoughts and Ideas {#your-thoughts-and-ideas}
+## Your Thoughts and Ideas {/*your-thoughts-and-ideas*/}
 
 We'd love to hear your feedback on this API and your preferred style. A plausible alternative could be to directly inline objects instead of creating factory functions:
 
@@ -202,7 +202,7 @@ This moves the noise down into the render method though. It also doesn't provide
 
 _NOTE: This won't work in this version of React because it's conflicting with other legacy APIs that we're deprecating. (We temporarily add a `element._isReactElement = true` marker on the object.)_
 
-## The Next Step: ES6 Classes {#the-next-step-es6-classes}
+## The Next Step: ES6 Classes {/*the-next-step-es6-classes*/}
 
 After 0.12 we'll begin work on moving to ES6 classes. We will still support `React.createClass` as a backwards compatible API. If you use an ES6 transpiler you will be able to declare your components like this:
 

--- a/beta/src/pages/blog/2014/10/16/react-v0.12-rc1.md
+++ b/beta/src/pages/blog/2014/10/16/react-v0.12-rc1.md
@@ -18,27 +18,27 @@ The release candidate is available for download:
 
 We've also published version `0.12.0-rc1` of the `react` and `react-tools` packages on npm and the `react` package on bower.
 
-## React Elements {#react-elements}
+## React Elements {/*react-elements*/}
 
 The biggest conceptual change we made in v0.12 is the move to React Elements. [We talked about this topic in depth earlier this week](/blog/2014/10/14/introducing-react-elements.html). If you haven't already, you should read up on the exciting changes in there!
 
-## JSX Changes {#jsx-changes}
+## JSX Changes {/*jsx-changes*/}
 
 Earlier this year we decided to write [a specification for JSX](https://facebook.github.io/jsx/). This has allowed us to make some changes focused on the React specific JSX and still allow others to innovate in the same space.
 
-### The `@jsx` Pragma is Gone! {#the-jsx-pragma-is-gone}
+### The `@jsx` Pragma is Gone! {/*the-jsx-pragma-is-gone*/}
 
 We have wanted to do this since before we even open sourced React. No more `/** @jsx React.DOM */`!. The React specific JSX transform assumes you have `React` in scope (which had to be true before anyway).
 
 `JSXTransformer` and `react-tools` have both been updated to account for this.
 
-### JSX for Function Calls is No Longer Supported {#jsx-for-function-calls-is-no-longer-supported}
+### JSX for Function Calls is No Longer Supported {/*jsx-for-function-calls-is-no-longer-supported*/}
 
 The React specific JSX transform no longer transforms to function calls. Instead we use `React.createElement` and pass it arguments. This allows us to make optimizations and better support React as a compile target for things like Om. Read more in the [React Elements introduction](/blog/2014/10/14/introducting-react-elements.html).
 
 The result of this change is that we will no longer support arbitrary function calls. We understand that the ability to do was a convenient shortcut for many people but we believe the gains will be worth it.
 
-### JSX Lower-case Convention {#jsx-lower-case-convention}
+### JSX Lower-case Convention {/*jsx-lower-case-convention*/}
 
 We used to have a whitelist of HTML tags that got special treatment in JSX. However as new HTML tags got added to the spec, or we added support for more SVG tags, we had to go update our whitelist. Additionally, there was ambiguity about the behavior. There was always the chance that something new added to the tag list would result in breaking your code. For example:
 
@@ -56,7 +56,7 @@ Currently we still use the whitelist as a sanity check. The transform will fail 
 
 In addition, the HTML tags are converted to strings instead of using `React.DOM` directly. `<div/>` becomes `React.createElement('div')` instead of `React.DOM.div()`.
 
-### JSX Spread Attributes {#jsx-spread-attributes}
+### JSX Spread Attributes {/*jsx-spread-attributes*/}
 
 Previously there wasn't a way to for you to pass a dynamic or unknown set of properties through JSX. This is now possible using the spread `...` operator.
 
@@ -81,7 +81,7 @@ You can now switch to using Spread Attributes instead:
 return <MyComponent {...myProps} />;
 ```
 
-## Breaking Change: `key` and `ref` Removed From `this.props` {#breaking-change-key-and-ref-removed-from-thisprops}
+## Breaking Change: `key` and `ref` Removed From `this.props` {/*breaking-change-key-and-ref-removed-from-thisprops*/}
 
 The props `key` and `ref` were already reserved property names. This turned out to be difficult to explicitly statically type since any object can accept these extra props. It also screws up JIT optimizations of React internals in modern VMs.
 
@@ -95,13 +95,13 @@ You can no longer access `this.props.ref` and `this.props.key` from inside the C
 
 You do NOT need to change the way to define `key` and `ref`, only if you need to read it. E.g. `<div key="my-key" />` and `div({ key: 'my-key' })` still works.
 
-## Breaking Change: Default Props Resolution {#breaking-change-default-props-resolution}
+## Breaking Change: Default Props Resolution {/*breaking-change-default-props-resolution*/}
 
 This is a subtle difference but `defaultProps` are now resolved at `ReactElement` creation time instead of when it's mounted. This is means that we can avoid allocating an extra object for the resolved props.
 
 You will primarily see this breaking if you're also using `transferPropsTo`.
 
-## Deprecated: transferPropsTo {#deprecated-transferpropsto}
+## Deprecated: transferPropsTo {/*deprecated-transferpropsto*/}
 
 `transferPropsTo` is deprecated in v0.12 and will be removed in v0.13. This helper function was a bit magical. It auto-merged a certain whitelist of properties and excluded others. It was also transferring too many properties. This meant that we have to keep a whitelist of valid HTML attributes in the React runtime. It also means that we can't catch typos on props.
 
@@ -119,11 +119,11 @@ return div(this.props);
 
 Although to avoid passing too many props down, you'll probably want to use something like ES7 rest properties. [Read more about upgrading from transferPropsTo](https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7).
 
-## Deprecated: Returning `false` in Event Handlers {#deprecated-returning-false-in-event-handlers}
+## Deprecated: Returning `false` in Event Handlers {/*deprecated-returning-false-in-event-handlers*/}
 
 It used to be possible to return `false` from event handlers to preventDefault. We did this because this works in most browsers. This is a confusing API and we might want to use the return value for something else. Therefore, this is deprecated. Use `event.preventDefault()` instead.
 
-## Renamed APIs {#renamed-apis}
+## Renamed APIs {/*renamed-apis*/}
 
 As part of the [new React terminology](https://gist.github.com/sebmarkbage/fcb1b6ab493b0c77d589) we aliased some existing APIs to use the new naming convention:
 

--- a/beta/src/pages/blog/2014/10/17/community-roundup-23.md
+++ b/beta/src/pages/blog/2014/10/17/community-roundup-23.md
@@ -5,13 +5,13 @@ author: [LoukaN]
 
 This round-up is a special edition on [Flux](https://facebook.github.io/flux/). If you expect to see diagrams showing arrows that all point in the same direction, you won't be disappointed!
 
-## React And Flux at ForwardJS {#react-and-flux-at-forwardjs}
+## React And Flux at ForwardJS {/*react-and-flux-at-forwardjs*/}
 
 Facebook engineers [Jing Chen](https://github.com/jingc) and [Bill Fisher](https://github.com/fisherwebdev) gave a talk about Flux and React at [ForwardJS](http://forwardjs.com/), and how using an application architecture with a unidirectional data flow helped solve recurring bugs.
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/i__969noyAM" frameborder="0" allowfullscreen></iframe>
 
-# Yahoo {#yahoo}
+# Yahoo {/*yahoo*/}
 
 Yahoo is converting Yahoo Mail to React and Flux and in the process, they open sourced several components. This will help you get an isomorphic application up and running.
 
@@ -20,7 +20,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 - [Fetchr](https://github.com/yahoo/fetchr)
 - [Flux Examples](https://github.com/yahoo/flux-examples)
 
-## Reflux {#reflux}
+## Reflux {/*reflux*/}
 
 [Mikael Brassman](https://spoike.ghost.io/) wrote [Reflux](https://github.com/spoike/refluxjs), a library that implements Flux concepts. Note that it diverges significantly from the way we use Flux at Facebook. He explains [the reasons why in a blog post](https://spoike.ghost.io/deconstructing-reactjss-flux/).
 
@@ -28,7 +28,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 <a href="https://spoike.ghost.io/deconstructing-reactjss-flux/"><img src="/images/blog/reflux-flux.png" width="400" /></a>
 </center>
 
-## React and Flux Interview {#react-and-flux-interview}
+## React and Flux Interview {/*react-and-flux-interview*/}
 
 [Ian Obermiller](http://ianobermiller.com/), engineer at Facebook, [made a lengthy interview](http://ianobermiller.com/blog/2014/09/15/react-and-flux-interview/) on the experience of using React and Flux in order to build probably the biggest React application ever written so far.
 
@@ -38,7 +38,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 >
 > [Read the full interview...](http://ianobermiller.com/blog/2014/09/15/react-and-flux-interview/)
 
-## Adobe's Brackets Project Tree {#adobes-brackets-project-tree}
+## Adobe's Brackets Project Tree {/*adobes-brackets-project-tree*/}
 
 [Kevin Dangoor](http://www.kevindangoor.com/) is converting the project tree of [Adobe's Bracket text editor](http://brackets.io/) to React and Flux. He wrote about his experience [using Flux](http://www.kevindangoor.com/2014/09/intro-to-the-new-brackets-project-tree/).
 
@@ -46,7 +46,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 <a href="http://www.kevindangoor.com/2014/09/intro-to-the-new-brackets-project-tree/"><img src="/images/blog/flux-diagram.png" width="400" /></a>
 </center>
 
-## Async Requests with Flux Revisited {#async-requests-with-flux-revisited}
+## Async Requests with Flux Revisited {/*async-requests-with-flux-revisited*/}
 
 [Reto Schläpfer](http://www.code-experience.com/the-code-experience/) came back to a Flux project he hasn't worked on for a month and [saw many ways to improve the way he implemented Flux](http://www.code-experience.com/async-requests-with-react-js-and-flux-revisited/). He summarized his learnings in a blog post.
 
@@ -62,7 +62,7 @@ Yahoo is converting Yahoo Mail to React and Flux and in the process, they open s
 >
 > [Read the full article...](http://www.code-experience.com/async-requests-with-react-js-and-flux-revisited/)
 
-## Undo-Redo with Immutable Data Structures {#undo-redo-with-immutable-data-structures}
+## Undo-Redo with Immutable Data Structures {/*undo-redo-with-immutable-data-structures*/}
 
 [Ameya Karve](https://github.com/ameyakarve) explained how to use [Mori](https://github.com/swannodette/mori), a library that provides immutable data structures, in order to [implement undo-redo](http://ameyakarve.com/jekyll/update/2014/02/06/Undo-React-Flux-Mori.html). This usually very challenging feature only takes a few lines of code with Flux!
 
@@ -82,7 +82,7 @@ undo: function() {
 },
 ```
 
-## Flux in practice {#flux-in-practice}
+## Flux in practice {/*flux-in-practice*/}
 
 [Gary Chambers](https://twitter.com/garychambers108) wrote a [guide to get started with Flux](https://medium.com/@garychambers108/flux-in-practice-ec08daa9041a). This is a very practical introduction to Flux.
 
@@ -90,13 +90,13 @@ undo: function() {
 >
 > [Read the full guide...](https://medium.com/@garychambers108/flux-in-practice-ec08daa9041a)
 
-## Components, React and Flux {#components-react-and-flux}
+## Components, React and Flux {/*components-react-and-flux*/}
 
 [Dan Abramov](https://twitter.com/dan_abramov) working at Stampsy made a talk about React and Flux. It's a very good overview of the concepts at play.
 
 <iframe src="//slides.com/danabramov/components-react-flux-wip/embed"  width="100%" height="315" scrolling="no" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-## React and Flux {#react-and-flux}
+## React and Flux {/*react-and-flux*/}
 
 [Christian Alfoni](https://github.com/christianalfoni) wrote an article where [he compares Backbone, Angular and Flux](https://christianalfoni.github.io/javascript/2014/08/20/react-js-and-flux.html) on a simple example that's representative of a real project he worked on.
 
@@ -106,7 +106,7 @@ undo: function() {
 >
 > [Read the full article...](https://christianalfoni.github.io/javascript/2014/08/20/react-js-and-flux.html)
 
-## Flux: Step by Step approach {#flux-step-by-step-approach}
+## Flux: Step by Step approach {/*flux-step-by-step-approach*/}
 
 [Nicola Paolucci](https://github.com/durdn) from Atlassian wrote a great guide to help your getting understand [Flux step by step](https://blogs.atlassian.com/2014/08/flux-architecture-step-by-step/).
 
@@ -114,7 +114,7 @@ undo: function() {
 <a href="https://blogs.atlassian.com/2014/08/flux-architecture-step-by-step/"><img src="/images/blog/flux-chart.png" width="400" /></a>
 </center>
 
-## DeLorean: Back to the future! {#delorean-back-to-the-future}
+## DeLorean: Back to the future! {/*delorean-back-to-the-future*/}
 
 [DeLorean](https://github.com/deloreanjs/delorean) is a tiny Flux pattern implementation developed by [Fatih Kadir Akin](https://github.com/f).
 
@@ -126,12 +126,12 @@ undo: function() {
 > - Built-in React.js integration, easy to use with Flight.js and Ractive.js and probably all others
 > - Improve your UI/data consistency using rollbacks
 
-## Facebook's iOS Infrastructure {#facebooks-ios-infrastructure}
+## Facebook's iOS Infrastructure {/*facebooks-ios-infrastructure*/}
 
 Last but not least, Flux and React ideas are not limited to JavaScript inside of the browser. The iOS team at Facebook re-implemented Newsfeed using very similar patterns.
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/XhXC4SKOGfQ" frameborder="0" allowfullscreen></iframe>
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 <blockquote class="twitter-tweet" lang="en"><p>If you build your app with flux, you can swap out React for a canvas or svg view layer and keep 85% of your code. (or the thing after React)</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/507309645372076034">September 3, 2014</a></blockquote>

--- a/beta/src/pages/blog/2014/10/28/react-v0.12.md
+++ b/beta/src/pages/blog/2014/10/28/react-v0.12.md
@@ -20,7 +20,7 @@ The release is available for download:
 
 We've also published version `0.12.0` of the `react` and `react-tools` packages on npm and the `react` package on bower.
 
-## New Terminology & Updated APIs {#new-terminology--updated-apis}
+## New Terminology & Updated APIs {/*new-terminology--updated-apis*/}
 
 v0.12 is bringing about some new terminology. [We introduced](/blog/2014/10/14/introducing-react-elements.html) this 2 weeks ago and we've also documented it in [a new section of the documentation](/docs/glossary.html). As a part of this, we also corrected many of our top-level APIs to align with the terminology. `Component` has been removed from all of our `React.render*` methods. While at one point the argument you passed to these functions was called a Component, it no longer is. You are passing ReactElements. To align with `render` methods in your component classes, we decided to keep the top-level functions short and sweet. `React.renderComponent` is now `React.render`.
 
@@ -28,7 +28,7 @@ We also corrected some other misnomers. `React.isValidComponent` actually determ
 
 The old methods will still work but will warn upon first use. They will be removed in v0.13.
 
-## JSX Changes {#jsx-changes}
+## JSX Changes {/*jsx-changes*/}
 
 [We talked more in depth about these before](/blog/2014/10/16/react-v0.12-rc1.html#jsx-changes), so here are the highlights.
 
@@ -37,13 +37,13 @@ The old methods will still work but will warn upon first use. They will be remov
 - DOM components don't make use of `React.DOM`, instead we pass the tag name directly. `<div/>` becomes `React.createElement('div')`
 - We introduced spread attributes as a quick way to transfer props.
 
-## DevTools Improvements, No More `__internals` {#devtools-improvements-no-more-\_\_internals}
+## DevTools Improvements, No More `__internals` {#devtools-improvements-no-more-\_\_internals} {/*devtools-improvements-no-more-__internals-devtools-improvements-no-more-__internals*/}
 
 For months we've gotten complaints about the React DevTools message. It shouldn't have logged the up-sell message when you were already using the DevTools. Unfortunately this was because the way we implemented these tools resulted in the DevTools knowing about React, but not the reverse. We finally gave this some attention and enabled React to know if the DevTools are installed. We released an update to the devtools several weeks ago making this possible. Extensions in Chrome should auto-update so you probably already have the update installed!
 
 As a result of this update, we no longer need to expose several internal modules to the world. If you were taking advantage of this implementation detail, your code will break. `React.__internals` is no more.
 
-## License Change - BSD {#license-change---bsd}
+## License Change - BSD {/*license-change---bsd*/}
 
 We updated the license on React to the BSD 3-Clause license with an explicit patent grant. Previously we used the Apache 2 license. These licenses are very similar and our extra patent grant is equivalent to the grant provided in the Apache license. You can still use React with the confidence that we have granted the use of any patents covering it. This brings us in line with the same licensing we use across the majority of our open source projects at Facebook.
 
@@ -51,11 +51,11 @@ You can read the full text of the [LICENSE](https://github.com/facebook/react/bl
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - `key` and `ref` moved off props object, now accessible on the element directly
 - React is now BSD licensed with accompanying Patents grant
@@ -63,12 +63,12 @@ You can read the full text of the [LICENSE](https://github.com/facebook/react/bl
 - `React.__internals` is removed - it was exposed for DevTools which no longer needs access
 - Composite Component functions can no longer be called directly - they must be wrapped with `React.createFactory` first. This is handled for you when using JSX.
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Spread operator (`{...}`) introduced to deprecate `this.transferPropsTo`
 - Added support for more HTML attributes: `acceptCharset`, `classID`, `manifest`
 
-#### Deprecations {#deprecations}
+#### Deprecations {/*deprecations*/}
 
 - `React.renderComponent` --> `React.render`
 - `React.renderComponentToString` --> `React.renderToString`
@@ -82,7 +82,7 @@ You can read the full text of the [LICENSE](https://github.com/facebook/react/bl
 - **DEPRECATED** Convenience Constructor usage as function, instead wrap with `React.createFactory`
 - **DEPRECATED** use of `key={null}` to assign implicit keys
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Better handling of events and updates in nested results, fixing value restoration in "layered" controlled components
 - Correctly treat `event.getModifierState` as case sensitive
@@ -95,32 +95,32 @@ You can read the full text of the [LICENSE](https://github.com/facebook/react/bl
   - `scrollLeft`, `scrollTop` removed, these should not be specified as props
 - Improved error messages
 
-### React With Addons {#react-with-addons}
+### React With Addons {/*react-with-addons*/}
 
-#### New Features {#new-features-1}
+#### New Features {/*new-features-1*/}
 
 - `React.addons.batchedUpdates` added to API for hooking into update cycle
 
-#### Breaking Changes {#breaking-changes-1}
+#### Breaking Changes {/*breaking-changes-1*/}
 
 - `React.addons.update` uses `assign` instead of `copyProperties` which does `hasOwnProperty` checks. Properties on prototypes will no longer be updated correctly.
 
-#### Bug Fixes {#bug-fixes-1}
+#### Bug Fixes {/*bug-fixes-1*/}
 
 - Fixed some issues with CSS Transitions
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
-#### Breaking Changes {#breaking-changes-2}
+#### Breaking Changes {/*breaking-changes-2*/}
 
 - Enforced convention: lower case tag names are always treated as HTML tags, upper case tag names are always treated as composite components
 - JSX no longer transforms to simple function calls
 
-#### New Features {#new-features-2}
+#### New Features {/*new-features-2*/}
 
 - `@jsx React.DOM` no longer required
 - spread (`{...}`) operator introduced to allow easier use of props
 
-#### Bug Fixes {#bug-fixes-2}
+#### Bug Fixes {/*bug-fixes-2*/}
 
 - JSXTransformer: Make sourcemaps an option when using APIs directly (eg, for react-rails)

--- a/beta/src/pages/blog/2014/11/25/community-roundup-24.md
+++ b/beta/src/pages/blog/2014/11/25/community-roundup-24.md
@@ -3,7 +3,7 @@ title: 'Community Round-up #24'
 author: [steveluscher]
 ---
 
-## Keep it Simple {#keep-it-simple}
+## Keep it Simple {/*keep-it-simple*/}
 
 Pedro Nauck ([pedronauck](https://github.com/pedronauck)) delivered an impeccably illustrated deck at Brazil's _Front in Floripa_ conference. Watch him talk about how to keep delivering value as your app scales, by keeping your development process simple.
 
@@ -19,7 +19,7 @@ James Pearce ([jamesgpearce](https://github.com/jamesgpearce)) carried Big-Coffe
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/m2fuO2wl_3c" frameborder="0" allowfullscreen></iframe>
 
-## All About Isomorphism {#all-about-isomorphism}
+## All About Isomorphism {/*all-about-isomorphism*/}
 
 Michael Ridgway ([mridgway](https://github.com/mridgway)) shows us how Yahoo! (who recently [moved Yahoo! Mail to React](http://www.slideshare.net/rmsguhan/react-meetup-mailonreact)) renders their React+Flux application, server-side.
 
@@ -29,11 +29,11 @@ Péter Márton ([hekike](https://github.com/hekike)) helps us brew a cold one (l
 
 And, lest you think that client-server isomorphism exists in pursuit of crawalable, indexable HTML alone, watch as Nate Hunzaker ([nhunzaker](https://github.com/nhunzaker)) [server renders data visualizations as SVG](http://viget.com/extend/visualization-is-for-sharing-using-react-for-portable-data-visualization) with React.
 
-## React Router Mows the Lawn {#react-router-mows-the-lawn}
+## React Router Mows the Lawn {/*react-router-mows-the-lawn*/}
 
 Ryan Florence ([rpflorence](https://github.com/rpflorence])) and Michael Jackson ([mjackson](https://github.com/mjackson)) unveiled a new API for [React Router](https://github.com/rackt/react-router) that solves some of its user's problems by eliminating the problems themselves. Read all about what React Router learned from its community of users, and how they've [rolled your ideas into their latest release](https://github.com/rackt/react-router/wiki/Announcements).
 
-## React in Practice {#react-in-practice}
+## React in Practice {/*react-in-practice*/}
 
 Jonathan Beebe ([somethingkindawierd](https://github.com/somethingkindawierd)) spoke about how he uses React to build tools that deliver hope to those trying to make the best of a bad situation. Watch his talk from this year's _Nodevember_ conference in Nashville
 
@@ -43,13 +43,13 @@ If you take a peek under the covers, you'll find that React powers [Carousel](ht
 
 We enjoyed a cinematic/narrative experience with this React-powered, interactive story by British author William Boyd. Dive into “[The Vanishing Game](https://thevanishinggame.wellstoried.com)” and see for yourself.
 
-## Be Kind, Rewind {#be-kind-rewind}
+## Be Kind, Rewind {/*be-kind-rewind*/}
 
 Spend the next 60 seconds watching Daniel Woelfel ([dwwoelfel](https://github.com/dwwoelfel)) serialize a React app's state as a string, then deserialize it to produce a working UI. Read about how he uses this technique to [reproduce bugs](http://blog.circleci.com/local-state-global-concerns/) reported to him by his users.
 
 <iframe width="650" height="315" src="//www.youtube-nocookie.com/embed/5yHFTN-_mOo" frameborder="0" allowfullscreen></iframe>
 
-## Community Components {#community-components}
+## Community Components {/*community-components*/}
 
 Tom Chen ([tomchentw](https://github.com/tomchentw)) brings us a [react-google-maps](https://tomchentw.github.io/react-google-maps/) component, and a way to syntax highlight source code using Prism and the [react-prism](https://tomchentw.github.io/react-prism/) component, for good measure.
 
@@ -57,23 +57,23 @@ Jed Watson ([jedwatson](https://github.com/JedWatson)) helps you manage touch, t
 
 To find these, and more community-built components, consult the [React Components](http://react-components.com/) and [React Rocks](http://react.rocks) component directories. React Rocks recently exceeded one-hundred listed components and counting. See one missing? Add the keyword `react-component` to your `package.json` to get listed on React Components, and [submit a link to React Rocks](https://docs.google.com/forms/d/1TpnwJmLcmmGj-_TI68upu_bKBViYeiKx7Aj9uKmV6wY/viewform).
 
-## Waiter, There's a CSS In My JavaScript {#waiter-theres-a-css-in-my-javascript}
+## Waiter, There's a CSS In My JavaScript {/*waiter-theres-a-css-in-my-javascript*/}
 
 The internet is abuzz with talk of styling React components using JavaScript instead of CSS. Christopher Chedeau ([vjeux](https://github.com/vjeux)) talks about some of the [fundamental style management challenges](https://speakerdeck.com/vjeux/react-css-in-js) we grapple with, at Facebook scale. A number of implementations of JavaScript centric style management solutions have appeared in the wild, including the React-focused [react-style](https://github.com/js-next/react-style).
 
-## Test Isolation {#test-isolation}
+## Test Isolation {/*test-isolation*/}
 
 Yahoo! shows us how they make use of `iframe` elements to [unit test React components in isolation](http://yahooeng.tumblr.com/post/102274727496/to-testutil-or-not-to-testutil).
 
-## You've Got The Hang of Flux, Now Let's Flow {#youve-got-the-hang-of-flux-now-lets-flow}
+## You've Got The Hang of Flux, Now Let's Flow {/*youve-got-the-hang-of-flux-now-lets-flow*/}
 
 Facebook Open Source released [Flow](https://code.facebook.com/posts/1505962329687926/flow-a-new-static-type-checker-for-javascript/) this month – a static type checker for JavaScript. Naturally, Flow supports JSX, and you can use it to [type check React applications](https://code.facebook.com/posts/1505962329687926/flow-a-new-static-type-checker-for-javascript/#compatibility). There's never been a better reason to start making use of `propTypes` in your component specifications!
 
-## Countdown to React.js Conf 2014 {#countdown-to-reactjs-conf-2014}
+## Countdown to React.js Conf 2014 {/*countdown-to-reactjs-conf-2014*/}
 
 We're counting down the days until [React.js Conf](http://conf.reactjs.com) at Facebook's headquarters in Menlo Park, California, on January 28th & 29th, 2015. Thank you, to everyone who responded to the Call for Presenters. Mark the dates; tickets go on sale in three waves: at noon PST on November 28th, December 5th, and December 12th, 2014.
 
-## React Meetups Around the World {#react-meetups-around-the-world}
+## React Meetups Around the World {/*react-meetups-around-the-world*/}
 
 <blockquote class="twitter-tweet" lang="en"><p>React JS meetup having pretty good turn up rate today <a href="https://twitter.com/hashtag/londonreact?src=hash">#londonreact</a> <a href="http://t.co/c360dlVVAe">pic.twitter.com/c360dlVVAe</a></p>&mdash; Alexander Savin (@karismafilms) <a href="https://twitter.com/karismafilms/status/535152580377468928">November 19, 2014</a></blockquote>
 

--- a/beta/src/pages/blog/2014/12/18/react-v0.12.2.md
+++ b/beta/src/pages/blog/2014/12/18/react-v0.12.2.md
@@ -22,15 +22,15 @@ We've also published version `0.12.2` of the `react` and `react-tools` packages 
 
 Please try these builds out and [file an issue on GitHub](https://github.com/facebook/react/issues/new) if you see anything awry.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
 - Added support for more HTML attributes: `formAction`, `formEncType`, `formMethod`, `formTarget`, `marginHeight`, `marginWidth`
 - Added `strokeOpacity` to the list of unitless CSS properties
 - Removed trailing commas (allows npm module to be bundled and used in IE8)
 - Fixed bug resulting in error when passing `undefined` to `React.createElement` - now there is a useful warning
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
 - JSX-related transforms now always use double quotes for props and `displayName`

--- a/beta/src/pages/blog/2014/12/19/react-js-conf-diversity-scholarship.md
+++ b/beta/src/pages/blog/2014/12/19/react-js-conf-diversity-scholarship.md
@@ -18,19 +18,19 @@ Facebook will make determinations on scholarship recipients in its sole discreti
 
 To apply for the scholarship, please visit the Application Page: <https://www.surveymonkey.com/s/XVJGK6R>
 
-## Award Includes {#award-includes}
+## Award Includes {/*award-includes*/}
 
 - Paid registration fee for the React.js Conf January 28 & 29th at Facebook’s Headquarters in Menlo Park, CA
 - Paid travel and lodging expenses
 - Additional \$200 meal stipend
 
-## Important Dates {#important-dates}
+## Important Dates {/*important-dates*/}
 
 - Monday, January 5, 2015: Applications for the React.js Conf Scholarship must be submitted in full
 - Friday, January 9, 2015: Award recipients will be notified by email of their acceptance
 - Wednesday & Thursday, January 28 & 29, 2015: React.js Conf
 
-## Eligibility {#eligibility}
+## Eligibility {/*eligibility*/}
 
 - Must currently be studying or working in Computer Science or a related field
 - International applicants are welcome, but you will be responsible for securing your own visa to attend the conference

--- a/beta/src/pages/blog/2015/01/27/react-v0.13.0-beta-1.md
+++ b/beta/src/pages/blog/2015/01/27/react-v0.13.0-beta-1.md
@@ -11,7 +11,7 @@ We just published a beta version of React v0.13.0 to [npm](https://www.npmjs.com
 
 So what is that one feature I'm so excited about that I just couldn't wait to share?
 
-## Plain JavaScript Classes!! {#plain-javascript-classes}
+## Plain JavaScript Classes!! {/*plain-javascript-classes*/}
 
 JavaScript originally didn't have a built-in class system. Every popular framework built their own, and so did we. This means that you have a learn slightly different semantics for each framework.
 
@@ -19,7 +19,7 @@ We figured that we're not in the business of designing a class system. We just w
 
 In React 0.13.0 you no longer need to use `React.createClass` to create React components. If you have a transpiler you can use ES6 classes today. You can use the transpiler we ship with `react-tools` by making use of the harmony option: `jsx --harmony`.
 
-### ES6 Classes {#es6-classes}
+### ES6 Classes {/*es6-classes*/}
 
 ```javascript
 class HelloMessage extends React.Component {
@@ -50,7 +50,7 @@ Counter.propTypes = {initialCount: React.PropTypes.number};
 Counter.defaultProps = {initialCount: 0};
 ```
 
-### ES7+ Property Initializers {#es7-property-initializers}
+### ES7+ Property Initializers {/*es7-property-initializers*/}
 
 Wait, assigning to properties seems like a very imperative way of defining classes! You're right, however, we designed it this way because it's idiomatic. We fully expect a more declarative syntax for property initialization to arrive in future version of JavaScript. It might look something like this:
 
@@ -71,7 +71,7 @@ export class Counter extends React.Component {
 
 This was inspired by TypeScript's property initializers.
 
-### Autobinding {#autobinding}
+### Autobinding {/*autobinding*/}
 
 `React.createClass` has a built-in magic feature that bound all methods to `this` automatically for you. This can be a little confusing for JavaScript developers that are not used to this feature in other classes, or it can be confusing when they move from React to other classes.
 
@@ -101,7 +101,7 @@ class Counter extends React.Component {
 }
 ```
 
-### Mixins {#mixins}
+### Mixins {/*mixins*/}
 
 Unfortunately, we will not launch any mixin support for ES6 classes in React. That would defeat the purpose of only using idiomatic JavaScript concepts.
 
@@ -115,7 +115,7 @@ Luckily, if you want to keep using mixins, you can just keep using `React.create
 >
 > The classic `React.createClass` style of creating classes will continue to work just fine.
 
-## Other Languages! {#other-languages}
+## Other Languages! {/*other-languages*/}
 
 Since these classes are just plain old JavaScript classes, you can use other languages that compile to JavaScript classes, such as TypeScript.
 

--- a/beta/src/pages/blog/2015/02/18/react-conf-roundup-2015.md
+++ b/beta/src/pages/blog/2015/02/18/react-conf-roundup-2015.md
@@ -5,7 +5,7 @@ author: [steveluscher]
 
 It was a privilege to welcome the React community to Facebook HQ on January 28â€“29 for the first-ever React.js Conf, and a pleasure to be able to unveil three new technologies that we've been using internally at Facebook for some time: GraphQL, Relay, and React Native.
 
-## The talks {#the-talks}
+## The talks {/*the-talks*/}
 
 <div class="skinny-row">
   <div class="skinny-col">
@@ -247,7 +247,7 @@ It was a privilege to welcome the React community to Facebook HQ on January 28â€
   </div>
 </div>
 
-## Reactions {#reactions}
+## Reactions {/*reactions*/}
 
 The conference is over, but the conversation has just begun.
 

--- a/beta/src/pages/blog/2015/02/20/introducing-relay-and-graphql.md
+++ b/beta/src/pages/blog/2015/02/20/introducing-relay-and-graphql.md
@@ -3,7 +3,7 @@ title: 'Introducing Relay and GraphQL'
 author: [wincent]
 ---
 
-## Data fetching for React applications {#data-fetching-for-react-applications}
+## Data fetching for React applications {/*data-fetching-for-react-applications*/}
 
 There's more to building an application than creating a user interface. Data fetching is still a tricky problem, especially as applications become more complicated. At [React.js Conf](http://conf.reactjs.com/) we announced two projects we've created at Facebook to make data fetching simple for developers, even as a product grows to include dozens of contributors and the application becomes as complex as Facebook itself.
 
@@ -13,7 +13,7 @@ The two projects &mdash; Relay and GraphQL &mdash; have been in use in productio
 
 <script async class="speakerdeck-embed" data-id="7af7c2f33bf9451a892dcd91de55b7c2" data-ratio="1.29456384323641" src="//speakerdeck.com/assets/embed.js"></script>
 
-## What is Relay? {#what-is-relay}
+## What is Relay? {/*what-is-relay*/}
 
 Relay is a new framework from Facebook that provides data-fetching functionality for React applications. It was announced at React.js Conf (January 2015).
 
@@ -21,13 +21,13 @@ Each component specifies its own data dependencies declaratively using a query l
 
 Developers compose these React components naturally, and Relay takes care of composing the data queries into efficient batches, providing each component with exactly the data that it requested (and no more), updating those components when the data changes, and maintaining a client-side store (cache) of all data.
 
-## What is GraphQL? {#what-is-graphql}
+## What is GraphQL? {/*what-is-graphql*/}
 
 GraphQL is a data querying language designed to describe the complex, nested data dependencies of modern applications. It's been in production use in Facebook's native apps for several years.
 
 On the server, we configure the GraphQL system to map queries to underlying data-fetching code. This configuration layer allows GraphQL to work with arbitrary underlying storage mechanisms. Relay uses GraphQL as its query language, but it is not tied to a specific implementation of GraphQL.
 
-## The value proposition {#the-value-proposition}
+## The value proposition {/*the-value-proposition*/}
 
 Relay was born out of our experiences building large applications at Facebook. Our overarching goal is to enable developers to create correct, high-performance applications in a straightforward and obvious way. The design enables even large teams to make changes with a high degree of isolation and confidence. Fetching data is hard, dealing with ever-changing data is hard, and performance is hard. Relay aims to reduce these problems to simple ones, moving the tricky bits into the framework and freeing you to concentrate on building your application.
 
@@ -47,13 +47,13 @@ By handling all data-fetching via a single abstraction, we're able to handle a b
 - **Simplified server implementation:** Rather than having a proliferation of end-points (per action, per route), a single GraphQL endpoint can serve as a facade for any number of underlying resources.
 - **Uniform mutations:** There is one consistent pattern for performing mutations (writes), and it is conceptually baked into the data querying model itself. You can think of a mutation as a query with side-effects: you provide some parameters that describe the change to be made (eg. attaching a comment to a record) and a query that specifies the data you'll need to update your view of the world after the mutation completes (eg. the comment count on the record), and the data flows through the system using the normal flow. We can do an immediate "optimistic" update on the client (ie. update the view under the assumption that the write will succeed), and finally commit it, retry it or roll it back in the event of an error when the server payload comes back.
 
-## How does it relate to Flux? {#how-does-it-relate-to-flux}
+## How does it relate to Flux? {/*how-does-it-relate-to-flux*/}
 
 In some ways Relay is inspired by Flux, but the mental model is much simpler. Instead of multiple stores, there is one central store that caches all GraphQL data. Instead of explicit subscriptions, the framework itself can track which data each component requests, and which components should be updated whenever the data change. Instead of actions, modifications take the form of mutations.
 
 At Facebook, we have apps built entirely using Flux, entirely using Relay, or with both. One pattern we see emerging is letting Relay manage the bulk of the data flow for an application, but using Flux stores on the side to handle a subset of application state.
 
-## Open source plans {#open-source-plans}
+## Open source plans {/*open-source-plans*/}
 
 We're working very hard right now on getting both GraphQL (a spec, and a reference implementation) and Relay ready for public release (no specific dates yet, but we are super excited about getting these out there).
 

--- a/beta/src/pages/blog/2015/02/24/react-v0.13-rc1.md
+++ b/beta/src/pages/blog/2015/02/24/react-v0.13-rc1.md
@@ -23,11 +23,11 @@ We've also published version `0.13.0-rc1` of the `react` and `react-tools` packa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - Mutating `props` after an element is created is deprecated and will cause warnings in development mode; future versions of React will incorporate performance optimizations assuming that props aren't mutated
 - Static methods (defined in `statics`) are no longer autobound to the component class
@@ -36,7 +36,7 @@ We've also published version `0.13.0-rc1` of the `react` and `react-tools` packa
 - `setState` and `forceUpdate` on an unmounted component now warns instead of throwing. That avoids a possible race condition with Promises.
 - Access to most internal properties has been completely removed, including `this._pendingState` and `this._rootNodeID`.
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Support for using ES6 classes to build React components; see the [v0.13.0 beta 1 notes](/blog/2015/01/27/react-v0.13.0-beta-1.html) for details
 - Added new top-level API `React.findDOMNode(component)`, which should be used in place of `component.getDOMNode()`. The base class for ES6-based components will not have `getDOMNode`. This change will enable some more patterns moving forward.
@@ -44,32 +44,32 @@ We've also published version `0.13.0-rc1` of the `react` and `react-tools` packa
 - `this.setState()` can now take a function as the first argument for transactional state updates, such as `this.setState((state, props) => ({count: state.count + 1}));` -- this means that you no longer need to use `this._pendingState`, which is now gone.
 - Support for iterators and immutable-js sequences as children
 
-#### Deprecations {#deprecations}
+#### Deprecations {/*deprecations*/}
 
 - `ComponentClass.type` is deprecated. Just use `ComponentClass` (usually as `element.type === ComponentClass`)
 - Some methods that are available on `createClass`-based components are removed or deprecated from ES6 classes (for example, `getDOMNode`, `setProps`, `replaceState`).
 
-### React with Add-Ons {#react-with-add-ons}
+### React with Add-Ons {/*react-with-add-ons*/}
 
-#### Deprecations {#deprecations-1}
+#### Deprecations {/*deprecations-1*/}
 
 - `React.addons.classSet` is now deprecated. This functionality can be replaced with several freely available modules. [classnames](https://www.npmjs.com/package/classnames) is one such module.
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
-#### Breaking Changes {#breaking-changes-1}
+#### Breaking Changes {/*breaking-changes-1*/}
 
 - When transforming ES6 syntax, `class` methods are no longer enumerable by default, which requires `Object.defineProperty`; if you support browsers such as IE8, you can pass `--target es3` to mirror the old behavior
 
-#### New Features {#new-features-1}
+#### New Features {/*new-features-1*/}
 
 - `--target` option is available on the jsx command, allowing users to specify and ECMAScript version to target.
   - `es5` is the default.
   - `es3` restored the previous default behavior. An additional transform is added here to ensure the use of reserved words as properties is safe (eg `this.static` will become `this['static']` for IE8 compatibility).
 - The transform for the call spread operator has also been enabled.
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
-#### Breaking Changes {#breaking-changes-2}
+#### Breaking Changes {/*breaking-changes-2*/}
 
 - A change was made to how some JSX was parsed, specifically around the use of `>` or `}` when inside an element. Previously it would be treated as a string but now it will be treated as a parse error. We will be releasing a standalone executable to find and fix potential issues in your JSX code.

--- a/beta/src/pages/blog/2015/02/24/streamlining-react-elements.md
+++ b/beta/src/pages/blog/2015/02/24/streamlining-react-elements.md
@@ -8,7 +8,7 @@ React v0.13 is right around the corner and so we wanted to discuss some upcoming
 
 If you use React in an idiomatic way, chances are, you’ll never see any of these warnings. In that case, you can skip this blog post. You can just enjoy the benefits! These changes will unlock simplified semantics, better error messages, stack traces and compiler optimizations!
 
-## Immutable Props {#immutable-props}
+## Immutable Props {/*immutable-props*/}
 
 In React 0.12, the props object was mutable. It allows you to do patterns like this:
 
@@ -22,7 +22,7 @@ if (shouldUseFoo) {
 
 The problem is that we don’t have a convenient way to tell when you’re done mutating.
 
-### Problem: Mutating Props You Don’t Own {#problem-mutating-props-you-dont-own}
+### Problem: Mutating Props You Don’t Own {/*problem-mutating-props-you-dont-own*/}
 
 If you mutate something, you destroy the original value. Therefore, there is nothing to diff against. Imagine something like this:
 
@@ -40,13 +40,13 @@ Additionally, if this element is reused in other places or used to switch back a
 
 It has always been broken to mutate the props of something passed into you. The problem is that we can’t warn you about this special case if you accidentally do this.
 
-### Problem: Too Late Validation {#problem-too-late-validation}
+### Problem: Too Late Validation {/*problem-too-late-validation*/}
 
 In React 0.12, we do PropType validation very deep inside React during mounting. This means that by the time you get an error, the debugger stack is long gone. This makes it difficult to find complex issues during debugging. We have to do this since it is fairly common for extra props to be added between the call to React.createElement and the mount time. So the type is incomplete until then.
 
 The static analysis in Flow is also impaired by this. There is no convenient place in the code where Flow can determine that the props are finalized.
 
-### Solution: Immutable Props {#solution-immutable-props}
+### Solution: Immutable Props {/*solution-immutable-props*/}
 
 Therefore, we would like to be able to freeze the element.props object so that it is immediately immutable at the JSX callsite (or createElement). In React 0.13 we will start warning you if you mutate `element.props` after this point.
 
@@ -79,7 +79,7 @@ return <Foo nestedObject={this.state.myModel} />;
 
 In this case it's still ok to mutate the myModel object in state. We recommend that you use fully immutable models. E.g. by using immutable-js. However, we realize that mutable models are still convenient in many cases. Therefore we're only considering shallow freezing the props object that belongs to the ReactElement itself. Not nested objects.
 
-### Solution: Early PropType Warnings {#solution-early-proptype-warnings}
+### Solution: Early PropType Warnings {/*solution-early-proptype-warnings*/}
 
 We will also start warning you for PropTypes at the JSX or createElement callsite. This will help debugging as you’ll have the stack trace right there. Similarly, Flow also validates PropTypes at this callsite.
 
@@ -90,7 +90,7 @@ var element1 = <Foo />; // extra prop is optional
 var element2 = React.addons.cloneWithProps(element1, {extra: 'prop'});
 ```
 
-## Owner {#owner}
+## Owner {/*owner*/}
 
 In React each child has both a "parent" and an “owner”. The owner is the component that created a ReactElement. I.e. the render method which contains the JSX or createElement callsite.
 
@@ -110,7 +110,7 @@ In this example, the owner of the `span` is `Foo` but the parent is the `div`.
 
 There is also an undocumented feature called "context" that also relies on the concept of an “owner” to pass hidden props down the tree.
 
-### Problem: The Semantics are Opaque and Confusing {#problem-the-semantics-are-opaque-and-confusing}
+### Problem: The Semantics are Opaque and Confusing {/*problem-the-semantics-are-opaque-and-confusing*/}
 
 The problem is that these are hidden artifacts attached to the ReactElement. In fact, you probably didn’t even know about it. It silently changes semantics. Take this for example:
 
@@ -125,7 +125,7 @@ class Component {
 
 These two inputs have different owners, therefore React will not keep its state when the conditional switches. There is nothing in the code to indicate that. Similarly, if you use `React.addons.cloneWithProps`, the owner changes.
 
-### Problem: Timing Matters {#problem-timing-matters}
+### Problem: Timing Matters {/*problem-timing-matters*/}
 
 The owner is tracked by the currently executing stack. This means that the semantics of a ReactElement varies depending on when it is executed. Take this example:
 
@@ -144,25 +144,25 @@ class B {
 
 The owner of the `span` is actually `B`, not `A` because of the timing of the callback. This all adds complexity and suffers from similar problems as mutation.
 
-### Problem: It Couples JSX to React {#problem-it-couples-jsx-to-react}
+### Problem: It Couples JSX to React {/*problem-it-couples-jsx-to-react*/}
 
 Have you wondered why JSX depends on React? Couldn’t the transpiler have that built-in to its runtime? The reason you need to have `React.createElement` in scope is because we depend on internal state of React to capture the current "owner". Without this, you wouldn’t need to have React in scope.
 
-### Solution: Make Context Parent-Based Instead of Owner-Based {#solution-make-context-parent-based-instead-of-owner-based}
+### Solution: Make Context Parent-Based Instead of Owner-Based {/*solution-make-context-parent-based-instead-of-owner-based*/}
 
 The first thing we’re doing is warning you if you’re using the "owner" feature in a way that relies on it propagating through owners. Instead, we’re planning on propagating it through parents to its children. In almost all cases, this shouldn’t matter. In fact, parent-based contexts is simply a superset.
 
-### Solution: Remove the Semantic Implications of Owner {#solution-remove-the-semantic-implications-of-owner}
+### Solution: Remove the Semantic Implications of Owner {/*solution-remove-the-semantic-implications-of-owner*/}
 
 It turns out that there are very few cases where owners are actually important part of state-semantics. As a precaution, we’ll warn you if it turns out that the owner is important to determine state. In almost every case this shouldn’t matter. Unless you’re doing some weird optimizations, you shouldn’t see this warning.
 
-### Pending: Change the refs Semantics {#pending-change-the-refs-semantics}
+### Pending: Change the refs Semantics {/*pending-change-the-refs-semantics*/}
 
 Refs are still based on "owner". We haven’t fully solved this special case just yet.
 
 In 0.13 we introduced a new callback-refs API that doesn’t suffer from these problems but we’ll keep on a nice declarative alternative to the current semantics for refs. As always, we won’t deprecate something until we’re sure that you’ll have a nice upgrade path.
 
-## Keyed Objects as Maps {#keyed-objects-as-maps}
+## Keyed Objects as Maps {/*keyed-objects-as-maps*/}
 
 In React 0.12, and earlier, you could use keyed objects to provide an external key to an element or a set. This pattern isn’t actually widely used. It shouldn’t be an issue for most of you.
 
@@ -170,11 +170,11 @@ In React 0.12, and earlier, you could use keyed objects to provide an external k
 <div>{{a: <span />, b: <span />}}</div>
 ```
 
-### Problem: Relies on Enumeration Order {#problem-relies-on-enumeration-order}
+### Problem: Relies on Enumeration Order {/*problem-relies-on-enumeration-order*/}
 
 The problem with this pattern is that it relies on enumeration order of objects. This is technically unspecified, even though implementations now agree to use insertion order. Except for the special case when numeric keys are used.
 
-### Problem: Using Objects as Maps is Bad {#problem-using-objects-as-maps-is-bad}
+### Problem: Using Objects as Maps is Bad {/*problem-using-objects-as-maps-is-bad*/}
 
 It is generally accepted that using objects as maps screw up type systems, VM optimizations, compilers etc. It is much better to use a dedicated data structure like ES6 Maps.
 
@@ -188,13 +188,13 @@ return <div>{children}</div>;
 
 Imagine if `item.title === '__proto__'` for example.
 
-### Problem: Can’t be Differentiated from Arbitrary Objects {#problem-cant-be-differentiated-from-arbitrary-objects}
+### Problem: Can’t be Differentiated from Arbitrary Objects {/*problem-cant-be-differentiated-from-arbitrary-objects*/}
 
 Since these objects can have any keys with almost any value, we can’t differentiate them from a mistake. If you put some random object, we will try our best to traverse it and render it, instead of failing with a helpful warning. In fact, this is one of the few places where you can accidentally get an infinite loop in React.
 
 To differentiate ReactElements from one of these objects, we have to tag them with `_isReactElement`. This is another issue preventing us from inlining ReactElements as simple object literals.
 
-### Solution: Just use an Array and key={…} {#solution-just-use-an-array-and-key}
+### Solution: Just use an Array and key={…} {/*solution-just-use-an-array-and-key*/}
 
 Most of the time you can just use an array with keyed ReactElements.
 
@@ -203,7 +203,7 @@ var children = items.map((item) => <span key={item.title} />);
 <div>{children}</div>;
 ```
 
-### Solution: React.addons.createFragment {#solution-reactaddonscreatefragment}
+### Solution: React.addons.createFragment {/*solution-reactaddonscreatefragment*/}
 
 However, this is not always possible if you’re trying to add a prefix key to an unknown set (e.g. this.props.children). It is also not always the easiest upgrade path. Therefore, we are adding a helper to `React.addons` called `createFragment()`. This accepts a keyed object and returns an opaque type.
 
@@ -215,7 +215,7 @@ The exact signature of this kind of fragment will be determined later. It will l
 
 Note: This will still not be valid as the direct return value of `render()`. Unfortunately, they still need to be wrapped in a `<div />` or some other element.
 
-## Compiler Optimizations: Unlocked! {#compiler-optimizations-unlocked}
+## Compiler Optimizations: Unlocked! {/*compiler-optimizations-unlocked*/}
 
 These changes also unlock several possible compiler optimizations for static content in React 0.14. These optimizations were previously only available to template-based frameworks. They will now also be possible for React code! Both for JSX and `React.createElement/Factory`\*!
 
@@ -227,7 +227,7 @@ See these GitHub Issues for a deep dive into compiler optimizations:
 
 \* If you use the recommended pattern of explicit React.createFactory calls on the consumer side - since they are easily statically analyzed.
 
-## Rationale {#rationale}
+## Rationale {/*rationale*/}
 
 I thought that these changes were particularly important because the mere existence of these patterns means that even components that DON’T use these patterns have to pay the price. There are other problematic patterns such as mutating state, but they’re at least localized to a component subtree so they don’t harm the ecosystem.
 

--- a/beta/src/pages/blog/2015/03/03/react-v0.13-rc2.md
+++ b/beta/src/pages/blog/2015/03/03/react-v0.13-rc2.md
@@ -25,7 +25,7 @@ We've also published version `0.13.0-rc2` of the `react` and `react-tools` packa
 
 ---
 
-## React.cloneElement {#reactcloneelement}
+## React.cloneElement {/*reactcloneelement*/}
 
 In React v0.13 RC2 we will introduce a new API, similar to `React.addons.cloneWithProps`, with this signature:
 

--- a/beta/src/pages/blog/2015/03/04/community-roundup-25.md
+++ b/beta/src/pages/blog/2015/03/04/community-roundup-25.md
@@ -3,7 +3,7 @@ title: 'Community Round-up #25'
 author: [matthewjohnston4]
 ---
 
-## React 101 {#react-101}
+## React 101 {/*react-101*/}
 
 Interest in React has been exploding recently, so it's a good time to explore some great recent tutorials and videos that cover getting started.
 
@@ -21,7 +21,7 @@ Our own [Sebastian Markbåge](https://github.com/sebmarkbage) was on the [Web Pl
 
 <iframe style={{border: 'none'}} src="//html5-player.libsyn.com/embed/episode/id/3370114/height/75/width/200/theme/standard-mini/direction/no/autoplay/no/autonext/no/thumbnail/yes/preload/no/no_addthis/no/" height={26} width="100%" scrolling="no" allowFullScreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen />
 
-## Community Additions {#community-additions}
+## Community Additions {/*community-additions*/}
 
 [Formidable Labs](https://github.com/FormidableLabs) have been busy, as they've also[ just launched Radium](http://projects.formidablelabs.com/radium/), a React component that provides you with the ability to use inline styles instead of CSS. They're also [looking for some help](http://projects.formidablelabs.com/radium-bootstrap/) contributing to a Radium Bootstrap implementation.
 
@@ -33,7 +33,7 @@ Our own [Sebastian Markbåge](https://github.com/sebmarkbage) was on the [Web Pl
 
 [react-meteor](https://github.com/reactjs/react-meteor), a package that replaces the default templating system of the Meteor platform with React, recently received a big update.
 
-## Rebuilding with React {#rebuilding-with-react}
+## Rebuilding with React {/*rebuilding-with-react*/}
 
 [Rich Manalang](https://github.com/rmanalan) from Atlassian [explains why](https://developer.atlassian.com/blog/2015/02/rebuilding-hipchat-with-react/) they rebuilt their HipChat web client from scratch using React, and how they're already using it to rebuild their native desktop clients.
 
@@ -45,11 +45,11 @@ A team from New Zealand called [Atomic](https://atomic.io/) is [building web and
 
 <center><a href="http://polarrist.tumblr.com/post/111290422225/polarr-photo-editor-2-0-alpha-is-here"><img src="/images/blog/polarr.jpg"/></a></center>
 
-## It's F8! {#its-f8}
+## It's F8! {/*its-f8*/}
 
 F8 2015 is just around the corner, and you can [sign up for the video streams](https://www.fbf8.com/stream.html) in advance because we're sure to be covering all things React.
 
-## Meetups {#meetups}
+## Meetups {/*meetups*/}
 
 <table><tr><td width="50%" valign="top">
 <blockquote class="twitter-tweet" lang="en"><p>Our <a href="https://twitter.com/reactjs">@reactjs</a> meetup is in full effect <a href="https://twitter.com/hashtag/ReactJS?src=hash">#ReactJS</a> &#10;&#10;btw bathroom code is 6012 lol <a href="http://t.co/7iUpvmm3zz">pic.twitter.com/7iUpvmm3zz</a></p>&mdash; littleBits (@littleBits) <a href="https://twitter.com/littleBits/status/570373833028472832">February 25, 2015</a></blockquote>

--- a/beta/src/pages/blog/2015/03/10/react-v0.13.md
+++ b/beta/src/pages/blog/2015/03/10/react-v0.13.md
@@ -29,11 +29,11 @@ We've also published version `0.13.0` of the `react` and `react-tools` packages 
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Breaking Changes {#breaking-changes}
+#### Breaking Changes {/*breaking-changes*/}
 
 - Deprecated patterns that warned in 0.12 no longer work: most prominently, calling component classes without using JSX or React.createElement and using non-component functions with JSX or createElement
 - Mutating `props` after an element is created is deprecated and will cause warnings in development mode; future versions of React will incorporate performance optimizations assuming that props aren't mutated
@@ -43,7 +43,7 @@ We've also published version `0.13.0` of the `react` and `react-tools` packages 
 - `setState` and `forceUpdate` on an unmounted component now warns instead of throwing. That avoids a possible race condition with Promises.
 - Access to most internal properties has been completely removed, including `this._pendingState` and `this._rootNodeID`.
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Support for using ES6 classes to build React components; see the [v0.13.0 beta 1 notes](/blog/2015/01/27/react-v0.13.0-beta-1.html) for details.
 - Added new top-level API `React.findDOMNode(component)`, which should be used in place of `component.getDOMNode()`. The base class for ES6-based components will not have `getDOMNode`. This change will enable some more patterns moving forward.
@@ -52,37 +52,37 @@ We've also published version `0.13.0` of the `react` and `react-tools` packages 
 - `this.setState()` can now take a function as the first argument for transactional state updates, such as `this.setState((state, props) => ({count: state.count + 1}));` – this means that you no longer need to use `this._pendingState`, which is now gone.
 - Support for iterators and immutable-js sequences as children.
 
-#### Deprecations {#deprecations}
+#### Deprecations {/*deprecations*/}
 
 - `ComponentClass.type` is deprecated. Just use `ComponentClass` (usually as `element.type === ComponentClass`).
 - Some methods that are available on `createClass`-based components are removed or deprecated from ES6 classes (`getDOMNode`, `replaceState`, `isMounted`, `setProps`, `replaceProps`).
 
-### React with Add-Ons {#react-with-add-ons}
+### React with Add-Ons {/*react-with-add-ons*/}
 
-#### New Features {#new-features-1}
+#### New Features {/*new-features-1*/}
 
 - [`React.addons.createFragment` was added](/docs/create-fragment.html) for adding keys to entire sets of children.
 
-#### Deprecations {#deprecations-1}
+#### Deprecations {/*deprecations-1*/}
 
 - `React.addons.classSet` is now deprecated. This functionality can be replaced with several freely available modules. [classnames](https://www.npmjs.com/package/classnames) is one such module.
 - Calls to `React.addons.cloneWithProps` can be migrated to use `React.cloneElement` instead – make sure to merge `style` and `className` manually if desired.
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
-#### Breaking Changes {#breaking-changes-1}
+#### Breaking Changes {/*breaking-changes-1*/}
 
 - When transforming ES6 syntax, `class` methods are no longer enumerable by default, which requires `Object.defineProperty`; if you support browsers such as IE8, you can pass `--target es3` to mirror the old behavior
 
-#### New Features {#new-features-2}
+#### New Features {/*new-features-2*/}
 
 - `--target` option is available on the jsx command, allowing users to specify and ECMAScript version to target.
   - `es5` is the default.
   - `es3` restores the previous default behavior. An additional transform is added here to ensure the use of reserved words as properties is safe (eg `this.static` will become `this['static']` for IE8 compatibility).
 - The transform for the call spread operator has also been enabled.
 
-### JSX {#jsx}
+### JSX {/*jsx*/}
 
-#### Breaking Changes {#breaking-changes-2}
+#### Breaking Changes {/*breaking-changes-2*/}
 
 - A change was made to how some JSX was parsed, specifically around the use of `>` or `}` when inside an element. Previously it would be treated as a string but now it will be treated as a parse error. The [`jsx_orphaned_brackets_transformer`](https://www.npmjs.com/package/jsx_orphaned_brackets_transformer) package on npm can be used to find and fix potential issues in your JSX code.

--- a/beta/src/pages/blog/2015/03/16/react-v0.13.1.md
+++ b/beta/src/pages/blog/2015/03/16/react-v0.13.1.md
@@ -22,25 +22,25 @@ We've also published version `0.13.1` of the `react` and `react-tools` packages 
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Don't throw when rendering empty `<select>` elements
 - Ensure updating `style` works when transitioning from `null`
 
-### React with Add-Ons {#react-with-add-ons}
+### React with Add-Ons {/*react-with-add-ons*/}
 
-#### Bug Fixes {#bug-fixes-1}
+#### Bug Fixes {/*bug-fixes-1*/}
 
 - TestUtils: Don't warn about `getDOMNode` for ES6 classes
 - TestUtils: Ensure wrapped full page components (`<html>`, `<head>`, `<body>`) are treated as DOM components
 - Perf: Stop double-counting DOM components
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
-#### Bug Fixes {#bug-fixes-2}
+#### Bug Fixes {/*bug-fixes-2*/}
 
 - Fix option parsing for `--non-strict-es6module`

--- a/beta/src/pages/blog/2015/03/19/building-the-facebook-news-feed-with-relay.md
+++ b/beta/src/pages/blog/2015/03/19/building-the-facebook-news-feed-with-relay.md
@@ -9,7 +9,7 @@ We're working hard to prepare GraphQL and Relay for public release. In the meant
 
 <br/>
 
-## The Relay Architecture {#the-relay-architecture}
+## The Relay Architecture {/*the-relay-architecture*/}
 
 The diagram below shows the main parts of the Relay architecture on the client and the server:
 
@@ -26,7 +26,7 @@ This post will focus on **Relay components** that describe encapsulated units of
 
 <br/>
 
-## A Relay Application {#a-relay-application}
+## A Relay Application {/*a-relay-application*/}
 
 To see how components work and can be composed, let's implement a basic version of the Facebook News Feed in Relay. Our application will have two components: a `<NewsFeed>` that renders a list of `<Story>` items. We'll introduce the plain React version of each component first and then convert it to a Relay component. The goal is something like the following:
 
@@ -34,7 +34,7 @@ To see how components work and can be composed, let's implement a basic version 
 
 <br/>
 
-## The `<Story>` Begins {#the-story-begins}
+## The `<Story>` Begins {/*the-story-begins*/}
 
 The first step is a React `<Story>` component that accepts a `story` prop with the story's text and author information. Note that all examples uses ES6 syntax and elide presentation details to focus on the pattern of data access.
 
@@ -56,7 +56,7 @@ export default class Story extends React.Component {
 
 <br/>
 
-## What's the `<Story>`? {#whats-the-story}
+## What's the `<Story>`? {/*whats-the-story*/}
 
 Relay automates the process of fetching data for components by wrapping existing React components in Relay containers (themselves React components):
 
@@ -102,7 +102,7 @@ Queries use ES6 template literals tagged with the `Relay.QL` function. Similar t
 
 <br/>
 
-## `<Story>`s on Demand {#storys-on-demand}
+## `<Story>`s on Demand {/*storys-on-demand*/}
 
 We can render a Relay component by providing Relay with the component (`<Story>`) and the ID of the data (a story ID). Given this information, Relay will first fetch the results of the query and then `render()` the component. The value of `props.story` will be a plain JavaScript object such as the following:
 
@@ -126,7 +126,7 @@ The diagram below shows how Relay containers make data available to our React co
 
 <br/>
 
-## `<NewsFeed>` Worthy {#newsfeed-worthy}
+## `<NewsFeed>` Worthy {/*newsfeed-worthy*/}
 
 Now that the `<Story>` is over we can continue with the `<NewsFeed>` component. Again, we'll start with a React version:
 
@@ -155,7 +155,7 @@ module.exports = NewsFeed;
 
 <br/>
 
-## All the News Fit to be Relayed {#all-the-news-fit-to-be-relayed}
+## All the News Fit to be Relayed {/*all-the-news-fit-to-be-relayed*/}
 
 `<NewsFeed>` has two new requirements: it composes `<Story>` and requests more data at runtime.
 
@@ -209,7 +209,7 @@ Now when `loadMore()` is called, Relay will send a GraphQL request for the addit
 
 <br/>
 
-## In Conclusion {#in-conclusion}
+## In Conclusion {/*in-conclusion*/}
 
 These two components form a solid core for our application. With the use of Relay containers and GraphQL queries, we've enabled the following benefits:
 

--- a/beta/src/pages/blog/2015/03/30/community-roundup-26.md
+++ b/beta/src/pages/blog/2015/03/30/community-roundup-26.md
@@ -7,13 +7,13 @@ We open sourced React Native last week and the community reception blew away all
 
 <blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/hashtag/reactnative?src=hash">#reactnative</a> is like when you get a new expansion pack, and everybody is running around clueless about which NPC to talk to for the quests</p>&mdash; Ryan Florence (@ryanflorence) <a href="https://twitter.com/ryanflorence/status/581810423554543616">March 28, 2015</a></blockquote>
 
-## When is React Native Android coming? {#when-is-react-native-android-coming}
+## When is React Native Android coming? {/*when-is-react-native-android-coming*/}
 
 **Give us 6 months**. At Facebook, we strive to only open-source projects that we are using in production. While the Android backend for React Native is starting to work (see video below at 37min), it hasn't been shipped to any users yet. There's a lot of work that goes into open-sourcing a project, and we want to do it right so that you have a great experience when using it.
 
 <iframe width="650" height="315" src="https://www.youtube-nocookie.com/embed/X6YbAKiLCLU?start=2220" frameborder="0" allowfullscreen></iframe>
 
-## Ray Wenderlich - Property Finder {#ray-wenderlich---property-finder}
+## Ray Wenderlich - Property Finder {/*ray-wenderlich---property-finder*/}
 
 If you are getting started with React Native, you should absolutely [use this tutorial](http://www.raywenderlich.com/99473/introducing-react-native-building-apps-javascript) from Colin Eberhardt. It goes through all the steps to make a reasonably complete app.
 
@@ -21,51 +21,51 @@ If you are getting started with React Native, you should absolutely [use this tu
 
 Colin also [blogged about his experience using React Native](http://blog.scottlogic.com/2015/03/26/react-native-retrospective.html) for a few weeks and gives his thoughts on why you would or wouldn't use it.
 
-## The Changelog {#the-changelog}
+## The Changelog {/*the-changelog*/}
 
 Spencer Ahrens and I had the great pleasure to talk about React Native on [The Changelog](https://thechangelog.com/149/) podcast. It was really fun to chat for an hour, I hope that you'll enjoy listening to it. :)
 
 <audio src="https://cdn.changelog.com/uploads/podcast/149/the-changelog-149.mp3" controls="controls" style={{ width: '100%' }}></audio>
 
-## Hacker News {#hacker-news}
+## Hacker News {/*hacker-news*/}
 
 Less than 24 hours after React Native was open sourced, Simarpreet Singh built an [Hacker News reader app from scratch](https://github.com/iSimar/HackerNews-React-Native). It's unbelievable how fast he was able to pull it off!
 
 [![](/images/blog/hacker-news-react-native.png)](https://github.com/iSimar/HackerNews-React-Native)
 
-## Parse + React {#parse--react}
+## Parse + React {/*parse--react*/}
 
 There's a huge ecosystem of JavaScript modules on npm and React Native was designed to work well with the ones that don't have DOM dependencies. Parse is a great example; you can `npm install parse` on your React Native project and it'll work as is. :) We still have [a](https://github.com/facebook/react-native/issues/406) [few](https://github.com/facebook/react-native/issues/370) [issues](https://github.com/facebook/react-native/issues/316) to solve; please create an issue if your favorite library doesn't work out of the box.
 
 [![](/images/blog/parse-react.jpg)](http://blog.parse.com/2015/03/25/parse-and-react-shared-chemistry/)
 
-## tcomb-form-native {#tcomb-form-native}
+## tcomb-form-native {/*tcomb-form-native*/}
 
 Giulio Canti is the author of the [tcomb-form library](https://github.com/gcanti/tcomb-form) for React. He already [ported it to React Native](https://github.com/gcanti/tcomb-form-native) and it looks great!
 
 [![](/images/blog/tcomb-react-native.png)](https://github.com/gcanti/tcomb-form-native)
 
-## Facebook Login with React Native {#facebook-login-with-react-native}
+## Facebook Login with React Native {/*facebook-login-with-react-native*/}
 
 One of the reason we built React Native is to be able to use all the libraries in the native ecosystem. Brent Vatne leads the way and explains [how to use Facebook Login with React Native](http://brentvatne.ca/facebook-login-with-react-native/).
 
-## Modus Create {#modus-create}
+## Modus Create {/*modus-create*/}
 
 Jay Garcia spent a lot of time during the beta working on a NES music player with React Native. He wrote a blog post to share his experience and explains some code snippets.
 
 [![](/images/blog/modus-create.gif)](http://moduscreate.com/react-native-has-landed/)
 
-## React Native with Babel and webpack {#react-native-with-babel-and-webpack}
+## React Native with Babel and webpack {/*react-native-with-babel-and-webpack*/}
 
 React Native ships with a custom packager and custom ES6 transforms instead of using what the open source community settled on such as [webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/). The main reason for this is performance – we couldn't get those tools to have sub-second reload time on a large codebase.
 
 Roman Liutikov found a way to [use webpack and Babel to run on React Native](https://github.com/roman01la/react-native-babel)! In the future, we want to work with those projects to provide cleaner extension mechanisms.
 
-## A Dynamic, Crazy, Native Mobile Future—Powered by JavaScript {#a-dynamic-crazy-native-mobile-futurepowered-by-javascript}
+## A Dynamic, Crazy, Native Mobile Future—Powered by JavaScript {/*a-dynamic-crazy-native-mobile-futurepowered-by-javascript*/}
 
 Clay Allsopp wrote a post about [all the crazy things you could do with a JavaScript engine that renders native views](https://medium.com/@clayallsopp/a-dynamic-crazy-native-mobile-future-powered-by-javascript-70f2d56b1987). What about native embeds, seamless native browser, native search engine or even app generation...
 
-## Random Tweet {#random-tweet}
+## Random Tweet {/*random-tweet*/}
 
 We've spent a lot of efforts getting the onboarding as easy as possible and we're really happy that people noticed. We still have a lot of work to do on documentation, stay tuned!
 

--- a/beta/src/pages/blog/2015/04/17/react-native-v0.4.md
+++ b/beta/src/pages/blog/2015/04/17/react-native-v0.4.md
@@ -7,7 +7,7 @@ It's been three weeks since we open sourced React Native and there's been some i
 
 I'd especially like to thank community members Brent Vatne and James Ide who have both already contributed meaningfully to the project and have been extremely helpful on IRC and with issues and pull requests
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
 The main focus of the past few weeks has been to make React Native the best possible experience for people outside of Facebook. Here's a high level summary of what's happened since we open sourced:
 
@@ -19,6 +19,6 @@ The main focus of the past few weeks has been to make React Native the best poss
 - **Patent Grant**: Many of you had concerns and questions around the PATENTS file. We pushed [a new version of the grant](https://code.facebook.com/posts/1639473982937255/updating-our-open-source-patent-grant/).
 - **Per commit history**: In order to synchronize from Facebook to GitHub, we used to do one giant commit every few days. We improved our tooling and now have per commit history that maintains author information (both internal and external from pull requests), and we retroactively applied this to historical diffs to provide proper attribution.
 
-## Where are we going? {#where-are-we-going}
+## Where are we going? {/*where-are-we-going*/}
 
 In addition to supporting pull requests, issues, and general improvements, we're also working hard on our internal React Native integrations and on React Native for Android.

--- a/beta/src/pages/blog/2015/04/18/react-v0.13.2.md
+++ b/beta/src/pages/blog/2015/04/18/react-v0.13.2.md
@@ -20,11 +20,11 @@ We've also published version `0.13.2` of the `react` and `react-tools` packages 
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Added `strokeDashoffset`, `flexPositive`, `flexNegative` to the list of unitless CSS properties
 - Added support for more DOM properties:
@@ -32,19 +32,19 @@ We've also published version `0.13.2` of the `react` and `react-tools` packages 
   - `high`, `low`, `optimum` - for `<meter>` elements
   - `unselectable` - IE-specific property to prevent user selection
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Fixed a case where re-rendering after rendering null didn't properly pass context
 - Fixed a case where re-rendering after rendering with `style={null}` didn't properly update `style`
 - Update `uglify` dependency to prevent a bug in IE8
 - Improved warnings
 
-### React with Add-Ons {#react-with-add-ons}
+### React with Add-Ons {/*react-with-add-ons*/}
 
-#### Bug Fixes {#bug-fixes-1}
+#### Bug Fixes {/*bug-fixes-1*/}
 
 - Immutabilty Helpers: Ensure it supports `hasOwnProperty` as an object key
 
-### React Tools {#react-tools}
+### React Tools {/*react-tools*/}
 
 - Improve documentation for new options

--- a/beta/src/pages/blog/2015/05/01/graphql-introduction.md
+++ b/beta/src/pages/blog/2015/05/01/graphql-introduction.md
@@ -11,7 +11,7 @@ GraphQL was not invented to enable Relay. In fact, GraphQL predates Relay by nea
 
 We plan to open-source a reference implementation of a GraphQL server and publish a language specification in the coming months. Our goal is to evolve GraphQL to adapt to a wide range of backends, so that projects and companies can use this technology to access their own data. We believe that this is a compelling way to structure servers and to provide powerful abstractions, frameworks and tools – including, but not exclusively, Relay – for product developers.
 
-## What is GraphQL? {#what-is-graphql}
+## What is GraphQL? {/*what-is-graphql*/}
 
 A GraphQL query is a string interpreted by a server that returns data in a specified format. Here is an example query:
 
@@ -60,11 +60,11 @@ We will dig into the syntax and semantics of GraphQL in a later post, but even a
 - **Strongly-typed:** GraphQL is strongly-typed. Given a query, tooling can ensure that the query is both syntactically correct and valid within the GraphQL type system before execution, i.e. at development time, and the server can make certain guarantees about the shape and nature of the response. This makes it easier to build high quality client tools.
 - **Introspective:** GraphQL is introspective. Clients and tools can query the type system using the GraphQL syntax itself. This is a powerful platform for building tools and client software, such as automatic parsing of incoming data into strongly-typed interfaces. It is especially useful in statically typed languages such as Swift, Objective-C and Java, as it obviates the need for repetitive and error-prone code to shuffle raw, untyped JSON into strongly-typed business objects.
 
-## Why invent something new? {#why-invent-something-new}
+## Why invent something new? {/*why-invent-something-new*/}
 
 Obviously GraphQL is not the first system to manage client-server interactions. In today's world there are two dominant architectural styles for client-server interaction: REST and _ad hoc_ endpoints.
 
-### REST {#rest}
+### REST {/*rest*/}
 
 REST, an acronym for Representational State Transfer, is an architectural style rather than a formal protocol. There is actually much debate about what exactly REST is and is not. We wish to avoid such debates. We are interested in the typical attributes of systems that _self-identify_ as REST, rather than systems which are formally REST.
 
@@ -81,7 +81,7 @@ Nearly all externally facing REST APIs we know of trend or end up in these non-i
 
 Because of multiple round-trips and over-fetching, applications built in the REST style inevitably end up building _ad hoc_ endpoints that are superficially in the REST style. These actually couple the data to a particular view which explicitly violates one of REST's major goals. Most REST systems of any complexity end up as a continuum of endpoints that span from “traditional” REST to _ad hoc_ endpoints.
 
-### Ad Hoc Endpoints {#ad-hoc-endpoints}
+### Ad Hoc Endpoints {/*ad-hoc-endpoints*/}
 
 Many applications have no formalized client-server contract. Product developers access server capabilities through _ad hoc_ endpoints and write custom code to fetch the data they need. Servers define procedures, and they return data. This approach has the virtue of simplicity, but can often become untenable as systems age.
 
@@ -96,6 +96,6 @@ This is a liberating platform for product developers. With GraphQL, no more cont
 
 Product developers are free to focus on their client software and requirements while rarely leaving their development environment; they can more confidently support shipped clients as a system evolves; and they are using a protocol designed to operate well within the constraints of mobile applications. Product developers can query for exactly what they want, in the way they think about it, across their entire application's data model.
 
-## What's next? {#whats-next}
+## What's next? {/*whats-next*/}
 
 Over the coming months, we will share more technical details about GraphQL, including additional language features, tools that support it, and how it is built and used at Facebook. These posts will culminate in a formal specification of GraphQL to guide implementors across various languages and platforms. We also plan on releasing a reference implementation in the summer, in order to provide a basis for custom deployments and a platform for experimentation. We're incredibly excited to share this system and work with the open source community to improve it.

--- a/beta/src/pages/blog/2015/05/08/react-v0.13.3.md
+++ b/beta/src/pages/blog/2015/05/08/react-v0.13.3.md
@@ -20,23 +20,23 @@ We've also published version `0.13.3` of the `react` and `react-tools` packages 
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React Core {#react-core}
+### React Core {/*react-core*/}
 
-#### New Features {#new-features}
+#### New Features {/*new-features*/}
 
 - Added `clipPath` element and attribute for SVG
 - Improved warnings for deprecated methods in plain JS classes
 
-#### Bug Fixes {#bug-fixes}
+#### Bug Fixes {/*bug-fixes*/}
 
 - Loosened `dangerouslySetInnerHTML` restrictions so `{__html: undefined}` will no longer throw
 - Fixed extraneous context warning with non-pure `getChildContext`
 - Ensure `replaceState(obj)` retains prototype of `obj`
 
-### React with Add-ons {#react-with-add-ons}
+### React with Add-ons {/*react-with-add-ons*/}
 
-### Bug Fixes {#bug-fixes-1}
+### Bug Fixes {/*bug-fixes-1*/}
 
 - Test Utils: Ensure that shallow rendering works when components define `contextTypes`

--- a/beta/src/pages/blog/2015/06/12/deprecating-jstransform-and-react-tools.md
+++ b/beta/src/pages/blog/2015/06/12/deprecating-jstransform-and-react-tools.md
@@ -9,21 +9,21 @@ As many people have noticed already, React and React Native have both switched t
 
 react-tools has always been a very thin wrapper around JSTransform. It has served as a great tool for the community to get up and running, but at this point we're ready to [let it go](https://www.youtube.com/watch?v=moSFlvxnbgk). We won't ship a new version for v0.14.
 
-## Migrating to Babel {#migrating-to-babel}
+## Migrating to Babel {/*migrating-to-babel*/}
 
 Many people in the React and broader JavaScript community have already adopted Babel. It has [integrations with a number of tools](http://babeljs.io/docs/setup/). Depending on your tool, you'll want to read up on the instructions.
 
 We've been working with the Babel team as we started making use of it and we're confident that it will be the right tool to use with React.
 
-## Other Deprecations {#other-deprecations}
+## Other Deprecations {/*other-deprecations*/}
 
-### esprima-fb {#esprima-fb}
+### esprima-fb {/*esprima-fb*/}
 
 As a result of no longer maintaining JSTransform, we no longer have a need to maintain our Esprima fork ([esprima-fb](https://github.com/facebook/esprima/)). The upstream Esprima and other esprima-based forks, like Espree, have been doing an excellent job of supporting new language features recently. If you have a need of an esprima-based parser, we encourage you to look into using one of those.
 
 Alternatively, if you need to parse JSX, take a look at [acorn](https://github.com/marijnh/acorn) parser in combination with [acorn-jsx](https://github.com/RReverser/acorn-jsx) plugin which is used inside of Babel and thus always supports the latest syntax.
 
-### JSXTransformer {#jsxtransformer}
+### JSXTransformer {/*jsxtransformer*/}
 
 JSXTransformer is another tool we built specifically for consuming JSX in the browser. It was always intended as a quick way to prototype code before setting up a build process. It would look for `<script>` tags with `type="text/jsx"` and then transform and run. This ran the same code that react-tools ran on the server. Babel ships with [a nearly identical tool](https://babeljs.io/docs/usage/browser/), which has already been integrated into [JS Bin](https://jsbin.com/).
 

--- a/beta/src/pages/blog/2015/07/03/react-v0.14-beta-1.md
+++ b/beta/src/pages/blog/2015/07/03/react-v0.14-beta-1.md
@@ -9,7 +9,7 @@ With React 0.14, we're continuing to let React mature and to make minor changes 
 
 You can install the new beta with `npm install react@0.14.0-beta1` and `npm install react-dom@0.14.0-beta1`. As mentioned in [Deprecating react-tools](/blog/2015/06/12/deprecating-jstransform-and-react-tools.html), we're no longer updating the react-tools package so this release doesn't include a new version of it. Please try the new version out and let us know what you think, and please do file issues on our GitHub repo if you run into any problems.
 
-## Two Packages {#two-packages}
+## Two Packages {/*two-packages*/}
 
 As we look at packages like [react-native](https://github.com/facebook/react-native), [react-art](https://github.com/reactjs/react-art), [react-canvas](https://github.com/Flipboard/react-canvas), and [react-three](https://github.com/Izzimach/react-three), it's become clear that the beauty and essence of React has nothing to do with browsers or the DOM.
 
@@ -42,7 +42,7 @@ The addons have moved to separate packages as well: `react-addons-clone-with-pro
 
 For now, please use the same version of `react` and `react-dom` in your apps to avoid versioning problems -- but we plan to remove this requirement later. (This release includes the old methods in the `react` package with a deprecation warning, but they'll be removed completely in 0.15.)
 
-## DOM node refs {#dom-node-refs}
+## DOM node refs {/*dom-node-refs*/}
 
 The other big change we're making in this release is exposing refs to DOM components as the DOM node itself. That means: we looked at what you can do with a `ref` to a DOM component and realized that the only useful thing you can do with it is call `this.refs.giraffe.getDOMNode()` to get the underlying DOM node. In this release, `this.refs.giraffe` _is_ the actual DOM node.
 

--- a/beta/src/pages/blog/2015/08/03/new-react-devtools-beta.md
+++ b/beta/src/pages/blog/2015/08/03/new-react-devtools-beta.md
@@ -8,7 +8,7 @@ out!
 
 ![The full devtools gif](/images/blog/devtools-full.gif)
 
-## Why entirely new? {#why-entirely-new}
+## Why entirely new? {/*why-entirely-new*/}
 
 Perhaps the biggest reason was to create a defined API for dealing with
 internals, so that other tools could benefit as well and not have to depend on
@@ -20,18 +20,18 @@ is imperative, mutation-driven, and tightly integrated with Chrome-specific
 APIs. The new devtools are much less coupled to Chrome, and easier to reason
 about thanks to React.
 
-## What are the benefits? {#what-are-the-benefits}
+## What are the benefits? {/*what-are-the-benefits*/}
 
 - 100% React
 - Firefox compatible
 - React Native compatible
 - more extensible & hackable
 
-## Are there any new features? {#are-there-any-new-features}
+## Are there any new features? {/*are-there-any-new-features*/}
 
 Yeah!
 
-### The Tree View {#the-tree-view}
+### The Tree View {/*the-tree-view*/}
 
 ![The new tree view of the devtools](/images/blog/devtools-tree-view.png)
 
@@ -47,21 +47,21 @@ Yeah!
   - Show the source for a component in the "Sources" pane
   - Show the element in the "Elements" pane
 
-### Searching {#searching}
+### Searching {/*searching*/}
 
 Select the search bar (or press "/"), and start searching for a component by
 name.
 
 ![](/images/blog/devtools-search.gif)
 
-### The Side Pane {#the-side-pane}
+### The Side Pane {/*the-side-pane*/}
 
 - Now shows the `context` for a component
 - Right-click to store a prop/state value as a global variable
 
 ![](/images/blog/devtools-side-pane.gif)
 
-## How do I install it? {#how-do-i-install-it}
+## How do I install it? {/*how-do-i-install-it*/}
 
 First, disable the Chrome web store version, or it will break things. Then
 [download the .crx](https://github.com/facebook/react-devtools/releases) and
@@ -72,19 +72,19 @@ there.
 Once we've determined that there aren't any major regressions, we'll update
 the official web store version, and everyone will be automatically upgraded.
 
-### Also Firefox! {#also-firefox}
+### Also Firefox! {/*also-firefox*/}
 
 We also have an initial version of the devtools for Firefox, which you can
 download from the same [release page](https://github.com/facebook/react-devtools/releases).
 
-## Feedback welcome {#feedback-welcome}
+## Feedback welcome {/*feedback-welcome*/}
 
 Let us know what issues you run into
 [on GitHub](https://github.com/facebook/react-devtools/issues), and check out
 [the README](https://github.com/facebook/react-devtools/tree/devtools-next)
 for more info.
 
-## Update {#update}
+## Update {/*update*/}
 
 _August 12, 2015_
 

--- a/beta/src/pages/blog/2015/08/11/relay-technical-preview.md
+++ b/beta/src/pages/blog/2015/08/11/relay-technical-preview.md
@@ -3,11 +3,11 @@ title: 'Relay Technical Preview'
 author: [josephsavona]
 ---
 
-# Relay {#relay}
+# Relay {/*relay*/}
 
 Today we're excited to share an update on Relay - the technical preview is now open-source and [available on GitHub](http://github.com/facebook/relay).
 
-## Why Relay {#why-relay}
+## Why Relay {/*why-relay*/}
 
 While React simplified the process of developing complex user-interfaces, it left open the question of how to interact with data on the server. It turns out that this was a significant source of friction for our developers; fragile coupling between client and server caused data-related bugs and made iteration harder. Furthermore, developers were forced to constantly re-implement complex async logic instead of focusing on their apps. Relay addresses these concerns by borrowing important lessons from React: it provides _declarative, component-oriented data fetching for React applications_.
 
@@ -17,13 +17,13 @@ Relay is also component-oriented, extending the notion of a React component to i
 
 Relay is in use at Facebook in production apps, and we're using it more and more because _Relay lets developers focus on their products and move fast_. It's working for us and we'd like to share it with the community.
 
-## What's Included {#whats-included}
+## What's Included {/*whats-included*/}
 
 We're open-sourcing a technical preview of Relay - the core framework that we use internally, with some modifications for use outside Facebook. As this is the first release, it's good to keep in mind that there may be some incomplete or missing features. We'll continue to develop Relay and are working closely with the GraphQL community to ensure that Relay tracks updates during GraphQL's RFC period. But we couldn't wait any longer to get this in your hands, and we're looking forward to your feedback and contributions.
 
 Relay is available on [GitHub](http://github.com/facebook/relay) and [npm](https://www.npmjs.com/package/react-relay).
 
-## What's Next {#whats-next}
+## What's Next {/*whats-next*/}
 
 The team is super excited to be releasing Relay - and just as excited about what's next. Here are some of the things we'll be focusing on:
 

--- a/beta/src/pages/blog/2015/09/02/new-react-developer-tools.md
+++ b/beta/src/pages/blog/2015/09/02/new-react-developer-tools.md
@@ -17,7 +17,7 @@ It contains a handful of new features, including:
 - Right-click any props or state value to make it available as `$tmp` from the console
 - Full React Native support
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 Download the new devtools from the [Chrome Web Store](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) for Firefox, and [Microsoft Edge Addons](https://microsoftedge.microsoft.com/addons/detail/gpphkfbcpidddadnkolkpfckpihlkkil) for Edge. If you're developing using React, we highly recommend installing these devtools.
 

--- a/beta/src/pages/blog/2015/09/10/react-v0.14-rc1.md
+++ b/beta/src/pages/blog/2015/09/10/react-v0.14-rc1.md
@@ -7,7 +7,7 @@ We’re happy to announce our first release candidate for React 0.14! We gave yo
 
 Let us know if you run into any problems by filing issues on our [GitHub repo](https://github.com/facebook/react).
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using React from `npm` and using a tool like browserify or webpack to build your code into a single package:
 
@@ -30,9 +30,9 @@ If you can’t use `npm` yet, we also provide pre-built browser builds for your 
 
 These builds are also available in the `react` package on bower.
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### Major changes {#major-changes}
+### Major changes {/*major-changes*/}
 
 - #### Two Packages: React and React DOM
 
@@ -117,7 +117,7 @@ These builds are also available in the `react` package on bower.
 
   **Constant hoisting for React elements:** The `optimisation.react.constantElements` transform hoists element creation to the top level for subtrees that are fully static, which reduces calls to `React.createElement` and the resulting allocations. More importantly, it tells React that the subtree hasn’t changed so React can completely skip it when reconciling.
 
-### Breaking changes {#breaking-changes}
+### Breaking changes {/*breaking-changes*/}
 
 As always, we have a few breaking changes in this release. Whenever we make large changes, we warn for at least one release so you have time to update your code. The Facebook codebase has over 15,000 React components, so on the React team, we always try to minimize the pain of breaking changes.
 
@@ -132,7 +132,7 @@ And these two changes did not warn in 0.13 but should be easy to find and clean 
 - `React.initializeTouchEvents` is no longer necessary and has been removed completely. Touch events now work automatically.
 - Add-Ons: Due to the DOM node refs change mentioned above, `TestUtils.findAllInRenderedTree` and related helpers are no longer able to take a DOM component, only a custom component.
 
-### New deprecations, introduced with a warning {#new-deprecations-introduced-with-a-warning}
+### New deprecations, introduced with a warning {/*new-deprecations-introduced-with-a-warning*/}
 
 - Due to the DOM node refs change mentioned above, `this.getDOMNode()` is now deprecated and `ReactDOM.findDOMNode(this)` can be used instead. Note that in most cases, calling `findDOMNode` is now unnecessary – see the example above in the “DOM node refs” section.
 
@@ -144,7 +144,7 @@ And these two changes did not warn in 0.13 but should be easy to find and clean 
 - Add-Ons: `cloneWithProps` is now deprecated. Use [`React.cloneElement`](/docs/top-level-api.html#react.cloneelement) instead (unlike `cloneWithProps`, `cloneElement` does not merge `className` or `style` automatically; you can merge them manually if needed).
 - Add-Ons: To improve reliability, `CSSTransitionGroup` will no longer listen to transition events. Instead, you should specify transition durations manually using props such as `transitionEnterTimeout={500}`.
 
-### Notable enhancements {#notable-enhancements}
+### Notable enhancements {/*notable-enhancements*/}
 
 - Added `React.Children.toArray` which takes a nested children object and returns a flat array with keys assigned to each child. This helper makes it easier to manipulate collections of children in your `render` methods, especially if you want to reorder or slice `this.props.children` before passing it down. In addition, `React.Children.map` now returns plain arrays too.
 - React uses `console.error` instead of `console.warn` for warnings so that browsers show a full stack trace in the console. (Our warnings appear when you use patterns that will break in future releases and for code that is likely to behave unexpectedly, so we do consider our warnings to be “must-fix” errors.)
@@ -160,13 +160,13 @@ And these two changes did not warn in 0.13 but should be easy to find and clean 
 - Add-Ons: A [`shallowCompare`](https://github.com/facebook/react/pull/3355) add-on has been added as a migration path for `PureRenderMixin` in ES6 classes.
 - Add-Ons: `CSSTransitionGroup` can now use [custom class names](https://github.com/facebook/react/blob/48942b85/docs/docs/10.1-animation.md#custom-classes) instead of appending `-enter-active` or similar to the transition name.
 
-### New helpful warnings {#new-helpful-warnings}
+### New helpful warnings {/*new-helpful-warnings*/}
 
 - React DOM now warns you when nesting HTML elements invalidly, which helps you avoid surprising errors during updates.
 - Passing `document.body` directly as the container to `ReactDOM.render` now gives a warning as doing so can cause problems with browser extensions that modify the DOM.
 - Using multiple instances of React together is not supported, so we now warn when we detect this case to help you avoid running into the resulting problems.
 
-### Notable bug fixes {#notable-bug-fixes}
+### Notable bug fixes {/*notable-bug-fixes*/}
 
 - Click events are handled by React DOM more reliably in mobile browsers, particularly in Mobile Safari.
 - SVG elements are created with the correct namespace in more cases.

--- a/beta/src/pages/blog/2015/09/14/community-roundup-27.md
+++ b/beta/src/pages/blog/2015/09/14/community-roundup-27.md
@@ -5,7 +5,7 @@ author: [steveluscher]
 
 In the weeks following the [open-source release](/blog/2015/08/11/relay-technical-preview.html) of the Relay technical preview, the community has been abuzz with activity. We are honored to have been able to enjoy a steady stream of ideas and contributions from such a talented group of individuals. Let's take a look at some of the things we've achieved, together!
 
-## Teaching servers to speak GraphQL {#teaching-servers-to-speak-graphql}
+## Teaching servers to speak GraphQL {/*teaching-servers-to-speak-graphql*/}
 
 Every great Relay app starts by finding a GraphQL server to talk to. The community has spent the past few weeks teaching GraphQL to a few backend systems.
 
@@ -23,7 +23,7 @@ Espen Hovlandsdal ([rexxars](https://github.com/rexxars)) built a [sql-to-graphq
 
 Mick Hansen ([mickhansen](https://github.com/mickhansen)) offers a set of [schema-building helpers](https://github.com/mickhansen/graphql-sequelize) for use with the [Sequelize ORM](http://docs.sequelizejs.com/en/latest/) for MySQL, PostgreSQL, SQLite, and MSSQL.
 
-## GraphQL beyond JavaScript {#graphql-beyond-javascript}
+## GraphQL beyond JavaScript {/*graphql-beyond-javascript*/}
 
 Robert Mosolgo ([rmosolgo](https://github.com/rmosolgo)) brought the full set of schema-building and query execution tools to Ruby, in the form of [graphql-ruby](https://github.com/rmosolgo/graphql-ruby) and [graphql-relay-ruby](https://github.com/rmosolgo/graphql-relay-ruby). Check out his [Rails-based demo](https://github.com/rmosolgo/graphql-ruby-demo).
 
@@ -37,7 +37,7 @@ Oleg Ilyenko ([OlegIlyenko](https://github.com/OlegIlyenko)) made a beautiful an
 
 Joe McBride ([joemcbride](https://github.com/joemcbride)) has an up-and-running example of GraphQL for .NET, [graphql-dotnet](https://github.com/joemcbride/graphql-dotnet).
 
-## Show me, don't tell me {#show-me-dont-tell-me}
+## Show me, don't tell me {/*show-me-dont-tell-me*/}
 
 Interact with this [visual tour of Relay's architecture](http://sgwilym.github.io/relay-visual-learners/) by Sam Gwilym ([sgwilym](https://github.com/sgwilym)).
 
@@ -47,19 +47,19 @@ Interact with this [visual tour of Relay's architecture](http://sgwilym.github.i
 
 Sam has already launched a product that leverages Relay's data-fetching, optimistic responses, pagination, and mutations &ndash; all atop a Ruby GraphQL server: [new.comique.co](http://new.comique.co/)
 
-## Skeletons in the closet {#skeletons-in-the-closet}
+## Skeletons in the closet {/*skeletons-in-the-closet*/}
 
 Joseph Rollins ([fortruce](https://github.com/fortruce)) created a hot-reloading, auto schema-regenerating, [Relay skeleton](https://github.com/fortruce/relay-skeleton) that you can use to get up and running quickly.
 
 Michael Hart ([mhart](https://mhart)) built a [simple-relay-starter](https://github.com/mhart/simple-relay-starter) kit using Browserify.
 
-## Routing around {#routing-around}
+## Routing around {/*routing-around*/}
 
 Jimmy Jia ([taion](@taion)) and Gerald Monaco ([devknoll](@devknoll)) have been helping lost URLs find their way to Relay apps through their work on [react-router-relay](relay-tools/react-router-relay). Check out Christoph Nakazawa's ([cpojer](@cpojer)) [blog post](medium.com/@cpojer/relay-and-routing-36b5439bad9) on the topic. Jimmy completed the Relay TodoMVC example with routing, which you can check out at [taion/relay-todomvc](taion/relay-todomvc).
 
 Chen Hung-Tu ([transedward](https://github.com/transedward)) built a chat app atop the above mentioned router, with threaded conversations and pagination. Check it out at [transedward/relay-chat](https://github.com/transedward/relay-chat).
 
-## In your words {#in-your-words}
+## In your words {/*in-your-words*/}
 
 <div class="skinny-row">
   <div class="skinny-col">

--- a/beta/src/pages/blog/2015/10/01/react-render-and-top-level-api.md
+++ b/beta/src/pages/blog/2015/10/01/react-render-and-top-level-api.md
@@ -23,7 +23,7 @@ This is important and often forgotten. Forgetting to call `unmountComponentAtNod
 
 It is not unique to the DOM. If you want to insert a React Native view in the middle of an existing iOS app you will hit similar issues.
 
-## Helpers {#helpers}
+## Helpers {/*helpers*/}
 
 If you have multiple React roots, or a single root that gets deleted over time, we recommend that you always create your own wrapper API. These will all look slightly different depending on what your outer system looks like. For example, at Facebook we have a system that automatically ties into our page transition router to automatically call `unmountComponentAtNode`.
 
@@ -31,7 +31,7 @@ Rather than calling `ReactDOM.render()` directly everywhere, consider writing/us
 
 In your environment you may want to always configure internationalization, routers, user data etc. If you have many different React roots it can be a pain to set up configuration nodes all over the place. By creating your own wrapper you can unify that configuration into one place.
 
-## Object Oriented Updates {#object-oriented-updates}
+## Object Oriented Updates {/*object-oriented-updates*/}
 
 If you call `ReactDOM.render` a second time to update properties, all your props are completely replaced.
 

--- a/beta/src/pages/blog/2015/10/07/react-v0.14.md
+++ b/beta/src/pages/blog/2015/10/07/react-v0.14.md
@@ -9,7 +9,7 @@ If you tried the release candidate, thank you – your support is invaluable and
 
 As with all of our releases, we consider this version to be stable enough to use in production and recommend that you upgrade in order to take advantage of our latest improvements.
 
-## Upgrade Guide {#upgrade-guide}
+## Upgrade Guide {/*upgrade-guide*/}
 
 Like always, we have a few breaking changes in this release. We know changes can be painful (the Facebook codebase has over 15,000 React components), so we always try to make changes gradually in order to minimize the pain.
 
@@ -19,7 +19,7 @@ For the two major changes which require significant code changes, we've included
 
 See the changelog below for more details.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using React from `npm` and using a tool like browserify or webpack to build your code into a single bundle. To install the two packages:
 
@@ -39,9 +39,9 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
   Dev build with warnings: <https://fb.me/react-dom-0.14.0.js>  
   Minified build for production: <https://fb.me/react-dom-0.14.0.min.js>
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### Major changes {#major-changes}
+### Major changes {/*major-changes*/}
 
 - #### Two Packages: React and React DOM
 
@@ -142,7 +142,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
 
   **Constant hoisting for React elements:** The `optimisation.react.constantElements` transform hoists element creation to the top level for subtrees that are fully static, which reduces calls to `React.createElement` and the resulting allocations. More importantly, it tells React that the subtree hasn’t changed so React can completely skip it when reconciling.
 
-### Breaking changes {#breaking-changes}
+### Breaking changes {/*breaking-changes*/}
 
 In almost all cases, we change our APIs gradually and warn for at least one release to give you time to clean up your code. These two breaking changes did not have a warning in 0.13 but should be easy to find and clean up:
 
@@ -155,7 +155,7 @@ These three breaking changes had a warning in 0.13, so you shouldn’t have to d
 - Plain objects are no longer supported as React children; arrays should be used instead. You can use the [`createFragment`](/docs/create-fragment.html) helper to migrate, which now returns an array.
 - Add-Ons: `classSet` has been removed. Use [classnames](https://github.com/JedWatson/classnames) instead.
 
-### New deprecations, introduced with a warning {#new-deprecations-introduced-with-a-warning}
+### New deprecations, introduced with a warning {/*new-deprecations-introduced-with-a-warning*/}
 
 Each of these changes will continue to work as before with a new warning until the release of 0.15 so you can upgrade your code gradually.
 
@@ -169,7 +169,7 @@ Each of these changes will continue to work as before with a new warning until t
 - Add-Ons: `cloneWithProps` is now deprecated. Use [`React.cloneElement`](/docs/top-level-api.html#react.cloneelement) instead (unlike `cloneWithProps`, `cloneElement` does not merge `className` or `style` automatically; you can merge them manually if needed).
 - Add-Ons: To improve reliability, `CSSTransitionGroup` will no longer listen to transition events. Instead, you should specify transition durations manually using props such as `transitionEnterTimeout={500}`.
 
-### Notable enhancements {#notable-enhancements}
+### Notable enhancements {/*notable-enhancements*/}
 
 - Added `React.Children.toArray` which takes a nested children object and returns a flat array with keys assigned to each child. This helper makes it easier to manipulate collections of children in your `render` methods, especially if you want to reorder or slice `this.props.children` before passing it down. In addition, `React.Children.map` now returns plain arrays too.
 - React uses `console.error` instead of `console.warn` for warnings so that browsers show a full stack trace in the console. (Our warnings appear when you use patterns that will break in future releases and for code that is likely to behave unexpectedly, so we do consider our warnings to be “must-fix” errors.)
@@ -185,13 +185,13 @@ Each of these changes will continue to work as before with a new warning until t
 - Add-Ons: A [`shallowCompare`](https://github.com/facebook/react/pull/3355) add-on has been added as a migration path for `PureRenderMixin` in ES6 classes.
 - Add-Ons: `CSSTransitionGroup` can now use [custom class names](https://github.com/facebook/react/blob/48942b85/docs/docs/10.1-animation.md#custom-classes) instead of appending `-enter-active` or similar to the transition name.
 
-### New helpful warnings {#new-helpful-warnings}
+### New helpful warnings {/*new-helpful-warnings*/}
 
 - React DOM now warns you when nesting HTML elements invalidly, which helps you avoid surprising errors during updates.
 - Passing `document.body` directly as the container to `ReactDOM.render` now gives a warning as doing so can cause problems with browser extensions that modify the DOM.
 - Using multiple instances of React together is not supported, so we now warn when we detect this case to help you avoid running into the resulting problems.
 
-### Notable bug fixes {#notable-bug-fixes}
+### Notable bug fixes {/*notable-bug-fixes*/}
 
 - Click events are handled by React DOM more reliably in mobile browsers, particularly in Mobile Safari.
 - SVG elements are created with the correct namespace in more cases.

--- a/beta/src/pages/blog/2015/10/19/reactiflux-is-moving-to-discord.md
+++ b/beta/src/pages/blog/2015/10/19/reactiflux-is-moving-to-discord.md
@@ -5,45 +5,45 @@ author: [benigeri]
 
 TL;DR: Slack decided that Reactiflux had too many members and disabled new invites. Reactiflux is moving to Discord. Join us: [http://join.reactiflux.com](http://join.reactiflux.com/)
 
-## What happened with Slack? {#what-happened-with-slack}
+## What happened with Slack? {/*what-happened-with-slack*/}
 
 A few weeks ago, Reactiflux reached 7,500 members on Slack. Shortly after, Slack decided we were too big and disabled invites. There was no way for new users to join. Many of us were sad and upset. We loved Slack. Our community was built around it.
 
 We reached out to Slack several times, but their decision was firm. Our large community caused performance issues. Slack wants to focus on building a great product for teams, not necessarily large open communities. Losing focus and building for too many use cases always leads to product bloat, and eventually a decrease in quality.
 
-## So… why Discord? {#so-why-discord}
+## So… why Discord? {/*so-why-discord*/}
 
 After a [long and thorough debate](https://github.com/reactiflux/volunteers/issues/25), Discord quickly emerged as the most promising service. After just a few days, 400 members had joined the Discord server, and many already loved it.
 
-### Easiest to join {#easiest-to-join}
+### Easiest to join {/*easiest-to-join*/}
 
 Discord is the easiest platform to join. New users can immediately join our conversations without having to create an account. All they need to do is provide a name. No permission granting, no password, no email confirmation.
 
 This is critically useful for us, and will make Reactiflux even more open and accessible.
 
-### Great apps {#great-apps}
+### Great apps {/*great-apps*/}
 
 Out of all of the services we’ve tried, Discord’s apps are by far the most polished. They are well designed, easy to use, and surprisingly fast. In addition to the web app, they have mobile apps on both iOS and Android as well as desktop apps for OS X and Windows, with Linux support coming soon.
 
 Their desktop apps are built with React and Electron, and their iOS app is built with React Native.
 
-### Moderation tools {#moderation-tools}
+### Moderation tools {/*moderation-tools*/}
 
 So far, we’ve been fortunate not to have to deal with spammers and trolls. As our community continues to grow, that might change. Unsurprisingly, Discord is the only app we’ve seen with legitimate moderation tools. It was built for gaming communities, after all.
 
-### Great multiple Server support {#great-multiple-server-support}
+### Great multiple Server support {/*great-multiple-server-support*/}
 
 Your Discord account works with every Discord server, which is the equivalent of a Slack team. You don’t need to create a new account every time you join a new team. You can join new servers in one click, and it’s very easy to switch between them. Discord messages also work across servers, so your personal conversations are not scoped to a single server.
 
 Instead of having one huge, crowded Reactiflux server, we can branch off closely related channels into sub-servers. Communities will start overlapping, and it will be easy to interact with non-Reactiflux channels.
 
-### It’s hosted {#its-hosted}
+### It’s hosted {/*its-hosted*/}
 
 Self-hosted apps require maintenance. We’re all busy, and we can barely find the time to keep our landing page up to date and running smoothly. More than anything, we need a stable platform, and we don’t have the resources to guarantee that right now.
 
 It’s a much safer bet to offload the hosting to Discord, who is already keeping the lights on for all their users.
 
-### We like the team {#we-like-the-team}
+### We like the team {/*we-like-the-team*/}
 
 And they seem to like us back. They are excited for us to join them, and they’ve been very responsive to our feedback and suggestions.
 
@@ -51,11 +51,11 @@ They implemented code syntax highlighting just a few days after we told them we 
 
 Discord’s team has already built a solid suite of apps, and they have shown us how much they care about their users. We’re excited to see how they will continue to improve their product.
 
-## And what’s the catch? {#and-whats-the-catch}
+## And what’s the catch? {/*and-whats-the-catch*/}
 
 Choosing the best chat service is subjective. There are a million reasons why Discord _might be_ a terrible idea. Here are the ones that we’re most worried about:
 
-### Difficult channel management {#difficult-channel-management}
+### Difficult channel management {/*difficult-channel-management*/}
 
 Channel management seems to be the biggest issue. There is no way to opt out of channels; you can only mute them. And you can only mute channels one by one. There is no way to star channels, and channels can only be sorted on the server level. Each user will see the list of channels in the same order.
 
@@ -63,23 +63,23 @@ As the number of channels grow, it will be challenging to keep things in order. 
 
 We can build simple tools to make channel lookup easier, and the Discord team is working on improvements that should make this more manageable.
 
-### No Search {#no-search}
+### No Search {/*no-search*/}
 
 Lack of search is clearly a bummer, but Discord is working on it. Search is coming!
 
-### Firewall {#firewall}
+### Firewall {/*firewall*/}
 
 A couple of users aren’t able to access Discord at work since other corporate filters classify it as a gaming application. This sucks, but it seems to be a rare case. So far, it seems only to affect 0.6% of our current community (3/500).
 
 We hope that these users can get Discord's domains whitelisted, and we’ll try to find a solution if this is a widespread issue. The Discord team is aware of the issue as well.
 
-## Is Discord going to disappear tomorrow? {#is-discord-going-to-disappear-tomorrow}
+## Is Discord going to disappear tomorrow? {/*is-discord-going-to-disappear-tomorrow*/}
 
 Probably not tomorrow. They have 14 people [full time](https://discordapp.com/company), and they’ve raised money from some of the best investors in Silicon Valley, including [Benchmark](http://www.benchmark.com/) and [Accel](http://www.accel.com/companies/).
 
 By focusing on gaming communities, Discord has differentiated itself from the many other communication apps. Discord is well received and has a rapidly growing user base. They plan to keep their basic offerings free for unlimited users and hope to make money with premium offerings (themes, add-ons, content, and more).
 
-## Join us! {#join-us}
+## Join us! {/*join-us*/}
 
 More than 500 of us have already migrated to the new Reactiflux. Join us, we're one click away: [http://join.reactiflux.com](http://join.reactiflux.com/)
 

--- a/beta/src/pages/blog/2015/10/28/react-v0.14.1.md
+++ b/beta/src/pages/blog/2015/10/28/react-v0.14.1.md
@@ -21,9 +21,9 @@ We've also published version `0.14.1` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fixed bug where events wouldn't fire in old browsers when using React in development mode
 - Fixed bug preventing use of `dangerouslySetInnerHTML` with Closure Compiler Advanced mode
@@ -31,14 +31,14 @@ We've also published version `0.14.1` of the `react`, `react-dom`, and addons pa
 - Added support for `color` attribute
 - Ensured legacy `.props` access on DOM nodes is updated on re-renders
 
-### React TestUtils Add-on {#react-testutils-add-on}
+### React TestUtils Add-on {/*react-testutils-add-on*/}
 
 - Fixed `scryRenderedDOMComponentsWithClass` so it works with SVG
 
-### React CSSTransitionGroup Add-on {#react-csstransitiongroup-add-on}
+### React CSSTransitionGroup Add-on {/*react-csstransitiongroup-add-on*/}
 
 - Fix bug preventing `0` to be used as a timeout value
 
-### React on Bower {#react-on-bower}
+### React on Bower {/*react-on-bower*/}
 
 - Added `react-dom.js` to `main` to improve compatibility with tooling

--- a/beta/src/pages/blog/2015/11/02/react-v0.14.2.md
+++ b/beta/src/pages/blog/2015/11/02/react-v0.14.2.md
@@ -21,9 +21,9 @@ We've also published version `0.14.2` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fixed bug with development build preventing events from firing in some versions of Internet Explorer & Edge
 - Fixed bug with development build when using es5-sham in older versions of Internet Explorer

--- a/beta/src/pages/blog/2015/11/18/react-v0.14.3.md
+++ b/beta/src/pages/blog/2015/11/18/react-v0.14.3.md
@@ -24,21 +24,21 @@ We've also published version `0.14.3` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Added support for `nonce` attribute for `<script>` and `<style>` elements
 - Added support for `reversed` attribute for `<ol>` elements
 
-### React TestUtils Add-on {#react-testutils-add-on}
+### React TestUtils Add-on {/*react-testutils-add-on*/}
 
 - Fixed bug with shallow rendering and function refs
 
-### React CSSTransitionGroup Add-on {#react-csstransitiongroup-add-on}
+### React CSSTransitionGroup Add-on {/*react-csstransitiongroup-add-on*/}
 
 - Fixed bug resulting in timeouts firing incorrectly when mounting and unmounting rapidly
 
-### React on Bower {#react-on-bower}
+### React on Bower {/*react-on-bower*/}
 
 - Added `react-dom-server.js` to expose `renderToString` and `renderToStaticMarkup` for usage in the browser

--- a/beta/src/pages/blog/2015/12/04/react-js-conf-2016-diversity-scholarship.md
+++ b/beta/src/pages/blog/2015/12/04/react-js-conf-2016-diversity-scholarship.md
@@ -25,18 +25,18 @@ At Facebook, we believe that anyone anywhere can make a positive impact by devel
 
 To apply for the scholarship, please visit the application page: **<http://goo.gl/forms/PEmKj8oUp4>**
 
-## Award Includes {#award-includes}
+## Award Includes {/*award-includes*/}
 
 - Paid registration fee for the React.js Conf February 22 & 23 in downtown San Francisco, CA
 - Paid lodging expenses for February 21, 22, 23
 
-## Important Dates {#important-dates}
+## Important Dates {/*important-dates*/}
 
 - Sunday December 13th 2015 - 11:59 PST: Applications for the React.js Conf Scholarship must be submitted in full
 - Wednesday, December 16th, 2015: Award recipients will be notified by email of their acceptance
 - Monday & Tuesday, February 22 & 23, 2016: React.js Conf
 
-## Eligibility {#eligibility}
+## Eligibility {/*eligibility*/}
 
 - Must currently be studying or working in Computer Science or a related field
 - International applicants are welcome, but you will be responsible for securing your own visa to attend the conference

--- a/beta/src/pages/blog/2015/12/18/react-components-elements-and-instances.md
+++ b/beta/src/pages/blog/2015/12/18/react-components-elements-and-instances.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 The difference between **components, their instances, and elements** confuses many React beginners. Why are there three different terms to refer to something that is painted on screen?
 
-## Managing the Instances {#managing-the-instances}
+## Managing the Instances {/*managing-the-instances*/}
 
 If you’re new to React, you probably only worked with component classes and instances before. For example, you may declare a `Button` _component_ by creating a class. When the app is running, you may have several _instances_ of this component on screen, each with its own properties and local state. This is the traditional object-oriented UI programming. Why introduce _elements_?
 
@@ -53,13 +53,13 @@ Each component instance has to keep references to its DOM node and to the instan
 
 So how is React different?
 
-## Elements Describe the Tree {#elements-describe-the-tree}
+## Elements Describe the Tree {/*elements-describe-the-tree*/}
 
 In React, this is where the _elements_ come to rescue. **An element is a plain object _describing_ a component instance or DOM node and its desired properties.** It contains only information about the component type (for example, a `Button`), its properties (for example, its `color`), and any child elements inside it.
 
 An element is not an actual instance. Rather, it is a way to tell React what you _want_ to see on the screen. You can’t call any methods on the element. It’s just an immutable description object with two fields: `type: (string | ReactClass)` and `props: Object`[^1].
 
-### DOM Elements {#dom-elements}
+### DOM Elements {/*dom-elements*/}
 
 When an element’s `type` is a string, it represents a DOM node with that tag name, and `props` correspond to its attributes. This is what React will render. For example:
 
@@ -94,7 +94,7 @@ What’s important is that both child and parent elements are _just descriptions
 
 React elements are easy to traverse, don’t need to be parsed, and of course they are much lighter than the actual DOM elements—they’re just objects!
 
-### Component Elements {#component-elements}
+### Component Elements {/*component-elements*/}
 
 However, the `type` of an element can also be a function or a class corresponding to a React component:
 
@@ -168,7 +168,7 @@ This mix and matching helps keep components decoupled from each other, as they c
 - `DangerButton` is a `Button` with specific properties.
 - `DeleteAccount` contains a `Button` and a `DangerButton` inside a `<div>`.
 
-### Components Encapsulate Element Trees {#components-encapsulate-element-trees}
+### Components Encapsulate Element Trees {/*components-encapsulate-element-trees*/}
 
 When React sees an element with a function or class `type`, it knows to ask _that_ component what element it renders to, given the corresponding `props`.
 
@@ -236,7 +236,7 @@ That’s it! For a React component, props are the input, and an element tree is 
 
 We let React create, update, and destroy instances. We _describe_ them with elements we return from the components, and React takes care of managing the instances.
 
-### Components Can Be Classes or Functions {#components-can-be-classes-or-functions}
+### Components Can Be Classes or Functions {/*components-can-be-classes-or-functions*/}
 
 In the code above, `Form`, `Message`, and `Button` are React components. They can either be written as functions, like above, or as classes descending from `React.Component`. These three ways to declare a component are mostly equivalent:
 
@@ -300,7 +300,7 @@ A function component is less powerful but is simpler, and acts like a class comp
 
 **However, whether functions or classes, fundamentally they are all components to React. They take the props as their input, and return the elements as their output.**
 
-### Top-Down Reconciliation {#top-down-reconciliation}
+### Top-Down Reconciliation {/*top-down-reconciliation*/}
 
 When you call:
 
@@ -363,7 +363,7 @@ Only components declared as classes have instances, and you never create them di
 
 React takes care of creating an instance for every class component, so you can write components in an object-oriented way with methods and local state, but other than that, instances are not very important in the React’s programming model and are managed by React itself.
 
-## Summary {#summary}
+## Summary {/*summary*/}
 
 An _element_ is a plain object describing what you want to appear on the screen in terms of the DOM nodes or other components. Elements can contain other elements in their props. Creating a React element is cheap. Once an element is created, it is never mutated.
 
@@ -377,7 +377,7 @@ Function components don’t have instances at all. Class components have instanc
 
 Finally, to create elements, use [`React.createElement()`](/docs/top-level-api.html#react.createelement), [JSX](/docs/jsx-in-depth.html), or an [element factory helper](/docs/top-level-api.html#react.createfactory). Don’t write elements as plain objects in the real code—just know that they are plain objects under the hood.
 
-## Further Reading {#further-reading}
+## Further Reading {/*further-reading*/}
 
 - [Introducing React Elements](/blog/2014/10/14/introducing-react-elements.html)
 - [Streamlining React Elements](/blog/2015/02/24/streamlining-react-elements.html)

--- a/beta/src/pages/blog/2015/12/29/react-v0.14.4.md
+++ b/beta/src/pages/blog/2015/12/29/react-v0.14.4.md
@@ -24,17 +24,17 @@ We've also published version `0.14.4` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Minor internal changes for better compatibility with React Native
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - The `autoCapitalize` and `autoCorrect` props are now set as attributes in the DOM instead of properties to improve cross-browser compatibility
 - Fixed bug with controlled `<select>` elements not handling updates properly
 
-### React Perf Add-on {#react-perf-add-on}
+### React Perf Add-on {/*react-perf-add-on*/}
 
 - Some DOM operation names have been updated for clarity in the output of `.printDOM()`

--- a/beta/src/pages/blog/2016/02/19/new-versioning-scheme.md
+++ b/beta/src/pages/blog/2016/02/19/new-versioning-scheme.md
@@ -9,7 +9,7 @@ This change shouldn't materially affect most of you. Moving to major semver vers
 
 The core of the React API has been stable for years. Our business as well as many of yours all depend heavily on the use of React as a core piece of our infrastructure. We're committed to the stability as well as the progress of React going forward.
 
-## Bring Everyone Along {#bring-everyone-along}
+## Bring Everyone Along {/*bring-everyone-along*/}
 
 React isn't just a library but an ecosystem. We know that your applications and ours are not just isolated islands of code. It is a network of your own application code, your own open source components and third party libraries that all depend on React.
 
@@ -19,7 +19,7 @@ Therefore it is important that we don't just upgrade our own codebases but that 
 
 <img src="/images/blog/versioning-poll.png" width={596} />
 
-## Introducing Minor Releases {#introducing-minor-releases}
+## Introducing Minor Releases {/*introducing-minor-releases*/}
 
 Ideally everyone could just depend on the latest version of React all the time.
 
@@ -31,11 +31,11 @@ We know that in practice that is not possible. In the future, we expect more new
 
 That means that if one component needs a new API, there is no need for any of the other components to do any further work. They remain compatible.
 
-## What Happened to 1.0.0? {#what-happened-to-100}
+## What Happened to 1.0.0? {/*what-happened-to-100*/}
 
 Part of React's growth and popularity is that it is stable and performant in production. People have long asked what React v1.0 will look. Technically some breaking changes are important to avoid stagnating, but we still achieve stability by making it easy to upgrade. If major version numbers indicate API stability and engender trust that it can be used in production, then we got there a long time ago. There are too many preconceived notions of what v1.0 is. We're still following semver. We're just communicating stability by moving the 0 from the beginning to the end.
 
-## Breaking Changes {#breaking-changes}
+## Breaking Changes {/*breaking-changes*/}
 
 Minor revision releases will include deprecation warnings and tips for how to upgrade an API or pattern that will be removed or changed in the future.
 
@@ -43,7 +43,7 @@ We will continue to release [codemods](https://www.youtube.com/watch?v=d0pOgY8__
 
 Once we've reached the end of life for a particular major version, we'll release a new major version where all deprecated APIs have been removed.
 
-## Avoiding The Major Cliff {#avoiding-the-major-cliff}
+## Avoiding The Major Cliff {/*avoiding-the-major-cliff*/}
 
 If you try to upgrade your component to 16.0.0 you might find that your application no longer works if you still have other dependencies. E.g. if Ryan's and Jed's components are only compatible with 15.x.x.
 

--- a/beta/src/pages/blog/2016/03/07/react-v15-rc1.md
+++ b/beta/src/pages/blog/2016/03/07/react-v15-rc1.md
@@ -9,7 +9,7 @@ But now we're ready, so without further ado, we're shipping a release candidate 
 
 Please try it out before we publish the final release. Let us know if you run into any problems by filing issues on our [GitHub repo](https://github.com/facebook/react).
 
-## Upgrade Guide {#upgrade-guide}
+## Upgrade Guide {/*upgrade-guide*/}
 
 Like always, we have a few breaking changes in this release. We know changes can be painful (the Facebook codebase has over 15,000 React components), so we always try to make changes gradually in order to minimize the pain.
 
@@ -17,7 +17,7 @@ If your code is free of warnings when running under React 0.14, upgrading should
 
 See the changelog below for more details.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using React from `npm` and using a tool like browserify or webpack to build your code into a single bundle. To install the two packages:
 
@@ -37,9 +37,9 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
   Dev build with warnings: <https://fb.me/react-dom-15.0.0-rc.1.js>  
   Minified build for production: <https://fb.me/react-dom-15.0.0-rc.1.min.js>
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### Major changes {#major-changes}
+### Major changes {/*major-changes*/}
 
 - #### `document.createElement` is in and `data-reactid` is out
 
@@ -57,7 +57,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
 
   All SVG tags and attributes are now fully supported. (Uncommon SVG tags are not present on the `React.DOM` element helper, but JSX and `React.createElement` work on all tag names.) All SVG attributes match their original capitalization and hyphenation as defined in the specification (ex: `gradientTransform` must be camel-cased but `clip-path` should be hyphenated).
 
-### Breaking changes {#breaking-changes}
+### Breaking changes {/*breaking-changes*/}
 
 It's worth calling out the DOM structure changes above again, in particular the change from `<span>`s. In the course of updating the Facebook codebase, we found a very small amount of code that was depending on the markup that React generated. Some of these cases were integration tests like WebDriver which were doing very specific XPath queries to target nodes. Others were simply tests using `ReactDOM.renderToStaticMarkup` and comparing markup. Again, there were a very small number of changes that had to be made, but we don't want anybody to be blindsided. We encourage everybody to run their test suites when upgrading and consider alternative approaches when possible. One approach that will work for some cases is to explicitly use `<span>`s in your `render` method.
 
@@ -67,13 +67,13 @@ These deprecations were introduced in v0.14 with a warning and the APIs are now 
 - Deprecated APIs removed from `React.addons`, specifically `batchedUpdates` and `cloneWithProps`.
 - Deprecated APIs removed from component instances, specifically `setProps`, `replaceProps`, and `getDOMNode`.
 
-### New deprecations, introduced with a warning {#new-deprecations-introduced-with-a-warning}
+### New deprecations, introduced with a warning {/*new-deprecations-introduced-with-a-warning*/}
 
 Each of these changes will continue to work as before with a new warning until the release of React 16 so you can upgrade your code gradually.
 
 - `LinkedStateMixin` and `valueLink` are now deprecated due to very low popularity. If you need this, you can use a wrapper component that implements the same behavior: [react-linked-input](https://www.npmjs.com/package/react-linked-input).
 
-### New helpful warnings {#new-helpful-warnings}
+### New helpful warnings {/*new-helpful-warnings*/}
 
 - If you use a minified copy of the _development_ build, React DOM kindly encourages you to use the faster production build instead.
 - React DOM: When specifying a unit-less CSS value as a string, a future version will not add `px` automatically. This version now warns in this case (ex: writing `style={{width: '300'}}`. (Unitless _number_ values like `width: 300` are unchanged.)
@@ -81,7 +81,7 @@ Each of these changes will continue to work as before with a new warning until t
 - Elements will now warn when attempting to read `ref` and `key` from the props.
 - React DOM now attempts to warn for mistyped event handlers on DOM elements (ex: `onclick` which should be `onClick`)
 
-### Notable bug fixes {#notable-bug-fixes}
+### Notable bug fixes {/*notable-bug-fixes*/}
 
 - Fixed multiple small memory leaks
 - Input events are handled more reliably in IE 10 and IE 11; spurious events no longer fire when using a placeholder.

--- a/beta/src/pages/blog/2016/03/16/react-v15-rc2.md
+++ b/beta/src/pages/blog/2016/03/16/react-v15-rc2.md
@@ -11,7 +11,7 @@ The other change is to our SVG code. In RC1 we had made the decision to pass thr
 
 Thanks again to everybody who has tried the RC1 and reported issues. It has been extremely important and we wouldn't be able to do this without your help!
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using React from `npm` and using a tool like browserify or webpack to build your code into a single bundle. To install the two packages:
 

--- a/beta/src/pages/blog/2016/03/29/react-v0.14.8.md
+++ b/beta/src/pages/blog/2016/03/29/react-v0.14.8.md
@@ -26,8 +26,8 @@ We've also published version `0.14.8` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Fixed memory leak when rendering on the server

--- a/beta/src/pages/blog/2016/04/07/react-v15.md
+++ b/beta/src/pages/blog/2016/04/07/react-v15.md
@@ -19,7 +19,7 @@ While this isn’t directly related to the release, we understand that in order 
 
 We are also experimenting with a new changelog format in this post. Every change now links to the corresponding pull request and mentions the author. Let us know whether you find this useful!
 
-## Upgrade Guide {#upgrade-guide}
+## Upgrade Guide {/*upgrade-guide*/}
 
 As usual with major releases, React 15 will remove support for some of the patterns deprecated nine months ago in React 0.14. We know changes can be painful (the Facebook codebase has over 20,000 React components, and that’s not even counting React Native), so we always try to make changes gradually in order to minimize the pain.
 
@@ -27,7 +27,7 @@ If your code is free of warnings when running under React 0.14, upgrading should
 
 See the changelog below for more details.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using React from `npm` and using a tool like browserify or webpack to build your code into a single bundle. To install the two packages:
 
@@ -47,9 +47,9 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
   Dev build with warnings: <https://fb.me/react-dom-15.0.0.js>  
   Minified build for production: <https://fb.me/react-dom-15.0.0.min.js>
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### Major changes {#major-changes}
+### Major changes {/*major-changes*/}
 
 - #### `document.createElement` is in and `data-reactid` is out
 
@@ -83,7 +83,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
 
   <small>[@zpao](https://github.com/zpao) in [#6243](https://github.com/facebook/react/pull/6243)</small>
 
-### Breaking changes {#breaking-changes}
+### Breaking changes {/*breaking-changes*/}
 
 - #### No more extra `<span>`s
 
@@ -125,7 +125,7 @@ If you can’t use `npm` yet, we provide pre-built browser builds for your conve
   - React-specific properties on DOM `refs` (e.g. `this.refs.div.props`) were deprecated, and are removed now.  
     <small>[@jimfb](https://github.com/jimfb) in [#5495](https://github.com/facebook/react/pull/5495)</small>
 
-### New deprecations, introduced with a warning {#new-deprecations-introduced-with-a-warning}
+### New deprecations, introduced with a warning {/*new-deprecations-introduced-with-a-warning*/}
 
 Each of these changes will continue to work as before with a new warning until the release of React 16 so you can upgrade your code gradually.
 
@@ -138,7 +138,7 @@ Each of these changes will continue to work as before with a new warning until t
 - `ReactPerf.printDOM()` was renamed to `ReactPerf.printOperations()`, and `ReactPerf.getMeasurementsSummaryMap()` was renamed to `ReactPerf.getWasted()`.  
   <small>[@gaearon](https://github.com/gaearon) in [#6287](https://github.com/facebook/react/pull/6287)</small>
 
-### New helpful warnings {#new-helpful-warnings}
+### New helpful warnings {/*new-helpful-warnings*/}
 
 - If you use a minified copy of the _development_ build, React DOM kindly encourages you to use the faster production build instead.  
   <small>[@sophiebits](https://github.com/sophiebits) in [#5083](https://github.com/facebook/react/pull/5083)</small>
@@ -182,7 +182,7 @@ Each of these changes will continue to work as before with a new warning until t
 - PropTypes: `arrayOf()` and `objectOf()` provide better error messages for invalid arguments.  
   <small>[@chicoxyzzy](https://github.com/chicoxyzzy) in [#5390](https://github.com/facebook/react/pull/5390)</small>
 
-### Notable bug fixes {#notable-bug-fixes}
+### Notable bug fixes {/*notable-bug-fixes*/}
 
 - Fixed multiple small memory leaks.  
   <small>[@sophiebits](https://github.com/sophiebits) in [#4983](https://github.com/facebook/react/pull/4983) and [@victor-homyakov](https://github.com/victor-homyakov) in [#6309](https://github.com/facebook/react/pull/6309)</small>
@@ -235,7 +235,7 @@ Each of these changes will continue to work as before with a new warning until t
 - Add-Ons: ReactPerf no longer instruments adding or removing an event listener because they don’t really touch the DOM due to event delegation.  
   <small>[@antoaravinth](https://github.com/antoaravinth) in [#5209](https://github.com/facebook/react/pull/5209)</small>
 
-### Other improvements {#improvements}
+### Other improvements {/*improvements*/}
 
 - React now uses `loose-envify` instead of `envify` so it installs fewer transitive dependencies.  
   <small>[@qerub](https://github.com/qerub) in [#6303](https://github.com/facebook/react/pull/6303)</small>

--- a/beta/src/pages/blog/2016/04/07/react-v15.md
+++ b/beta/src/pages/blog/2016/04/07/react-v15.md
@@ -235,7 +235,7 @@ Each of these changes will continue to work as before with a new warning until t
 - Add-Ons: ReactPerf no longer instruments adding or removing an event listener because they don’t really touch the DOM due to event delegation.  
   <small>[@antoaravinth](https://github.com/antoaravinth) in [#5209](https://github.com/facebook/react/pull/5209)</small>
 
-### Other improvements {#improvements}
+### Other improvements {#improvements}
 
 - React now uses `loose-envify` instead of `envify` so it installs fewer transitive dependencies.  
   <small>[@qerub](https://github.com/qerub) in [#6303](https://github.com/facebook/react/pull/6303)</small>

--- a/beta/src/pages/blog/2016/04/08/react-v15.0.1.md
+++ b/beta/src/pages/blog/2016/04/08/react-v15.0.1.md
@@ -23,14 +23,14 @@ As usual, you can get install the `react` package via npm or download a browser 
   Dev build with warnings: <https://fb.me/react-dom-15.0.1.js>  
   Minified build for production: <https://fb.me/react-dom-15.0.1.min.js>
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Restore `React.__spread` API to unbreak code compiled with some tools making use of this undocumented API. It is now officially deprecated.  
   <small>[@zpao](https://github.com/zpao) in [#6444](https://github.com/facebook/react/pull/6444)</small>
 
-### ReactDOM {#reactdom}
+### ReactDOM {/*reactdom*/}
 
 - Fixed issue resulting in loss of cursor position in controlled inputs.  
   <small>[@sophiebits](https://github.com/sophiebits) in [#6449](https://github.com/facebook/react/pull/6449)</small>

--- a/beta/src/pages/blog/2016/07/13/mixins-considered-harmful.md
+++ b/beta/src/pages/blog/2016/07/13/mixins-considered-harmful.md
@@ -13,7 +13,7 @@ Three years passed since React was released. The landscape has changed. Multiple
 
 In this post, we will consider the problems commonly caused by mixins. Then we will suggest several alternative patterns for the same use cases. We have found those patterns to scale better with the complexity of the codebase than mixins.
 
-## Why Mixins are Broken {#why-mixins-are-broken}
+## Why Mixins are Broken {/*why-mixins-are-broken*/}
 
 At Facebook, React usage has grown from a few components to thousands of them. This gives us a window into how people use React. Thanks to declarative rendering and top-down data flow, many teams were able to fix a bunch of bugs while shipping new features as they adopted React.
 
@@ -21,7 +21,7 @@ However it’s inevitable that some of our code using React gradually became inc
 
 This doesn’t mean that mixins themselves are bad. People successfully employ them in different languages and paradigms, including some functional languages. At Facebook, we extensively use traits in Hack which are fairly similar to mixins. Nevertheless, we think that mixins are unnecessary and problematic in React codebases. Here’s why.
 
-### Mixins introduce implicit dependencies {#mixins-introduce-implicit-dependencies}
+### Mixins introduce implicit dependencies {/*mixins-introduce-implicit-dependencies*/}
 
 Sometimes a component relies on a certain method defined in the mixin, such as `getClassName()`. Sometimes it’s the other way around, and mixin calls a method like `renderHeader()` on the component. JavaScript is a dynamic language so it’s hard to enforce or document these dependencies.
 
@@ -31,7 +31,7 @@ These implicit dependencies make it hard for new team members to contribute to a
 
 Often, mixins come to depend on other mixins, and removing one of them breaks the other. In these situations it is very tricky to tell how the data flows in and out of mixins, and what their dependency graph looks like. Unlike components, mixins don’t form a hierarchy: they are flattened and operate in the same namespace.
 
-### Mixins cause name clashes {#mixins-cause-name-clashes}
+### Mixins cause name clashes {/*mixins-cause-name-clashes*/}
 
 There is no guarantee that two particular mixins can be used together. For example, if `FluxListenerMixin` defines `handleChange()` and `WindowSizeMixin` defines `handleChange()`, you can’t use them together. You also can’t define a method with this name on your own component.
 
@@ -41,7 +41,7 @@ If you have a name conflict with a mixin from a third party package, you can’t
 
 The situation is no better for mixin authors. Even adding a new method to a mixin is always a potentially breaking change because a method with the same name might already exist on some of the components using it, either directly or through another mixin. Once written, mixins are hard to remove or change. Bad ideas don’t get refactored away because refactoring is too risky.
 
-### Mixins cause snowballing complexity {#mixins-cause-snowballing-complexity}
+### Mixins cause snowballing complexity {/*mixins-cause-snowballing-complexity*/}
 
 Even when mixins start out simple, they tend to become complex over time. The example below is based on a real scenario I’ve seen play out in a codebase.
 
@@ -55,7 +55,7 @@ Every new requirement makes the mixins harder to understand. Components using th
 
 These are the same problems we faced building apps before React. We found that they are solved by declarative rendering, top-down data flow, and encapsulated components. At Facebook, we have been migrating our code to use alternative patterns to mixins, and we are generally happy with the results. You can read about those patterns below.
 
-## Migrating from Mixins {#migrating-from-mixins}
+## Migrating from Mixins {/*migrating-from-mixins*/}
 
 Let’s make it clear that mixins are not technically deprecated. If you use `React.createClass()`, you may keep using them. We only say that they didn’t work well for us, and so we won’t recommend using them in the future.
 
@@ -63,7 +63,7 @@ Every section below corresponds to a mixin usage pattern that we found in the Fa
 
 We hope that you find this list helpful. Please let us know if we missed important use cases so we can either amend the list or be proven wrong!
 
-### Performance Optimizations {#performance-optimizations}
+### Performance Optimizations {/*performance-optimizations*/}
 
 One of the most commonly used mixins is [`PureRenderMixin`](/docs/pure-render-mixin.html). You might be using it in some components to [prevent unnecessary re-renders](/docs/advanced-performance.html#shouldcomponentupdate-in-action) when the props and state are shallowly equal to the previous props and state:
 
@@ -77,7 +77,7 @@ var Button = React.createClass({
 });
 ```
 
-#### Solution {#solution}
+#### Solution {/*solution*/}
 
 To express the same without mixins, you can use the [`shallowCompare`](/docs/shallow-compare.html) function directly instead:
 
@@ -97,7 +97,7 @@ If you use a custom mixin implementing a `shouldComponentUpdate` function with d
 
 We understand that more typing can be annoying. For the most common case, we plan to [introduce a new base class](https://github.com/facebook/react/pull/7195) called `React.PureComponent` in the next minor release. It uses the same shallow comparison as `PureRenderMixin` does today.
 
-### Subscriptions and Side Effects {#subscriptions-and-side-effects}
+### Subscriptions and Side Effects {/*subscriptions-and-side-effects*/}
 
 The second most common type of mixins that we encountered are mixins that subscribe a React component to a third-party data source. Whether this data source is a Flux Store, an Rx Observable, or something else, the pattern is very similar: the subscription is created in `componentDidMount`, destroyed in `componentWillUnmount`, and the change handler calls `this.setState()`.
 
@@ -143,13 +143,13 @@ var CommentList = React.createClass({
 module.exports = CommentList;
 ```
 
-#### Solution {#solution-1}
+#### Solution {/*solution-1*/}
 
 If there is just one component subscribed to this data source, it is fine to embed the subscription logic right into the component. Avoid premature abstractions.
 
 If several components used this mixin to subscribe to a data source, a nice way to avoid repetition is to use a pattern called [“higher-order components”](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750). It can sound intimidating so we will take a closer look at how this pattern naturally emerges from the component model.
 
-#### Higher-Order Components Explained {#higher-order-components-explained}
+#### Higher-Order Components Explained {/*higher-order-components-explained*/}
 
 Let’s forget about React for a second. Consider these two functions that add and multiply numbers, logging the results as they do that:
 
@@ -337,7 +337,7 @@ var CommentListWithSubscription = withSubscription(CommentList);
 module.exports = CommentListWithSubscription;
 ```
 
-#### Solution, Revisited {#solution-revisited}
+#### Solution, Revisited {/*solution-revisited*/}
 
 Now that we understand higher-order components better, let’s take another look at the complete solution that doesn’t involve mixins. There are a few minor changes that are annotated with inline comments:
 
@@ -393,7 +393,7 @@ Higher-order components are a powerful pattern. You can pass additional argument
 
 Like any solution, higher-order components have their own pitfalls. For example, if you heavily use [refs](/docs/more-about-refs.html), you might notice that wrapping something into a higher-order component changes the ref to point to the wrapping component. In practice we discourage using refs for component communication so we don’t think it’s a big issue. In the future, we might consider adding [ref forwarding](https://github.com/facebook/react/issues/4213) to React to solve this annoyance.
 
-### Rendering Logic {#rendering-logic}
+### Rendering Logic {/*rendering-logic*/}
 
 The next most common use case for mixins that we discovered in our codebase is sharing rendering logic between components.
 
@@ -432,7 +432,7 @@ var UserRow = React.createClass({
 
 Multiple components may be sharing `RowMixin` to render the header, and each of them would need to define `getHeaderText()`.
 
-#### Solution {#solution-2}
+#### Solution {/*solution-2*/}
 
 If you see rendering logic inside a mixin, it’s time to extract a component!
 
@@ -465,7 +465,7 @@ Props keep component dependencies explicit, easy to replace, and enforceable wit
 >
 > Defining components as functions is not required. There is also nothing wrong with using lifecycle methods and state—they are first-class React features. We use function components in this example because they are easier to read and we didn’t need those extra features, but classes would work just as fine.
 
-### Context {#context}
+### Context {/*context*/}
 
 Another group of mixins we discovered were helpers for providing and consuming [React context](/docs/context.html). Context is an experimental unstable feature, has [certain issues](https://github.com/facebook/react/issues/2517), and will likely change its API in the future. We don’t recommend using it unless you’re confident there is no other way of solving your problem.
 
@@ -502,7 +502,7 @@ var Link = React.createClass({
 module.exports = Link;
 ```
 
-#### Solution {#solution-3}
+#### Solution {/*solution-3*/}
 
 We agree that hiding context usage from consuming components is a good idea until the context API stabilizes. However, we recommend using higher-order components instead of mixins for this.
 
@@ -543,7 +543,7 @@ module.exports = withRouter(Link);
 
 If you’re using a third party library that only provides a mixin, we encourage you to file an issue with them linking to this post so that they can provide a higher-order component instead. In the meantime, you can create a higher-order component around it yourself in exactly the same way.
 
-### Utility Methods {#utility-methods}
+### Utility Methods {/*utility-methods*/}
 
 Sometimes, mixins are used solely to share utility functions between components:
 
@@ -568,7 +568,7 @@ var Button = React.createClass({
 });
 ```
 
-#### Solution {#solution-4}
+#### Solution {/*solution-4*/}
 
 Put utility functions into regular JavaScript modules and import them. This also makes it easier to test them or use them outside of your components:
 
@@ -583,7 +583,7 @@ var Button = React.createClass({
 });
 ```
 
-### Other Use Cases {#other-use-cases}
+### Other Use Cases {/*other-use-cases*/}
 
 Sometimes people use mixins to selectively add logging to lifecycle methods in some components. In the future, we intend to provide an [official DevTools API](https://github.com/facebook/react/issues/5306) that would let you implement something similar without touching the components. However it’s still very much a work in progress. If you heavily depend on logging mixins for debugging, you might want to keep using those mixins for a little longer.
 

--- a/beta/src/pages/blog/2016/07/22/create-apps-with-no-configuration.md
+++ b/beta/src/pages/blog/2016/07/22/create-apps-with-no-configuration.md
@@ -5,9 +5,9 @@ author: [gaearon]
 
 **[Create React App](https://github.com/facebookincubator/create-react-app)** is a new officially supported way to create single-page React applications. It offers a modern build setup with no configuration.
 
-## Getting Started {#getting-started}
+## Getting Started {/*getting-started*/}
 
-### Installation {#installation}
+### Installation {/*installation*/}
 
 First, install the global package:
 
@@ -17,7 +17,7 @@ npm install -g create-react-app
 
 Node.js 4.x or higher is required.
 
-### Creating an App {#creating-an-app}
+### Creating an App {/*creating-an-app*/}
 
 Now you can use it to create a new app:
 
@@ -29,7 +29,7 @@ This will take a while as npm installs the transitive dependencies, but once it�
 
 ![created folder](/images/blog/create-apps-with-no-configuration/created-folder.png)
 
-### Starting the Server {#starting-the-server}
+### Starting the Server {/*starting-the-server*/}
 
 Run `npm start` to launch the development server. The browser will open automatically with the created app’s URL.
 
@@ -46,7 +46,7 @@ ESLint is also integrated so lint warnings are displayed right in the console:
 
 We only picked a small subset of lint rules that often lead to bugs.
 
-### Building for Production {#building-for-production}
+### Building for Production {/*building-for-production*/}
 
 To build an optimized bundle, run `npm run build`:
 
@@ -54,7 +54,7 @@ To build an optimized bundle, run `npm run build`:
 
 It is minified, correctly envified, and the assets include content hashes for caching.
 
-### One Dependency {#one-dependency}
+### One Dependency {/*one-dependency*/}
 
 Your `package.json` contains only a single build dependency and a few scripts:
 
@@ -78,7 +78,7 @@ Your `package.json` contains only a single build dependency and a few scripts:
 
 We take care of updating Babel, ESLint, and webpack to stable compatible versions so you can update a single dependency to get them all.
 
-### Zero Configuration {#zero-configuration}
+### Zero Configuration {/*zero-configuration*/}
 
 It is worth repeating: there are no configuration files or complicated folder structures. The tool only generates the files you need to build your app.
 
@@ -99,7 +99,7 @@ hello-world/
 
 All the build settings are preconfigured and can’t be changed. Some features, such as testing, are currently missing. This is an intentional limitation, and we recognize it might not work for everybody. And this brings us to the last point.
 
-### No Lock-In {#no-lock-in}
+### No Lock-In {/*no-lock-in*/}
 
 We first saw this feature in [Enclave](https://github.com/eanplatter/enclave), and we loved it. We talked to [Ean](https://twitter.com/EanPlatter), and he was excited to collaborate with us. He already sent a few pull requests!
 
@@ -107,7 +107,7 @@ We first saw this feature in [Enclave](https://github.com/eanplatter/enclave), a
 
 We expect that at early stages, many people will “eject” for one reason or another, but as we learn from them, we will make the default setup more and more compelling while still providing no configuration.
 
-## Try It Out! {#try-it-out}
+## Try It Out! {/*try-it-out*/}
 
 You can find [**Create React App**](https://github.com/facebookincubator/create-react-app) with additional instructions on GitHub.
 
@@ -115,7 +115,7 @@ This is an experiment, and only time will tell if it becomes a popular way of cr
 
 We welcome you to participate in this experiment. Help us build the React tooling that more people can use. We are always [open to feedback](https://github.com/facebookincubator/create-react-app/issues/11).
 
-## The Backstory {#the-backstory}
+## The Backstory {/*the-backstory*/}
 
 React was one of the first libraries to embrace transpiling JavaScript. As a result, even though you can [learn React without any tooling](https://github.com/facebook/react/blob/3fd582643ef3d222a00a0c756292c15b88f9f83c/examples/basic-jsx/index.html), the React ecosystem has commonly become associated with an overwhelming explosion of tools.
 
@@ -135,7 +135,7 @@ This doesn’t mean those tools aren’t great. To many of us, they have become 
 
 Still, we knew it was frustrating to spend days setting up a project when all you wanted was to learn React. We wanted to fix this.
 
-## Could We Fix This? {#could-we-fix-this}
+## Could We Fix This? {/*could-we-fix-this*/}
 
 We found ourselves in an unusual dilemma.
 
@@ -145,7 +145,7 @@ However, tooling at Facebook is different than at many smaller companies. Lintin
 
 The React community is very important to us. We knew that we couldn’t fix the problem within the limits of our open source philosophy. This is why we decided to make an exception, and to ship something that we didn’t use ourselves, but that we thought would be useful to the community.
 
-## The Quest for a React <abbr title="Command Line Interface">CLI</abbr> {#the-quest-for-a-react-abbr-titlecommand-line-interfacecliabbr}
+## The Quest for a React <abbr title="Command Line Interface">CLI</abbr> {/*the-quest-for-a-react-abbr-titlecommand-line-interfacecliabbr*/}
 
 Having just attended [EmberCamp](http://embercamp.com/) a week ago, I was excited about [Ember CLI](https://ember-cli.com/). Ember users have a great “getting started” experience thanks to a curated set of tools united under a single command-line interface. I have heard similar feedback about [Elm Reactor](https://github.com/elm-lang/elm-reactor).
 

--- a/beta/src/pages/blog/2016/08/05/relay-state-of-the-state.md
+++ b/beta/src/pages/blog/2016/08/05/relay-state-of-the-state.md
@@ -5,7 +5,7 @@ author: [josephsavona]
 
 This month marks a year since we released Relay and we'd like to share an update on the project and what's next.
 
-## A Year In Review {#a-year-in-review}
+## A Year In Review {/*a-year-in-review*/}
 
 A year after launch, we're incredibly excited to see an active community forming around Relay and that companies such as Twitter are [using Relay in production](https://fabric.io/blog/building-fabric-mission-control-with-graphql-and-relay):
 
@@ -28,11 +28,11 @@ We've also seen some great open-source projects spring up around Relay:
 
 This is just a small sampling of the community's contributions. So far we've merged over 300 PRs - about 25% of our commits - from over 80 of you. These PRs have improved everything from the website and docs down the very core of the framework. We're humbled by these outstanding contributions and excited to keep working with each of you!
 
-# Retrospective & Roadmap {#retrospective--roadmap}
+# Retrospective & Roadmap {/*retrospective--roadmap*/}
 
 Earlier this year we paused to reflect on the state of the project. What was working well? What could be improved? What features should we add, and what could we remove? A few themes emerged: performance on mobile, developer experience, and empowering the community.
 
-## Mobile Perf {#mobile-perf}
+## Mobile Perf {/*mobile-perf*/}
 
 First, Relay was built to serve the needs of product developers at Facebook. In 2016, that means helping developers to build apps that work well on [mobile devices connecting on slower networks](https://newsroom.fb.com/news/2015/10/news-feed-fyi-building-for-all-connectivity/). For example, people in developing markets commonly use [2011 year-class phones](https://code.facebook.com/posts/307478339448736/year-class-a-classification-system-for-android/) and connect via [2G class networks](https://code.facebook.com/posts/952628711437136/classes-performance-and-network-segmentation-on-android/). These scenarios present their own challenges.
 
@@ -44,17 +44,17 @@ Ideally, though, we could begin fetching data as soon as the native code had loa
 
 The key is that GraphQL is already static - we just need to fully embrace this fact. More on this later.
 
-## Developer Experience {#developer-experience}
+## Developer Experience {/*developer-experience*/}
 
 Next, we've paid attention to the community's feedback and know that, to put it simply, Relay could be "easier" to use (and "simpler" too). This isn't entirely surprising to us - Relay was originally designed as a routing library and gradually morphed into a data-fetching library. Concepts like Relay "routes", for example, no longer serve as critical a role and are just one more concept that developers have to learn about. Another example is mutations: while writes _are_ inherently more complex than reads, our API doesn't make the simple things simple enough.
 
 Alongside our focus on mobile performance, we've also kept the developer experience in mind as we evolve Relay core.
 
-## Empowering the Community {#empowering-the-community}
+## Empowering the Community {/*empowering-the-community*/}
 
 Finally, we want to make it easier for people in the community to develop useful libraries that work with Relay. By comparison, React's small surface area - components - allows developers to build cool things like routing, higher-order components, or reusable text editors. For Relay, this would mean having the framework provide core primitives that users can build upon. We want it to be possible for the community to integrate Relay with view libraries other than React, or to build real-time subscriptions as a complementary library.
 
-# What's Next {#whats-next}
+# What's Next {/*whats-next*/}
 
 These were big goals, and also a bit scary; we knew that incremental improvements would only allow us to move so fast. So in April we started a project to build a new implementation of Relay core targeting low-end mobile devices from the start.
 
@@ -71,7 +71,7 @@ Stepping back, we recognize that any API changes will require an investment on y
 
 Ultimately, we're making these changes because we believe they make Relay better all around: simpler for developers building apps and faster for the people using them.
 
-# Conclusion {#conclusion}
+# Conclusion {/*conclusion*/}
 
 If you made it this far, congrats and thanks for reading! We'll be sharing more information about these changes in some upcoming talks:
 

--- a/beta/src/pages/blog/2016/09/28/our-first-50000-stars.md
+++ b/beta/src/pages/blog/2016/09/28/our-first-50000-stars.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 Just three and a half years ago we open sourced a little JavaScript library called React. The journey since that day has been incredibly exciting.
 
-## Commemorative T-Shirt {#commemorative-t-shirt}
+## Commemorative T-Shirt {/*commemorative-t-shirt*/}
 
 In order to celebrate 50,000 GitHub stars, [Maggie Appleton](http://www.maggieappleton.com/) from [egghead.io](http://egghead.io/) has designed us a special T-shirt, which will be available for purchase from Teespring **only for a week** through Thursday, October 6. Maggie also wrote [a blog post](https://www.behance.net/gallery/43269677/Reacts-50000-Stars-Shirt) showing all the different concepts she came up with before settling on the final design.
 
@@ -20,7 +20,7 @@ The T-shirts are super soft using American Apparel's tri-blend fabric; we also h
 
 Proceeds from the shirts will be donated to [CODE2040](http://www.code2040.org/), a nonprofit that creates access, awareness, and opportunities in technology for underrepresented minorities with a specific focus on Black and Latinx talent.
 
-## Archeology {#archeology}
+## Archeology {/*archeology*/}
 
 We've spent a lot of time trying to explain the concepts behind React and the problems it attempts to solve, but we haven't talked much about how React evolved before being open sourced. This milestone seemed like as good a time as any to dig through the earliest commits and share some of the more important moments and fun facts.
 
@@ -81,7 +81,7 @@ TestProject.PersonDisplayer = {
 };
 ```
 
-## FBolt is Born {#fbolt-is-born}
+## FBolt is Born {/*fbolt-is-born*/}
 
 Through his FaxJS experiment, Jordan became convinced that functional APIs — which discouraged mutation — offered a better, more scalable way to build user interfaces. He imported his library into Facebook's codebase in March of 2012 and renamed it “FBolt”, signifying an extension of Bolt where components are written in a functional programming style. Or maybe “FBolt” was a nod to FaxJS – he didn't tell us! ;)
 
@@ -94,7 +94,7 @@ Realizing that FBolt wouldn't be a great name for the library when used on its o
 
 Most of Tom's other commits at the time were on the first version of [GraphiQL](https://github.com/graphql/graphiql), a project which was recently open sourced.
 
-## Adding JSX {#adding-jsx}
+## Adding JSX {/*adding-jsx*/}
 
 Since about 2010 Facebook has been using an extension of PHP called [XHP](https://www.facebook.com/notes/facebook-engineering/xhp-a-new-way-to-write-php/294003943919/), which enables engineers to create UIs using XML literals right inside their PHP code. It was first introduced to help prevent XSS holes but ended up being an excellent way to structure applications with custom components.
 
@@ -176,7 +176,7 @@ Adam made a very insightful comment, which is now the default way we write lists
 
 React didn't end up using Adam's implementation directly. Instead, we created JSX by forking [js-xml-literal](https://github.com/laverdet/js-xml-literal), a side project by XHP creator Marcel Laverdet. JSX took its name from js-xml-literal, which Jordan modified to just be syntactic sugar for deeply nested function calls.
 
-## API Churn {#api-churn}
+## API Churn {/*api-churn*/}
 
 During the first year of React, internal adoption was growing quickly but there was quite a lot of churn in the component APIs and naming conventions:
 
@@ -210,7 +210,7 @@ As the project was about to be open sourced, [Lee Byron](https://twitter.com/lee
   - objectWillAction
   - objectDidAction
 
-## Instagram {#instagram}
+## Instagram {/*instagram*/}
 
 In 2012, Instagram got acquired by Facebook. [Pete Hunt](https://twitter.com/floydophone), who was working on Facebook photos and videos at the time, joined their newly formed web team. He wanted to build their website completely in React, which was in stark contrast with the incremental adoption model that had been used at Facebook.
 

--- a/beta/src/pages/blog/2016/11/16/react-v15.4.0.md
+++ b/beta/src/pages/blog/2016/11/16/react-v15.4.0.md
@@ -7,7 +7,7 @@ Today we are releasing React 15.4.0.
 
 We didn't announce the [previous](https://github.com/facebook/react/blob/master/CHANGELOG.md#1510-may-20-2016) [minor](https://github.com/facebook/react/blob/master/CHANGELOG.md#1520-july-1-2016) [releases](https://github.com/facebook/react/blob/master/CHANGELOG.md#1530-july-29-2016) on the blog because most of the changes were bug fixes. However, 15.4.0 is a special release, and we would like to highlight a few notable changes in it.
 
-### Separating React and React DOM {#separating-react-and-react-dom}
+### Separating React and React DOM {/*separating-react-and-react-dom*/}
 
 [More than a year ago](/blog/2015/09/10/react-v0.14-rc1.html#two-packages-react-and-react-dom), we started separating React and React DOM into separate packages. We deprecated `React.render()` in favor of `ReactDOM.render()` in React 0.14, and removed DOM-specific APIs from `React` completely in React 15. However, the React DOM implementation still [secretly lived inside the React package](https://www.reddit.com/r/javascript/comments/3m6wyu/found_this_line_in_the_react_codebase_made_me/cvcyo4a/).
 
@@ -21,7 +21,7 @@ However, there is a possibility that you imported private APIs from `react/lib/*
 
 Another thing to watch out for is that React DOM Server is now about the same size as React DOM since it contains its own copy of the React reconciler. We don't recommend using React DOM Server on the client in most cases.
 
-### Profiling Components with Chrome Timeline {#profiling-components-with-chrome-timeline}
+### Profiling Components with Chrome Timeline {/*profiling-components-with-chrome-timeline*/}
 
 You can now visualize React components in the Chrome Timeline. This lets you see which components exactly get mounted, updated, and unmounted, how much time they take relative to each other.
 
@@ -43,7 +43,7 @@ Note that the numbers are relative so components will render faster in productio
 
 Currently Chrome, Edge, and IE are the only browsers supporting this feature, but we use the standard [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API) so we expect more browsers to add support for it.
 
-### Mocking Refs for Snapshot Testing {#mocking-refs-for-snapshot-testing}
+### Mocking Refs for Snapshot Testing {/*mocking-refs-for-snapshot-testing*/}
 
 If you're using Jest [snapshot testing](https://facebook.github.io/jest/blog/2016/07/27/jest-14.html), you might have had [issues](https://github.com/facebook/react/issues/7371) with components that rely on refs. With React 15.4.0, we introduce a way to provide mock refs to the test renderer. For example, consider this component using a ref in `componentDidMount`:
 
@@ -94,7 +94,7 @@ You can learn more about snapshot testing in [this Jest blog post](https://faceb
 
 ---
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 
@@ -133,9 +133,9 @@ We've also published version `15.4.0` of the `react`, `react-dom`, and addons pa
 
 - - -
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 * React package and browser build no longer "secretly" includes React DOM.  
   <small>([@sebmarkbage](https://github.com/sebmarkbage) in [#7164](https://github.com/facebook/react/pull/7164) and [#7168](https://github.com/facebook/react/pull/7168))</small>
 * Required PropTypes now fail with specific messages for null and undefined.  
@@ -143,7 +143,7 @@ We've also published version `15.4.0` of the `react`, `react-dom`, and addons pa
 * Improved development performance by freezing children instead of copying.  
   <small>([@keyanzhang](https://github.com/keyanzhang) in [#7455](https://github.com/facebook/react/pull/7455))</small>
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 * Fixed occasional test failures when React DOM is used together with shallow renderer.  
   <small>([@goatslacker](https://github.com/goatslacker) in [#8097](https://github.com/facebook/react/pull/8097))</small>
 * Added a warning for invalid `aria-` attributes.  
@@ -159,15 +159,15 @@ We've also published version `15.4.0` of the `react`, `react-dom`, and addons pa
 * Fixed a bug with updating text in IE 8.  
   <small>([@mnpenner](https://github.com/mnpenner) in [#7832](https://github.com/facebook/react/pull/7832))</small>
 
-### React Perf {#react-perf}
+### React Perf {/*react-perf*/}
 * When ReactPerf is started, you can now view the relative time spent in components as a chart in Chrome Timeline.  
   <small>([@gaearon](https://github.com/gaearon) in [#7549](https://github.com/facebook/react/pull/7549))</small>
 
-### React Test Utils {#react-test-utils}
+### React Test Utils {/*react-test-utils*/}
 * If you call `Simulate.click()` on a `<input disabled onClick={foo} />` then `foo` will get called whereas it didn't before.  
   <small>([@nhunzaker](https://github.com/nhunzaker) in [#7642](https://github.com/facebook/react/pull/7642))</small>
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 * Due to packaging changes, it no longer crashes when imported together with React DOM in the same file.  
   <small>([@sebmarkbage](https://github.com/sebmarkbage) in [#7164](https://github.com/facebook/react/pull/7164) and [#7168](https://github.com/facebook/react/pull/7168))</small>
 * `ReactTestRenderer.create()` now accepts `{createNodeMock: element => mock}` as an optional argument so you can mock refs with snapshot testing.  

--- a/beta/src/pages/blog/2017/04/07/react-v15.5.0.md
+++ b/beta/src/pages/blog/2017/04/07/react-v15.5.0.md
@@ -7,7 +7,7 @@ It's been exactly one year since the last breaking change to React. Our next maj
 
 To that end, today we're releasing React 15.5.0.
 
-### New Deprecation Warnings {#new-deprecation-warnings}
+### New Deprecation Warnings {/*new-deprecation-warnings*/}
 
 The biggest change is that we've extracted `React.PropTypes` and `React.createClass` into their own packages. Both are still accessible via the main `React` object, but using either will log a one-time deprecation warning to the console when in development mode. This will enable future code size optimizations.
 
@@ -19,7 +19,7 @@ So while the warnings may cause frustration in the short-term, we believe **prod
 
 For each of these new deprecations, we've provided a codemod to automatically migrate your code. They are available as part of the [react-codemod](https://github.com/reactjs/react-codemod) project.
 
-### Migrating from React.PropTypes {#migrating-from-reactproptypes}
+### Migrating from React.PropTypes {/*migrating-from-reactproptypes*/}
 
 Prop types are a feature for runtime validation of props during development. We've extracted the built-in prop types to a separate package to reflect the fact that not everybody uses them.
 
@@ -64,7 +64,7 @@ The `propTypes`, `contextTypes`, and `childContextTypes` APIs will work exactly 
 
 You may also consider using [Flow](https://flow.org/) to statically type check your JavaScript code, including [React components](https://flow.org/en/docs/react/components/).
 
-### Migrating from React.createClass {#migrating-from-reactcreateclass}
+### Migrating from React.createClass {/*migrating-from-reactcreateclass*/}
 
 When React was initially released, there was no idiomatic way to create classes in JavaScript, so we provided our own: `React.createClass`.
 
@@ -105,7 +105,7 @@ Basic usage:
 jscodeshift -t react-codemod/transforms/class.js path/to/components
 ```
 
-### Discontinuing support for React Addons {#discontinuing-support-for-react-addons}
+### Discontinuing support for React Addons {/*discontinuing-support-for-react-addons*/}
 
 We're discontinuing active maintenance of React Addons packages. In truth, most of these packages haven't been actively maintained in a long time. They will continue to work indefinitely, but we recommend migrating away as soon as you can to prevent future breakages.
 
@@ -120,7 +120,7 @@ We're discontinuing active maintenance of React Addons packages. In truth, most 
 
 We're also discontinuing support for the `react-with-addons` UMD build. It will be removed in React 16.
 
-### React Test Utils {#react-test-utils}
+### React Test Utils {/*react-test-utils*/}
 
 Currently, the React Test Utils live inside `react-addons-test-utils`. As of 15.5, we're deprecating that package and moving them to `react-dom/test-utils` instead:
 
@@ -146,7 +146,7 @@ import {createRenderer} from 'react-test-renderer/shallow';
 
 ---
 
-## Acknowledgements {#acknowledgements}
+## Acknowledgements {/*acknowledgements*/}
 
 A special thank you to these folks for transferring ownership of npm package names:
 
@@ -156,7 +156,7 @@ A special thank you to these folks for transferring ownership of npm package nam
 
 ---
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 
@@ -195,11 +195,11 @@ We've also published version `15.5.0` of the `react`, `react-dom`, and addons pa
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-## 15.5.0 (April 7, 2017) {#1550-april-7-2017}
+## 15.5.0 (April 7, 2017) {/*1550-april-7-2017*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Added a deprecation warning for `React.createClass`. Points users to create-react-class instead. ([@acdlite](https://github.com/acdlite) in [d9a4fa4](https://github.com/facebook/react/commit/d9a4fa4f51c6da895e1655f32255cf72c0fe620e))
 - Added a deprecation warning for `React.PropTypes`. Points users to prop-types instead. ([@acdlite](https://github.com/acdlite) in [043845c](https://github.com/facebook/react/commit/043845ce75ea0812286bbbd9d34994bb7e01eb28))
@@ -208,17 +208,17 @@ We've also published version `15.5.0` of the `react`, `react-dom`, and addons pa
 - Another fix for Closure Compiler. ([@Shastel](https://github.com/Shastel) in [#8882](https://github.com/facebook/react/pull/8882))
 - Added component stack info to invalid element type warning. ([@n3tr](https://github.com/n3tr) in [#8495](https://github.com/facebook/react/pull/8495))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fixed Chrome bug when backspacing in number inputs. ([@nhunzaker](https://github.com/nhunzaker) in [#7359](https://github.com/facebook/react/pull/7359))
 - Added `react-dom/test-utils`, which exports the React Test Utils. ([@bvaughn](https://github.com/bvaughn))
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 
 - Fixed bug where `componentWillUnmount` was not called for children. ([@gre](https://github.com/gre) in [#8512](https://github.com/facebook/react/pull/8512))
 - Added `react-test-renderer/shallow`, which exports the shallow renderer. ([@bvaughn](https://github.com/bvaughn))
 
-### React Addons {#react-addons}
+### React Addons {/*react-addons*/}
 
 - Last release for addons; they will no longer be actively maintained.
 - Removed `peerDependencies` so that addons continue to work indefinitely. ([@acdlite](https://github.com/acdlite) and [@bvaughn](https://github.com/bvaughn) in [8a06cd7](https://github.com/facebook/react/commit/8a06cd7a786822fce229197cac8125a551e8abfa) and [67a8db3](https://github.com/facebook/react/commit/67a8db3650d724a51e70be130e9008806402678a))

--- a/beta/src/pages/blog/2017/05/18/whats-new-in-create-react-app.md
+++ b/beta/src/pages/blog/2017/05/18/whats-new-in-create-react-app.md
@@ -27,7 +27,7 @@ The biggest notable webpack 2 feature is the ability to write and import [ES6 mo
 
 In the future, as the ecosystem around ES6 modules matures, you can expect more improvements to your app's bundle size thanks to [tree shaking](https://webpack.js.org/guides/tree-shaking/).
 
-### Runtime Error Overlay {#error-overlay}
+### Runtime Error Overlay {#error-overlay}
 
 > _This change was contributed by [@Timer](https://github.com/Timer) and [@nicinabox](https://github.com/nicinabox) in [#1101](https://github.com/facebookincubator/create-react-app/pull/1101), [@bvaughn](https://github.com/bvaughn) in [#2201](https://github.com/facebookincubator/create-react-app/pull/2201)._
 

--- a/beta/src/pages/blog/2017/05/18/whats-new-in-create-react-app.md
+++ b/beta/src/pages/blog/2017/05/18/whats-new-in-create-react-app.md
@@ -11,7 +11,7 @@ As usual with Create React App, **you can enjoy these improvements in your exist
 
 Newly created apps will get these improvements automatically.
 
-### webpack 2 {#webpack-2}
+### webpack 2 {/*webpack-2*/}
 
 > _This change was contributed by [@Timer](https://github.com/Timer) in [#1291](https://github.com/facebookincubator/create-react-app/pull/1291)._
 
@@ -27,7 +27,7 @@ The biggest notable webpack 2 feature is the ability to write and import [ES6 mo
 
 In the future, as the ecosystem around ES6 modules matures, you can expect more improvements to your app's bundle size thanks to [tree shaking](https://webpack.js.org/guides/tree-shaking/).
 
-### Runtime Error Overlay {#error-overlay}
+### Runtime Error Overlay {/*error-overlay*/}
 
 > _This change was contributed by [@Timer](https://github.com/Timer) and [@nicinabox](https://github.com/nicinabox) in [#1101](https://github.com/facebookincubator/create-react-app/pull/1101), [@bvaughn](https://github.com/bvaughn) in [#2201](https://github.com/facebookincubator/create-react-app/pull/2201)._
 
@@ -43,7 +43,7 @@ A GIF is worth a thousand words:
 
 In the future, we plan to teach the runtime error overlay to understand more about your React app. For example, after React 16 we plan to show React component stacks in addition to the JavaScript stacks when an error is thrown.
 
-### Progressive Web Apps by Default {#progressive-web-apps-by-default}
+### Progressive Web Apps by Default {/*progressive-web-apps-by-default*/}
 
 > _This change was contributed by [@jeffposnick](https://github.com/jeffposnick) in [#1728](https://github.com/facebookincubator/create-react-app/pull/1728)._
 
@@ -55,7 +55,7 @@ New apps automatically have these features, but you can easily convert an existi
 
 We will be adding [more documentation](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#making-a-progressive-web-app) on this topic in the coming weeks. Please feel free to [ask any questions](https://github.com/facebookincubator/create-react-app/issues/new) on the issue tracker!
 
-### Jest 20 {#jest-20}
+### Jest 20 {/*jest-20*/}
 
 > _This change was contributed by [@rogeliog](https://github.com/rogeliog) in [#1614](https://github.com/facebookincubator/create-react-app/pull/1614) and [@gaearon](https://github.com/gaearon) in [#2171](https://github.com/facebookincubator/create-react-app/pull/2171)._
 
@@ -67,7 +67,7 @@ Highlights include a new [immersive watch mode](https://facebook.github.io/jest/
 
 Additionally, Create React App now support configuring a few Jest options related to coverage reporting.
 
-### Code Splitting with Dynamic import() {#code-splitting-with-dynamic-import}
+### Code Splitting with Dynamic import() {/*code-splitting-with-dynamic-import*/}
 
 > _This change was contributed by [@Timer](https://github.com/Timer) in [#1538](https://github.com/facebookincubator/create-react-app/pull/1538) and [@tharakawj](https://github.com/tharakawj) in [#1801](https://github.com/facebookincubator/create-react-app/pull/1801)._
 
@@ -77,7 +77,7 @@ In this release, we are adding support for the [dynamic `import()` proposal](htt
 
 ![Creating chunks with dynamic import](/images/blog/cra-dynamic-import.gif)
 
-### Better Console Output {#better-console-output}
+### Better Console Output {/*better-console-output*/}
 
 > _This change was contributed by [@gaearon](https://github.com/gaearon) in [#2120](https://github.com/facebookincubator/create-react-app/pull/2120), [#2125](https://github.com/facebookincubator/create-react-app/pull/2125), and [#2161](https://github.com/facebookincubator/create-react-app/pull/2161)._
 
@@ -89,13 +89,13 @@ For example, when you start the development server, we now display the LAN addre
 
 When lint errors are reported, we no longer show the warnings so that you can concentrate on more critical issues. Errors and warnings in the production build output are better formatted, and the build error overlay font size now matches the browser font size more closely.
 
-### But Wait... There's More! {#but-wait-theres-more}
+### But Wait... There's More! {/*but-wait-theres-more*/}
 
 You can only fit so much in a blog post, but there are other long-requested features in this release, such as [environment-specific and local `.env` files](https://github.com/facebookincubator/create-react-app/pull/1344), [a lint rule against confusingly named globals](https://github.com/facebookincubator/create-react-app/pull/2130), [support for multiple proxies in development](https://github.com/facebookincubator/create-react-app/pull/1790), [a customizable browser launch script](https://github.com/facebookincubator/create-react-app/pull/1590), and many bugfixes.
 
 You can read the full changelog and the migration guide in the [v1.0.0 release notes](https://github.com/facebookincubator/create-react-app/releases/tag/v1.0.0).
 
-### Acknowledgements {#acknowledgements}
+### Acknowledgements {/*acknowledgements*/}
 
 This release is a result of months of work from many people in the React community. It is focused on improving both developer and end user experience, as we believe they are complementary and go hand in hand.
 

--- a/beta/src/pages/blog/2017/06/13/react-v15.6.0.md
+++ b/beta/src/pages/blog/2017/06/13/react-v15.6.0.md
@@ -5,7 +5,7 @@ author: [flarnie]
 
 Today we are releasing React 15.6.0. As we prepare for React 16.0, we have been fixing and cleaning up many things. This release continues to pave the way.
 
-## Improving Inputs {#improving-inputs}
+## Improving Inputs {/*improving-inputs*/}
 
 In React 15.6.0 the `onChange` event for inputs is a little bit more reliable and handles more edge cases, including the following:
 
@@ -18,7 +18,7 @@ In React 15.6.0 the `onChange` event for inputs is a little bit more reliable an
 
 Thanks to [Jason Quense](https://github.com/jquense) and everyone who helped out on those issues and PRs.
 
-## Less Noisy Deprecation Warnings {#less-noisy-deprecation-warnings}
+## Less Noisy Deprecation Warnings {/*less-noisy-deprecation-warnings*/}
 
 We are also including a couple of new warnings for upcoming deprecations. These should not affect most users, and for more details see the changelog below.
 
@@ -26,7 +26,7 @@ After the last release, we got valuable community feedback that deprecation warn
 
 ---
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 
@@ -65,18 +65,18 @@ We've also published version `15.6.0` of `react` and `react-dom` on npm, and the
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-## 15.6.0 (June 13, 2017) {#1560-june-13-2017}
+## 15.6.0 (June 13, 2017) {/*1560-june-13-2017*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Downgrade deprecation warnings to use `console.warn` instead of `console.error`. ([@flarnie](https://github.com/flarnie) in [#9753](https://github.com/facebook/react/pull/9753))
 - Add a deprecation warning for `React.createClass`. Points users to `create-react-class` instead. ([@flarnie](https://github.com/flarnie) in [#9771](https://github.com/facebook/react/pull/9771))
 - Add deprecation warnings and separate module for `React.DOM` factory helpers. ([@nhunzaker](https://github.com/nhunzaker) in [#8356](https://github.com/facebook/react/pull/8356))
 - Warn for deprecation of `React.createMixin` helper, which was never used. ([@aweary](https://github.com/aweary) in [#8853](https://github.com/facebook/react/pull/8853))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Add support for CSS variables in `style` attribute. ([@aweary](https://github.com/aweary) in [#9302](https://github.com/facebook/react/pull/9302))
 - Add support for CSS Grid style properties. ([@ericsakmar](https://github.com/ericsakmar) in [#9185](https://github.com/facebook/react/pull/9185))
@@ -85,7 +85,7 @@ We've also published version `15.6.0` of `react` and `react-dom` on npm, and the
 - Fix bug where controlled number input mistakenly allowed period. ([@nhunzaker](https://github.com/nhunzaker) in [#9584](https://github.com/facebook/react/pull/9584))
 - Fix bug where performance entries were being cleared. ([@chrisui](https://github.com/chrisui) in [#9451](https://github.com/facebook/react/pull/9451))
 
-### React Addons {#react-addons}
+### React Addons {/*react-addons*/}
 
 - Fix AMD support for addons depending on `react`. ([@flarnie](https://github.com/flarnie) in [#9919](https://github.com/facebook/react/issues/9919))
 - Fix `isMounted()` to return `true` in `componentWillUnmount`. ([@mridgway](https://github.com/mridgway) in [#9638](https://github.com/facebook/react/issues/9638))

--- a/beta/src/pages/blog/2017/07/26/error-handling-in-react-16.md
+++ b/beta/src/pages/blog/2017/07/26/error-handling-in-react-16.md
@@ -7,11 +7,11 @@ As React 16 release is getting closer, we would like to announce a few changes t
 
 **By the way, [we just released the first beta of React 16 for you to try!](https://github.com/facebook/react/issues/10294)**
 
-## Behavior in React 15 and Earlier {#behavior-in-react-15-and-earlier}
+## Behavior in React 15 and Earlier {/*behavior-in-react-15-and-earlier*/}
 
 In the past, JavaScript errors inside components used to corrupt React’s internal state and cause it to [emit](https://github.com/facebook/react/issues/4026) [cryptic](https://github.com/facebook/react/issues/6895) [errors](https://github.com/facebook/react/issues/8579) on next renders. These errors were always caused by an earlier error in the application code, but React did not provide a way to handle them gracefully in components, and could not recover from them.
 
-## Introducing Error Boundaries {#introducing-error-boundaries}
+## Introducing Error Boundaries {/*introducing-error-boundaries*/}
 
 A JavaScript error in a part of the UI shouldn’t break the whole app. To solve this problem for React users, React 16 introduces a new concept of an “error boundary”.
 
@@ -55,15 +55,15 @@ The `componentDidCatch()` method works like a JavaScript `catch {}` block, but f
 
 Note that **error boundaries only catch errors in the components below them in the tree**. An error boundary can’t catch an error within itself. If an error boundary fails trying to render the error message, the error will propagate to the closest error boundary above it. This, too, is similar to how `catch {}` block works in JavaScript.
 
-## Live Demo {#live-demo}
+## Live Demo {/*live-demo*/}
 
 Check out [this example of declaring and using an error boundary](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) with [React 16 beta](https://github.com/facebook/react/issues/10294).
 
-## Where to Place Error Boundaries {#where-to-place-error-boundaries}
+## Where to Place Error Boundaries {/*where-to-place-error-boundaries*/}
 
 The granularity of error boundaries is up to you. You may wrap top-level route components to display a “Something went wrong” message to the user, just like server-side frameworks often handle crashes. You may also wrap individual widgets in an error boundary to protect them from crashing the rest of the application.
 
-## New Behavior for Uncaught Errors {#new-behavior-for-uncaught-errors}
+## New Behavior for Uncaught Errors {/*new-behavior-for-uncaught-errors*/}
 
 This change has an important implication. **As of React 16, errors that were not caught by any error boundary will result in unmounting of the whole React component tree.**
 
@@ -75,7 +75,7 @@ For example, Facebook Messenger wraps content of the sidebar, the info panel, th
 
 We also encourage you to use JS error reporting services (or build your own) so that you can learn about unhandled exceptions as they happen in production, and fix them.
 
-## Component Stack Traces {#component-stack-traces}
+## Component Stack Traces {/*component-stack-traces*/}
 
 React 16 prints all errors that occurred during rendering to the console in development, even if the application accidentally swallows them. In addition to the error message and the JavaScript stack, it also provides component stack traces. Now you can see where exactly in the component tree the failure has happened:
 
@@ -89,7 +89,7 @@ You can also see the filenames and line numbers in the component stack trace. Th
 
 If you don’t use Create React App, you can add [this plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manually to your Babel configuration. Note that it’s intended only for development and **must be disabled in production**.
 
-## Why Not Use `try` / `catch`? {#why-not-use-try--catch}
+## Why Not Use `try` / `catch`? {/*why-not-use-try--catch*/}
 
 `try` / `catch` is great but it only works for imperative code:
 
@@ -109,7 +109,7 @@ However, React components are declarative and specify *what* should be rendered:
 
 Error boundaries preserve the declarative nature of React, and behave as you would expect. For example, even if an error occurs in a `componentDidUpdate` method caused by a `setState` somewhere deep in the tree, it will still correctly propagate to the closest error boundary.
 
-## Naming Changes from React 15 {#naming-changes-from-react-15}
+## Naming Changes from React 15 {/*naming-changes-from-react-15*/}
 
 React 15 included a very limited support for error boundaries under a different method name: `unstable_handleError`. This method no longer works, and you will need to change it to `componentDidCatch` in your code starting from the first 16 beta release.
 

--- a/beta/src/pages/blog/2017/09/08/dom-attributes-in-react-16.md
+++ b/beta/src/pages/blog/2017/09/08/dom-attributes-in-react-16.md
@@ -24,7 +24,7 @@ In React 16, we are making a change. Now, any unknown attributes will end up in 
 <div mycustomattribute="something" />
 ```
 
-## Why Are We Changing This? {#why-are-we-changing-this}
+## Why Are We Changing This? {/*why-are-we-changing-this*/}
 
 React has always provided a JavaScript-centric API to the DOM. Since React components often take both custom and DOM-related props, it makes sense for React to use the `camelCase` convention just like the DOM APIs:
 
@@ -63,13 +63,13 @@ With the new approach, both of these problems are solved. With React 16, you can
 
 In other words, the way you use DOM components in React hasn't changed, but now you have some new capabilities.
 
-## Should I Keep Data in Custom Attributes? {#should-i-keep-data-in-custom-attributes}
+## Should I Keep Data in Custom Attributes? {/*should-i-keep-data-in-custom-attributes*/}
 
 No. We don't encourage you to keep data in DOM attributes. Even if you have to, `data-` attributes are probably a better approach, but in most cases data should be kept in React component state or external stores.
 
 However, the new feature is handy if you need to use a non-standard or a new DOM attribute, or if you need to integrate with a third-party library that relies on such attributes.
 
-## Data and ARIA Attributes {#data-and-aria-attributes}
+## Data and ARIA Attributes {/*data-and-aria-attributes*/}
 
 Just like before, React lets you pass `data-` and `aria-` attributes freely:
 
@@ -82,7 +82,7 @@ This has not changed.
 
 [Accessibility](/docs/accessibility) is very important, so even though React 16 passes any attributes through, it still validates that `aria-` props have correct names in development mode, just like React 15 did.
 
-## Migration Path {#migration-path}
+## Migration Path {/*migration-path*/}
 
 We have included [a warning about unknown attributes](/warnings/unknown-prop) since [React 15.2.0](https://github.com/facebook/react/releases/tag/v15.2.0) which came out more than a year ago. The vast majority of third-party libraries have already updated their code. If your app doesn't produce warnings with React 15.2.0 or higher, this change should not require modifications in your application code.
 
@@ -96,7 +96,7 @@ This is somewhat safe (the browser will just ignore them) but we recommend to fi
 
 To avoid these problems, we suggest to fix the warnings you see in React 15 before upgrading to React 16.
 
-## Changes in Detail {#changes-in-detail}
+## Changes in Detail {/*changes-in-detail*/}
 
 We've made a few other changes to make the behavior more predictable and help ensure you're not making mistakes. We don't anticipate that these changes are likely to break real-world applications.
 
@@ -167,12 +167,12 @@ Below is a detailed list of them.
 
 While testing this release, we have also [created an automatically generated table](https://github.com/facebook/react/blob/master/fixtures/attribute-behavior/AttributeTableSnapshot.md) for all known attributes to track potential regressions.
 
-## Try It! {#try-it}
+## Try It! {/*try-it*/}
 
 You can try the change in [this CodePen](https://codepen.io/gaearon/pen/gxNVdP?editors=0010).  
 It uses React 16 RC, and you can [help us by testing the RC in your project!](https://github.com/facebook/react/issues/10294)
 
-## Thanks {#thanks}
+## Thanks {/*thanks*/}
 
 This effort was largely driven by [Nathan Hunzaker](https://github.com/nhunzaker) who has been a [prolific outside contributor to React](https://github.com/facebook/react/pulls?q=is:pr+author:nhunzaker+is:closed).
 
@@ -182,6 +182,6 @@ Major changes in a popular project can take a lot of time and research. Nathan d
 
 We would also like to thank [Brandon Dail](https://github.com/aweary) and [Jason Quense](https://github.com/jquense) for their invaluable help maintaining React this year.
 
-## Future Work {#future-work}
+## Future Work {/*future-work*/}
 
 We are not changing how [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements) work in React 16, but there are [existing discussions](https://github.com/facebook/react/issues/7249) about setting properties instead of attributes, and we might revisit this in React 17. Feel free to chime in if you'd like to help!

--- a/beta/src/pages/blog/2017/09/25/react-v15.6.2.md
+++ b/beta/src/pages/blog/2017/09/25/react-v15.6.2.md
@@ -7,7 +7,7 @@ Today we're sending out React 15.6.2. In 15.6.1, we shipped a few fixes for chan
 
 Additionally, 15.6.2 adds support for the [`controlList`](https://developers.google.com/web/updates/2017/03/chrome-58-media-updates#controlslist) attribute, and CSS columns are no longer appended with a `px` suffix.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We recommend using [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) for managing front-end dependencies. If you're new to package managers, the [Yarn documentation](https://yarnpkg.com/en/docs/getting-started) is a good place to get started.
 
@@ -46,15 +46,15 @@ We've also published version `15.6.2` of `react` and `react-dom` on npm, and the
 
 ---
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-## 15.6.2 (September 25, 2017) {#1562-september-25-2017}
+## 15.6.2 (September 25, 2017) {/*1562-september-25-2017*/}
 
-### All Packages {#all-packages}
+### All Packages {/*all-packages*/}
 
 - Switch from BSD + Patents to MIT license
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fix a bug where modifying `document.documentMode` would trigger IE detection in other browsers, breaking change events. ([@aweary](https://github.com/aweary) in [#10032](https://github.com/facebook/react/pull/10032))
 - CSS Columns are treated as unitless numbers. ([@aweary](https://github.com/aweary) in [#10115](https://github.com/facebook/react/pull/10115))

--- a/beta/src/pages/blog/2017/09/26/react-v16.0.md
+++ b/beta/src/pages/blog/2017/09/26/react-v16.0.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 We're excited to announce the release of React v16.0! Among the changes are some long-standing feature requests, including [**fragments**](#new-render-return-types-fragments-and-strings), [**error boundaries**](#better-error-handling), [**portals**](#portals), support for [**custom DOM attributes**](#support-for-custom-dom-attributes), improved [**server-side rendering**](#better-server-side-rendering), and [**reduced file size**](#reduced-file-size).
 
-### New render return types: fragments and strings {#new-render-return-types-fragments-and-strings}
+### New render return types: fragments and strings {/*new-render-return-types-fragments-and-strings*/}
 
 You can now return an array of elements from a component's `render` method. Like with other arrays, you'll need to add a key to each element to avoid the key warning:
 
@@ -33,7 +33,7 @@ render() {
 
 [See the full list of supported return types](/docs/react-component#render).
 
-### Better error handling {#better-error-handling}
+### Better error handling {/*better-error-handling*/}
 
 Previously, runtime errors during rendering could put React in a broken state, producing cryptic error messages and requiring a page refresh to recover. To address this problem, React 16 uses a more resilient error-handling strategy. By default, if an error is thrown inside a component's render or lifecycle methods, the whole component tree is unmounted from the root. This prevents the display of corrupted data. However, it's probably not the ideal user experience.
 
@@ -41,7 +41,7 @@ Instead of unmounting the whole app every time there's an error, you can use err
 
 For more details, check out our [previous post on error handling in React 16](/blog/2017/07/26/error-handling-in-react-16).
 
-### Portals {#portals}
+### Portals {/*portals*/}
 
 Portals provide a first-class way to render children into a DOM node that exists outside the DOM hierarchy of the parent component.
 
@@ -58,7 +58,7 @@ render() {
 
 See a full example in the [documentation for portals](/docs/portals).
 
-### Better server-side rendering {#better-server-side-rendering}
+### Better server-side rendering {/*better-server-side-rendering*/}
 
 React 16 includes a completely rewritten server renderer. It's really fast. It supports **streaming**, so you can start sending bytes to the client faster. And thanks to a [new packaging strategy](#reduced-file-size) that compiles away `process.env` checks (Believe it or not, reading `process.env` in Node is really slow!), you no longer need to bundle React to get good server-rendering performance.
 
@@ -68,11 +68,11 @@ In addition, React 16 is better at hydrating server-rendered HTML once it reache
 
 See the [documentation for `ReactDOMServer`](/docs/react-dom-server) for more details.
 
-### Support for custom DOM attributes {#support-for-custom-dom-attributes}
+### Support for custom DOM attributes {/*support-for-custom-dom-attributes*/}
 
 Instead of ignoring unrecognized HTML and SVG attributes, React will now [pass them through to the DOM](/blog/2017/09/08/dom-attributes-in-react-16). This has the added benefit of allowing us to get rid of most of React's attribute whitelist, resulting in reduced file sizes.
 
-### Reduced file size {#reduced-file-size}
+### Reduced file size {/*reduced-file-size*/}
 
 Despite all these additions, React 16 is actually **smaller** compared to 15.6.1!
 
@@ -84,11 +84,11 @@ That amounts to a combined **32% size decrease compared to the previous version 
 
 The size difference is partly attributable to a change in packaging. React now uses [Rollup](https://rollupjs.org/) to create flat bundles for each of its different target formats, resulting in both size and runtime performance wins. The flat bundle format also means that React's impact on bundle size is roughly consistent regardless of how you ship your app, whether it's with Webpack, Browserify, the pre-built UMD bundles, or any other system.
 
-### MIT licensed {#mit-licensed}
+### MIT licensed {/*mit-licensed*/}
 
 [In case you missed it](https://code.facebook.com/posts/300798627056246/relicensing-react-jest-flow-and-immutable-js/), React 16 is available under the MIT license. We've also published React 15.6.2 under MIT, for those who are unable to upgrade immediately.
 
-### New core architecture {#new-core-architecture}
+### New core architecture {/*new-core-architecture*/}
 
 React 16 is the first version of React built on top of a new core architecture, codenamed "Fiber." You can read all about this project over on [Facebook's engineering blog](https://code.facebook.com/posts/1716776591680069/react-16-a-look-inside-an-api-compatible-rewrite-of-our-frontend-ui-library/). (Spoiler: we rewrote React!)
 
@@ -104,7 +104,7 @@ _Tip: Pay attention to the spinning black square._
 
 We think async rendering is a big deal, and represents the future of React. To make migration to v16.0 as smooth as possible, we're not enabling any async features yet, but we're excited to start rolling them out in the coming months. Stay tuned!
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.0.0 is available on the npm registry.
 
@@ -135,18 +135,18 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Upgrading {#upgrading}
+## Upgrading {/*upgrading*/}
 
 Although React 16 includes significant internal changes, in terms of upgrading, you can think of this like any other major React release. We've been serving React 16 to Facebook and Messenger.com users since earlier this year, and we released several beta and release candidate versions to flush out additional issues. With minor exceptions, **if your app runs in 15.6 without any warnings, it should work in 16.**
 
 For deprecations listed in [packaging](#packaging) below, codemods are provided to automatically transform your deprecated code.
 See the [15.5.0](/blog/2017/04/07/react-v15.5.0) blog post for more information, or browse the codemods in the [react-codemod](https://github.com/reactjs/react-codemod) project.
 
-### New deprecations {#new-deprecations}
+### New deprecations {/*new-deprecations*/}
 
 Hydrating a server-rendered container now has an explicit API. If you're reviving server-rendered HTML, use [`ReactDOM.hydrate`](/docs/react-dom#hydrate) instead of `ReactDOM.render`. Keep using `ReactDOM.render` if you're just doing client-side rendering.
 
-### React Addons {#react-addons}
+### React Addons {/*react-addons*/}
 
 As previously announced, we've [discontinued support for React Addons](/blog/2017/04/07/react-v15.5.0#discontinuing-support-for-react-addons). We expect the latest version of each addon (except `react-addons-perf`; see below) to work for the foreseeable future, but we won't publish additional updates.
 
@@ -154,7 +154,7 @@ Refer to the previous announcement for [suggestions on how to migrate](/blog/201
 
 `react-addons-perf` no longer works at all in React 16. It's likely that we'll release a new version of this tool in the future. In the meantime, you can [use your browser's performance tools to profile React components](/docs/optimizing-performance#profiling-components-with-the-chrome-performance-tab).
 
-### Breaking changes {#breaking-changes}
+### Breaking changes {/*breaking-changes*/}
 
 React 16 includes a number of small breaking changes. These only affect uncommon use cases and we don't expect them to break most apps.
 
@@ -172,7 +172,7 @@ React 16 includes a number of small breaking changes. These only affect uncommon
 - Shallow renderer does not implement `unstable_batchedUpdates` anymore.
 - `ReactDOM.unstable_batchedUpdates` now only takes one extra argument after the callback.
 
-### Packaging {#packaging}
+### Packaging {/*packaging*/}
 
 - There is no `react/lib/*` and `react-dom/lib/*` anymore. Even in CommonJS environments, React and ReactDOM are precompiled to single files (“flat bundles”). If you previously relied on undocumented React internals, and they don’t work anymore, let us know about your specific case in a new issue, and we’ll try to figure out a migration strategy for you.
 - There is no `react-with-addons.js` build anymore. All compatible addons are published separately on npm, and have single-file browser versions if you need them.
@@ -183,7 +183,7 @@ React 16 includes a number of small breaking changes. These only affect uncommon
   - `react-dom/dist/react-dom.js` → `react-dom/umd/react-dom.development.js`
   - `react-dom/dist/react-dom.min`.js → `react-dom/umd/react-dom.production.min.js`
 
-## JavaScript Environment Requirements {#javascript-environment-requirements}
+## JavaScript Environment Requirements {/*javascript-environment-requirements*/}
 
 React 16 depends on the collection types [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set). If you support older browsers and devices which may not yet provide these natively (e.g. IE < 11), consider including a global polyfill in your bundled application, such as [core-js](https://github.com/zloirock/core-js) or [babel-polyfill](https://babeljs.io/docs/usage/polyfill/).
 
@@ -206,7 +206,7 @@ You can use the [raf](https://www.npmjs.com/package/raf) package to shim `reques
 import 'raf/polyfill';
 ```
 
-## Acknowledgments {#acknowledgments}
+## Acknowledgments {/*acknowledgments*/}
 
 As always, this release would not have been possible without our open source contributors. Thanks to everyone who filed bugs, opened PRs, responded to issues, wrote documentation, and more!
 

--- a/beta/src/pages/blog/2017/11/28/react-v16.2.0-fragment-support.md
+++ b/beta/src/pages/blog/2017/11/28/react-v16.2.0-fragment-support.md
@@ -21,7 +21,7 @@ render() {
 
 This exciting new feature is made possible by additions to both React and JSX.
 
-## What Are Fragments? {#what-are-fragments}
+## What Are Fragments? {/*what-are-fragments*/}
 
 A common pattern is for a component to return a list of children. Take this example HTML:
 
@@ -107,7 +107,7 @@ const Fragment = React.Fragment;
 </React.Fragment>
 ```
 
-## JSX Fragment Syntax {#jsx-fragment-syntax}
+## JSX Fragment Syntax {/*jsx-fragment-syntax*/}
 
 Fragments are a common pattern in our codebases at Facebook. We anticipate they'll be widely adopted by other teams, too. To make the authoring experience as convenient as possible, we're adding syntactical support for fragments to JSX:
 
@@ -129,7 +129,7 @@ In React, this desugars to a `<React.Fragment/>` element, as in the example from
 
 Fragment syntax in JSX was inspired by prior art such as the `XMLList() <></>` constructor in [E4X](https://developer.mozilla.org/en-US/docs/Archive/Web/E4X/E4X_for_templating). Using a pair of empty tags is meant to represent the idea it won't add an actual element to the DOM.
 
-### Keyed Fragments {#keyed-fragments}
+### Keyed Fragments {/*keyed-fragments*/}
 
 Note that the `<></>` syntax does not accept attributes, including keys.
 
@@ -153,19 +153,19 @@ function Glossary(props) {
 
 `key` is the only attribute that can be passed to `Fragment`. In the future, we may add support for additional attributes, such as event handlers.
 
-### Live Demo {#live-demo}
+### Live Demo {/*live-demo*/}
 
 You can experiment with JSX fragment syntax with this [CodePen](https://codepen.io/reactjs/pen/VrEbjE?editors=1000).
 
-## Support for Fragment Syntax {#support-for-fragment-syntax}
+## Support for Fragment Syntax {/*support-for-fragment-syntax*/}
 
 Support for fragment syntax in JSX will vary depending on the tools you use to build your app. Please be patient as the JSX community works to adopt the new syntax. We've been working closely with maintainers of the most popular projects:
 
-### Create React App {#create-react-app}
+### Create React App {/*create-react-app*/}
 
 Experimental support for fragment syntax will be added to Create React App within the next few days. A stable release may take a bit longer as we await adoption by upstream projects.
 
-### Babel {#babel}
+### Babel {/*babel*/}
 
 Support for JSX fragments is available in [Babel v7.0.0-beta.31](https://github.com/babel/babel/releases/tag/v7.0.0-beta.31) and above! If you are already on Babel 7, simply update to the latest Babel and plugin transform:
 
@@ -189,15 +189,15 @@ Note that Babel 7 is technically still in beta, but a [stable release is coming 
 
 Unfortunately, support for Babel 6.x is not available, and there are currently no plans to backport.
 
-#### Babel with Webpack (babel-loader) {#babel-with-webpack-babel-loader}
+#### Babel with Webpack (babel-loader) {/*babel-with-webpack-babel-loader*/}
 
 If you are using Babel with [Webpack](https://webpack.js.org/), no additional steps are needed because [babel-loader](https://github.com/babel/babel-loader) will use your peer-installed version of Babel.
 
-#### Babel with Other Frameworks {#babel-with-other-frameworks}
+#### Babel with Other Frameworks {/*babel-with-other-frameworks*/}
 
 If you use JSX with a non-React framework like Inferno or Preact, there is a [pragma option available in babel-plugin-transform-react-jsx](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx#pragmafrag) that configures the Babel compiler to de-sugar the `<></>` syntax to a custom identifier.
 
-### TypeScript {#typescript}
+### TypeScript {/*typescript*/}
 
 TypeScript has full support for fragment syntax! Please upgrade to [version 2.6.2](https://github.com/Microsoft/TypeScript/releases/tag/v2.6.2). (Note that this is important even if you are already on version 2.6.1, since support was added as patch release in 2.6.2.)
 
@@ -210,7 +210,7 @@ yarn upgrade typescript
 npm update typescript
 ```
 
-### Flow {#flow}
+### Flow {/*flow*/}
 
 [Flow](https://flow.org/) support for JSX fragments is available starting in [version 0.59](https://github.com/facebook/flow/releases/tag/v0.59.0)! Simply run
 
@@ -223,11 +223,11 @@ npm update flow-bin
 
 to update Flow to the latest version.
 
-### Prettier {#prettier}
+### Prettier {/*prettier*/}
 
 [Prettier](https://github.com/prettier/prettier) added support for fragments in their [1.9 release](https://prettier.io/blog/2017/12/05/1.9.0#jsx-fragment-syntax-3237-https-githubcom-prettier-prettier-pull-3237-by-duailibe-https-githubcom-duailibe).
 
-### ESLint {#eslint}
+### ESLint {/*eslint*/}
 
 JSX Fragments are supported by [ESLint](https://eslint.org/) 3.x when it is used together with [babel-eslint](https://github.com/babel/babel-eslint):
 
@@ -257,19 +257,19 @@ That's it!
 
 Note that `babel-eslint` is not officially supported by ESLint. We'll be looking into adding support for fragments to ESLint 4.x itself in the coming weeks (see [issue #9662](https://github.com/eslint/eslint/issues/9662)).
 
-### Editor Support {#editor-support}
+### Editor Support {/*editor-support*/}
 
 It may take a while for fragment syntax to be supported in your text editor. Please be patient as the community works to adopt the latest changes. In the meantime, you may see errors or inconsistent highlighting if your editor does not yet support fragment syntax. Generally, these errors can be safely ignored.
 
-#### TypeScript Editor Support {#typescript-editor-support}
+#### TypeScript Editor Support {/*typescript-editor-support*/}
 
 If you're a TypeScript user -- great news! Editor support for JSX fragments is already available in [Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48593), [Visual Studio 2017](https://www.microsoft.com/en-us/download/details.aspx?id=55258), [Visual Studio Code](https://code.visualstudio.com/updates/v1_19#_jsx-fragment-syntax) and [Sublime Text via Package Control](https://packagecontrol.io/packages/TypeScript).
 
-### Other Tools {#other-tools}
+### Other Tools {/*other-tools*/}
 
 For other tools, please check with the corresponding documentation to check if there is support available. However, if you're blocked by your tooling, you can always start with using the `<Fragment>` component and perform a codemod later to replace it with the shorthand syntax when the appropriate support is available.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.2.0 is available on the npm registry.
 
@@ -300,31 +300,31 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Add `Fragment` as named export to React. ([@clemmy](https://github.com/clemmy) in [#10783](https://github.com/facebook/react/pull/10783))
 - Support experimental Call/Return types in `React.Children` utilities. ([@MatteoVH](https://github.com/MatteoVH) in [#11422](https://github.com/facebook/react/pull/11422))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fix radio buttons not getting checked when using multiple lists of radios. ([@landvibe](https://github.com/landvibe) in [#11227](https://github.com/facebook/react/pull/11227))
 - Fix radio buttons not receiving the `onChange` event in some cases. ([@jquense](https://github.com/jquense) in [#11028](https://github.com/facebook/react/pull/11028))
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 
 - Fix `setState()` callback firing too early when called from `componentWillMount`. ([@accordeiro](https://github.com/accordeiro) in [#11507](https://github.com/facebook/react/pull/11507))
 
-### React Reconciler {#react-reconciler}
+### React Reconciler {/*react-reconciler*/}
 
 - Expose `react-reconciler/reflection` with utilities useful to custom renderers. ([@rivenhk](https://github.com/rivenhk) in [#11683](https://github.com/facebook/react/pull/11683))
 
-### Internal Changes {#internal-changes}
+### Internal Changes {/*internal-changes*/}
 
 - Many tests were rewritten against the public API. Big thanks to [everyone who contributed](https://github.com/facebook/react/issues/11299)!
 
-## Acknowledgments {#acknowledgments}
+## Acknowledgments {/*acknowledgments*/}
 
 This release was made possible by our open source contributors. A big thanks to everyone who filed issues, contributed to syntax discussions, reviewed pull requests, added support for JSX fragments in third party libraries, and more!
 

--- a/beta/src/pages/blog/2017/12/07/introducing-the-react-rfc-process.md
+++ b/beta/src/pages/blog/2017/12/07/introducing-the-react-rfc-process.md
@@ -15,13 +15,13 @@ Inspired by [Yarn](https://github.com/yarnpkg/rfcs), [Ember](https://github.com/
 
 RFCs are accepted when they are approved for implementation in React. A more thorough description of the process is available in the repository's [README](https://github.com/reactjs/rfcs/blob/master/README.md). The exact details may be refined in the future.
 
-## Who Can Submit RFCs? {#who-can-submit-rfcs}
+## Who Can Submit RFCs? {/*who-can-submit-rfcs*/}
 
 Anyone! No knowledge of React's internals is required, nor are you expected to implement the proposal yourself.
 
 As with our other repositories, we do ask that you complete a [Contributor License Agreement](https://github.com/reactjs/rfcs#contributor-license-agreement-cla) before we can accept your PR.
 
-## What Types of Changes Should Be Submitted As RFCs? {#what-types-of-changes-should-be-submitted-as-rfcs}
+## What Types of Changes Should Be Submitted As RFCs? {/*what-types-of-changes-should-be-submitted-as-rfcs*/}
 
 Generally, any idea that would benefit from additional review or design before being implemented is a good candidate for an RFC. As a rule of thumb, this means any proposal that adds, changes, or removes a React API.
 
@@ -33,7 +33,7 @@ We now have several repositories where you can submit contributions to React:
 - **Website and documentation**: [reactjs/reactjs.org](https://github.com/reactjs/reactjs.org)
 - **Ideas for changes that need additional review before being implemented**: [reactjs/rfcs](https://github.com/reactjs/rfcs)
 
-## RFC for A New Context API {#rfc-for-a-new-context-api}
+## RFC for A New Context API {/*rfc-for-a-new-context-api*/}
 
 Coinciding with the launch of our RFC process, we've submitted a [proposal for a new version of context](https://github.com/reactjs/rfcs/pull/2). The proposal has already received many valuable comments from the community that we will incorporate into the design of the new API.
 

--- a/beta/src/pages/blog/2017/12/15/improving-the-repository-infrastructure.md
+++ b/beta/src/pages/blog/2017/12/15/improving-the-repository-infrastructure.md
@@ -7,7 +7,7 @@ As we worked on [React 16](/blog/2017/09/26/react-v16.0), we revamped the folder
 
 While these changes helped us make React better, they don't affect most React users directly. However, we hope that blogging about them might help other library authors solve similar problems. Our contributors might also find these notes helpful!
 
-## Formatting Code with Prettier {#formatting-code-with-prettier}
+## Formatting Code with Prettier {/*formatting-code-with-prettier*/}
 
 React was one of the first large repositories to [fully embrace](https://github.com/facebook/react/pull/9101) opinionated automatic code formatting with [Prettier](https://prettier.io/). Our current Prettier setup consists of:
 
@@ -16,11 +16,11 @@ React was one of the first large repositories to [fully embrace](https://github.
 
 Some team members have also set up the [editor integrations](https://prettier.io/docs/en/editors). Our experience with Prettier has been fantastic, and we recommend it to any team that writes JavaScript.
 
-## Restructuring the Monorepo {#restructuring-the-monorepo}
+## Restructuring the Monorepo {/*restructuring-the-monorepo*/}
 
 Ever since React was split into packages, it has been a [monorepo](https://danluu.com/monorepo/): a set of packages under the umbrella of a single repository. This made it easier to coordinate changes and share the tooling, but our folder structure was deeply nested and difficult to understand. It was not clear which files belonged to which package. After releasing React 16, we've decided to completely reorganize the repository structure. Here is how we did it.
 
-### Migrating to Yarn Workspaces {#migrating-to-yarn-workspaces}
+### Migrating to Yarn Workspaces {/*migrating-to-yarn-workspaces*/}
 
 The Yarn package manager [introduced a feature called Workspaces](https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/) a few months ago. This feature lets you tell Yarn where your monorepo's packages are located in the source tree. Every time you run `yarn`, in addition to installing your dependencies it also sets up the symlinks that point from your project's `node_modules` to the source folders of your packages.
 
@@ -32,7 +32,7 @@ Each package is structured in a similar way. For every public API entry point su
 
 Not all packages have to be published on npm. For example, we keep some utilities that are tiny enough and can be safely duplicated in a [pseudo-package called `shared`](https://github.com/facebook/react/tree/cc52e06b490e0dc2482b345aa5d0d65fae931095/packages/shared). Our bundler is configured to [only treat `dependencies` declared from `package.json` as externals](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/build.js#L326-L329) so it happily bundles the `shared` code into `react` and `react-dom` without leaving any references to `shared/` in the build artifacts. So you can use Yarn Workspaces even if you don't plan to publish actual npm packages!
 
-### Removing the Custom Module System {#removing-the-custom-module-system}
+### Removing the Custom Module System {/*removing-the-custom-module-system*/}
 
 In the past, we used a non-standard module system called "Haste" that lets you import any file from any other file by its unique `@providesModule` directive no matter where it is in the tree. It neatly avoids the problem of deep relative imports with paths like `../../../../` and is great for the product code. However, this makes it hard to understand the dependencies between packages. We also had to resort to hacks to make it work with different tools.
 
@@ -55,7 +55,7 @@ This way, the relative paths can only contain one `./` or `../` followed by the 
 
 In practice, we still have [some cross-package "internal" imports](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/packages/react-dom/src/client/ReactDOMFiberComponent.js#L10-L11) that violate this principle, but they're explicit, and we plan to gradually get rid of them.
 
-## Compiling Flat Bundles {#compiling-flat-bundles}
+## Compiling Flat Bundles {/*compiling-flat-bundles*/}
 
 Historically, React was distributed in two different formats: as a single-file build that you can add as a `<script>` tag in the browser, and as a collection of CommonJS modules that you can bundle with a tool like webpack or Browserify.
 
@@ -89,7 +89,7 @@ For example, [`react.development.js`](https://unpkg.com/react@16/cjs/react.devel
 
 Note how this is essentially the same strategy that we've been using for the single-file browser builds (which now reside in the [`umd` directory](https://unpkg.com/react@16/umd/), short for [Universal Module Definition](https://www.davidbcalhoun.com/2014/what-is-amd-commonjs-and-umd/)). Now we just apply the same strategy to the CommonJS builds as well.
 
-### Migrating to Rollup {#migrating-to-rollup}
+### Migrating to Rollup {/*migrating-to-rollup*/}
 
 Just compiling CommonJS modules into single-file bundles doesn't solve all of the above problems. The really significant wins came from [migrating our build system](https://github.com/facebook/react/pull/9327) from Browserify to [Rollup](https://rollupjs.org/).
 
@@ -99,7 +99,7 @@ Rollup currently doesn't support some features that are important to application
 
 You can find our Rollup build configuration [here](https://github.com/facebook/react/blob/8ec146c38ee4f4c84b6ecf59f52de3371224e8bd/scripts/rollup/build.js#L336-L362), with a [list of plugins we currently use](https://github.com/facebook/react/blob/8ec146c38ee4f4c84b6ecf59f52de3371224e8bd/scripts/rollup/build.js#L196-L273).
 
-### Migrating to Google Closure Compiler {#migrating-to-google-closure-compiler}
+### Migrating to Google Closure Compiler {/*migrating-to-google-closure-compiler*/}
 
 After migrating to flat bundles, we [started](https://github.com/facebook/react/pull/10236) using [the JavaScript version of the Google Closure Compiler](https://github.com/google/closure-compiler-js) in its "simple" mode. In our experience, even with the advanced optimizations disabled, it still provided a significant advantage over Uglify, as it was able to better eliminate dead code and automatically inline small functions when appropriate.
 
@@ -107,7 +107,7 @@ At first, we could only use Google Closure Compiler for the React bundles we shi
 
 Currently, all production React bundles [run through Google Closure Compiler in simple mode](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/build.js#L235-L248), and we may look into enabling advanced optimizations in the future.
 
-### Protecting Against Weak Dead Code Elimination {#protecting-against-weak-dead-code-elimination}
+### Protecting Against Weak Dead Code Elimination {/*protecting-against-weak-dead-code-elimination*/}
 
 While we use an efficient [dead code elimination](https://en.wikipedia.org/wiki/Dead_code_elimination) solution in React itself, we can't make a lot of assumptions about the tools used by the React consumers.
 
@@ -129,7 +129,7 @@ if ('production' !== 'production') {
 
 However, if the bundler is misconfigured, you can accidentally ship development code into production. We can't completely prevent this, but we took a few steps to mitigate the common cases when it happens.
 
-#### Protecting Against Late Envification {#protecting-against-late-envification}
+#### Protecting Against Late Envification {/*protecting-against-late-envification*/}
 
 As mentioned above, our entry points now look like this:
 
@@ -161,7 +161,7 @@ This way, even if the application bundle includes both the development and the p
 
 The additional [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) wrapper is necessary because some declarations (e.g. functions) can't be placed inside an `if` statement in JavaScript.
 
-#### Detecting Misconfigured Dead Code Elimination {#detecting-misconfigured-dead-code-elimination}
+#### Detecting Misconfigured Dead Code Elimination {/*detecting-misconfigured-dead-code-elimination*/}
 
 Even though [the situation is changing](https://twitter.com/iamakulov/status/941336777188696066), many popular bundlers don't yet force the users to specify the development or production mode. In this case `process.env.NODE_ENV` is typically provided by a runtime polyfill, but the dead code elimination doesn't work.
 
@@ -179,11 +179,11 @@ We can write a function that contains a [development-only branch](https://github
 
 We recognize this approach is somewhat fragile. The `toString()` method is not reliable and may change its behavior in future browser versions. This is why we put that logic into React DevTools itself rather than into React. This allows us to remove it later if it becomes problematic. We also warn only if we _found_ the special string literal rather than if we _didn't_ find it. This way, if the `toString()` output becomes opaque, or is overridden, the warning just won't fire.
 
-## Catching Mistakes Early {#catching-mistakes-early}
+## Catching Mistakes Early {/*catching-mistakes-early*/}
 
 We want to catch bugs as early as possible. However, even with our extensive test coverage, occasionally we make a blunder. We made several changes to our build and test infrastructure this year to make it harder to mess up.
 
-### Migrating to ES Modules {#migrating-to-es-modules}
+### Migrating to ES Modules {/*migrating-to-es-modules*/}
 
 With the CommonJS `require()` and `module.exports`, it is easy to import a function that doesn't really exist, and not realize that until you call it. However, tools like Rollup that natively support [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [`export`](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export) syntax fail the build if you mistype a named import. After releasing React 16, [we have converted the entire React source code](https://github.com/facebook/react/pull/11389) to the ES Modules syntax.
 
@@ -191,13 +191,13 @@ Not only did this provide some extra protection, but it also helped improve the 
 
 For now, have decided to only convert the source code to ES Modules, but not the tests. We use powerful utilities like `jest.resetModules()` and want to retain tighter control over when the modules get initialized in tests. In order to consume ES Modules from our tests, we enabled the [Babel CommonJS transform](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/jest/preprocessor.js#L28-L29), but only for the test environment.
 
-### Running Tests in Production Mode {#running-tests-in-production-mode}
+### Running Tests in Production Mode {/*running-tests-in-production-mode*/}
 
 Historically, we've been running all tests in a development environment. This let us assert on the warning messages produced by React, and seemed to make general sense. However, even though we try to keep the differences between the development and production code paths minimal, occasionally we would make a mistake in production-only code branches that weren't covered by tests, and cause an issue at Facebook.
 
 To solve this problem, we have added a new [`yarn test-prod`](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/package.json#L110) command that runs on CI for every pull request, and [executes all React test cases in the production mode](https://github.com/facebook/react/pull/11616). We wrapped any assertions about warning messages into development-only conditional blocks in all tests so that they can still check the rest of the expected behavior in both environments. Since we have a custom Babel transform that replaces production error messages with the [error codes](/blog/2016/07/11/introducing-reacts-error-code-system), we also added a [reverse transformation](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/jest/setupTests.js#L91-L126) as part of the production test run.
 
-### Using Public API in Tests {#using-public-api-in-tests}
+### Using Public API in Tests {/*using-public-api-in-tests*/}
 
 When we were [rewriting the React reconciler](https://code.facebook.com/posts/1716776591680069/react-16-a-look-inside-an-api-compatible-rewrite-of-our-frontend-ui-library/), we recognized the importance of writing tests against the public API instead of internal modules. If the test is written against the public API, it is clear what is being tested from the user's perspective, and you can run it even if you rewrite the implementation from scratch.
 
@@ -205,7 +205,7 @@ We reached out to the wonderful React community [asking for help](https://github
 
 We would like to give our deepest thanks to [everyone who contributed to this effort](https://github.com/facebook/react/issues?q=is%3Apr+11299+is%3Aclosed).
 
-### Running Tests on Compiled Bundles {#running-tests-on-compiled-bundles}
+### Running Tests on Compiled Bundles {/*running-tests-on-compiled-bundles*/}
 
 There is also one more benefit to writing tests against the public API: now we can [run them against the compiled bundles](https://github.com/facebook/react/pull/11633).
 
@@ -221,17 +221,17 @@ There are still some test files that we intentionally don't run against the bund
 
 Currently, over 93% out of 2,650 React tests run against the compiled bundles.
 
-### Linting Compiled Bundles {#linting-compiled-bundles}
+### Linting Compiled Bundles {/*linting-compiled-bundles*/}
 
 In addition to linting our source code, we run a much more limited set of lint rules (really, [just two of them](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/validate/eslintrc.cjs.js#L26-L27)) on the compiled bundles. This gives us an extra layer of protection against regressions in the underlying tools and [ensures](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/validate/eslintrc.cjs.js#L22) that the bundles don't use any language features that aren't supported by older browsers.
 
-### Simulating Package Publishing {#simulating-package-publishing}
+### Simulating Package Publishing {/*simulating-package-publishing*/}
 
 Even running the tests on the built packages is not enough to avoid shipping a broken update. For example, we use the `files` field in our `package.json` files to specify a whitelist of folders and files that should be published on npm. However, it is easy to add a new entry point to a package but forget to add it to the whitelist. Even the bundle tests would pass, but after publishing the new entry point would be missing.
 
 To avoid situations like this, we are now simulating the npm publish by [running `npm pack` and then immediately unpacking the archive](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/packaging.js#L129-L134) after the build. Just like `npm publish`, this command filters out anything that isn't in the `files` whitelist. With this approach, if we were to forget adding an entry point to the list, it would be missing in the build folder, and the bundle tests relying on it would fail.
 
-### Creating Manual Test Fixtures {#creating-manual-test-fixtures}
+### Creating Manual Test Fixtures {/*creating-manual-test-fixtures*/}
 
 Our unit tests run only in the Node environment, but not in the browsers. This was an intentional decision because browser-based testing tools were flaky in our experience, and didn't catch many issues anyway.
 
@@ -255,7 +255,7 @@ In some cases, a change proved to be so complex that it necessitated a standalon
 
 Going through the fixtures is still a lot of work, and we are considering automating some of it. Still, the fixture app is invaluable even as documentation for the existing behavior and all the edge cases and browser bugs that React currently handles. Having it gives us confidence in making significant changes to the logic without breaking important use cases. Another improvement we're considering is to have a GitHub bot build and deploy the fixtures automatically for every pull request that touches the relevant files so anyone can help with browser testing.
 
-### Preventing Infinite Loops {#preventing-infinite-loops}
+### Preventing Infinite Loops {/*preventing-infinite-loops*/}
 
 The React 16 codebase contains many `while` loops. They let us avoid the dreaded deep stack traces that occurred with earlier versions of React, but can make development of React really difficult. Every time there is a mistake in an exit condition our tests would just hang, and it took a while to figure out which of the loops is causing the issue.
 
@@ -263,11 +263,11 @@ Inspired by the [strategy adopted by Repl.it](https://repl.it/site/blog/infinite
 
 This approach has a pitfall. If an error thrown from the Babel plugin gets caught and ignored up the call stack, the test will pass even though it has an infinite loop. This is really, really bad. To solve this problem, we [set a global field](https://github.com/facebook/react/blob/d906de7f602df810c38aa622c83023228b047db6/scripts/babel/transform-prevent-infinite-loops.js#L26-L30) before throwing the error. Then, after every test run, we [rethrow that error if the global field has been set](https://github.com/facebook/react/blob/d906de7f602df810c38aa622c83023228b047db6/scripts/jest/setupTests.js#L42-L56). This way any infinite loop will cause a test failure, no matter whether the error from the Babel plugin was caught or not.
 
-## Customizing the Build {#customizing-the-build}
+## Customizing the Build {/*customizing-the-build*/}
 
 There were a few things that we had to fine-tune after introducing our new build process. It took us a while to figure them out, but we're moderately happy with the solutions that we arrived at.
 
-### Dead Code Elimination {#dead-code-elimination}
+### Dead Code Elimination {/*dead-code-elimination*/}
 
 The combination of Rollup and Google Closure Compiler already gets us pretty far in terms of stripping development-only code in production bundles. We [replace](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/build.js#L223-L226) the `__DEV__` literal with a boolean constant during the build, and both Rollup together and Google Closure Compiler can strip out the `if (false) {}` code branches and even some more sophisticated patterns. However, there is one particularly nasty case:
 
@@ -285,7 +285,7 @@ To solve this problem, we use the [`treeshake.pureExternalModules` Rollup option
 
 When we optimize something, we need to ensure it doesn't regress in the future. What if somebody introduces a new development-only import of an external module, and not realize they also need to add it to `pureExternalModules`? Rollup prints a warning in such cases but we've [decided to fail the build completely](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/build.js#L395-L412) instead. This forces the person adding a new external development-only import to [explicitly specify whether it has side effects or not](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/scripts/rollup/modules.js#L10-L22) every time.
 
-### Forking Modules {#forking-modules}
+### Forking Modules {/*forking-modules*/}
 
 In some cases, different bundles need to contain slightly different code. For example, React Native bundles have a different error handling mechanism that shows a redbox instead of printing a message to the console. However, it can be very inconvenient to thread these differences all the way through the calling modules.
 
@@ -330,7 +330,7 @@ This works by essentially forcing Flow to verify that two types are assignable t
 
 To conclude this section, it is important to note that you can't specify your own module forks if you consume React from npm. This is intentional because none of these files are public API, and they are not covered by the [semver](https://semver.org/) guarantees. However, you are always welcome to build React from master or even fork it if you don't mind the instability and the risk of divergence. We hope that this writeup was still helpful in documenting one possible approach to targeting different environments from a single JavaScript library.
 
-### Tracking Bundle Size {#tracking-bundle-size}
+### Tracking Bundle Size {/*tracking-bundle-size*/}
 
 As a final build step, we now [record build sizes for all bundles](https://github.com/facebook/react/blob/d906de7f602df810c38aa622c83023228b047db6/scripts/rollup/build.js#L264-L272) and write them to a file that [looks like this](https://github.com/facebook/react/blob/d906de7f602df810c38aa622c83023228b047db6/scripts/rollup/results.json). When you run `yarn build`, it prints a table with the results:
 
@@ -344,17 +344,17 @@ Keeping the file sizes committed for everyone to see was helpful for tracking si
 
 We haven't been entirely happy with this strategy because the JSON file often causes merge conflicts on larger branches. Updating it is also not currently enforced so it gets out of date. In the future, we're considering integrating a bot that would comment on pull requests with the size changes.
 
-## Simplifying the Release Process {#simplifying-the-release-process}
+## Simplifying the Release Process {/*simplifying-the-release-process*/}
 
 We like to release updates to the open source community often. Unfortunately, the old process of creating a release was slow and would typically take an entire day. After some changes to this process, we're now able to do a full release in less than an hour. Here's what we changed.
 
-### Branching Strategy {#branching-strategy}
+### Branching Strategy {/*branching-strategy*/}
 
 Most of the time spent in the old release process was due to our branching strategy. The `master` branch was assumed to be unstable and would often contain breaking changes. Releases were done from a `stable` branch, and changes were manually cherry-picked into this branch prior to a release. We had [tooling to help automate](https://github.com/facebook/react/pull/7330) some of this process, but it was still [pretty complicated to use](https://github.com/facebook/react/blob/b5a2a1349d6e804d534f673612357c0be7e1d701/scripts/release-manager/Readme.md).
 
 As of version 16, we now release from the `master` branch. Experimental features and breaking changes are allowed, but must be hidden behind [feature flags](https://github.com/facebook/react/blob/cc52e06b490e0dc2482b345aa5d0d65fae931095/packages/shared/ReactFeatureFlags.js) so they can be removed during the build process. The new flat bundles and dead code elimination make it possible for us to do this without fear of leaking unwanted code into open source builds.
 
-### Automated Scripts {#automated-scripts}
+### Automated Scripts {/*automated-scripts*/}
 
 After changing to a stable `master`, we created a new [release process checklist](https://github.com/facebook/react/issues/10620). Although much simpler than the previous process, this still involved dozens of steps and forgetting one could result in a broken release.
 
@@ -372,13 +372,13 @@ All that's left is to tag and publish the release to NPM using the _publish_ scr
 
 (You may have noticed a `--dry` flag in the screenshots above. This flag allows us to run a release, end-to-end, without actually publishing to NPM. This is useful when working on the release script itself.)
 
-## In Conclusion {#in-conclusion}
+## In Conclusion {/*in-conclusion*/}
 
 Did this post inspire you to try some of these ideas in your own projects? We certainly hope so! If you have other ideas about how React build, test, or contribution workflow could be improved, please let us know on [our issue tracker](https://github.com/facebook/react/issues).
 
 You can find the related issues by the [build infrastructure label](https://github.com/facebook/react/labels/Component%3A%20Build%20Infrastructure). These are often great first contribution opportunities!
 
-## Acknowledgements {#acknowledgements}
+## Acknowledgements {/*acknowledgements*/}
 
 We would like to thank:
 

--- a/beta/src/pages/blog/2018/03/01/sneak-peek-beyond-react-16.md
+++ b/beta/src/pages/blog/2018/03/01/sneak-peek-beyond-react-16.md
@@ -13,7 +13,7 @@ Here's the video courtesy of JSConf Iceland:
 
 I think you'll enjoy the talk more if you stop reading here and just watch the video. If you don't have time to watch, a (very) brief summary follows.
 
-## About the Two Demos {#about-the-two-demos}
+## About the Two Demos {/*about-the-two-demos*/}
 
 On the first demo, Dan says: "We've built a generic way to ensure that high-priority updates don't get blocked by a low-priority update, called **time slicing**. If my device is fast enough, it feels almost like it's synchronous; if my device is slow, the app still feels responsive. It adapts to the device thanks to the [requestIdleCallback](https://developers.google.com/web/updates/2015/08/using-requestidlecallback) API. Notice that only the final state was displayed; the rendered screen is always consistent and we don't see visual artifacts of slow rendering causing a janky user experience."
 

--- a/beta/src/pages/blog/2018/03/27/update-on-async-rendering.md
+++ b/beta/src/pages/blog/2018/03/27/update-on-async-rendering.md
@@ -13,7 +13,7 @@ One of the biggest lessons we've learned is that some of our legacy component li
 
 These lifecycle methods have often been misunderstood and subtly misused; furthermore, we anticipate that their potential misuse may be more problematic with async rendering. Because of this, we will be adding an "UNSAFE\_" prefix to these lifecycles in an upcoming release. (Here, "unsafe" refers not to security but instead conveys that code using these lifecycles will be more likely to have bugs in future versions of React, especially once async rendering is enabled.)
 
-## Gradual Migration Path {#gradual-migration-path}
+## Gradual Migration Path {/*gradual-migration-path*/}
 
 [React follows semantic versioning](/blog/2016/02/19/new-versioning-scheme), so this change will be gradual. Our current plan is:
 
@@ -36,7 +36,7 @@ Learn more about this codemod on the [16.9.0 release post.](https://reactjs.org/
 
 ---
 
-## Migrating from Legacy Lifecycles {#migrating-from-legacy-lifecycles}
+## Migrating from Legacy Lifecycles {/*migrating-from-legacy-lifecycles*/}
 
 If you'd like to start using the new component APIs introduced in React 16.3 (or if you're a maintainer looking to update your library in advance) here are a few examples that we hope will help you to start thinking about components a bit differently. Over time, we plan to add additional "recipes" to our documentation that show how to perform common tasks in a way that avoids the problematic lifecycles.
 
@@ -45,7 +45,7 @@ Before we begin, here's a quick overview of the lifecycle changes planned for ve
 - We are **adding the following lifecycle aliases**: `UNSAFE_componentWillMount`, `UNSAFE_componentWillReceiveProps`, and `UNSAFE_componentWillUpdate`. (Both the old lifecycle names and the new aliases will be supported.)
 - We are **introducing two new lifecycles**, static `getDerivedStateFromProps` and `getSnapshotBeforeUpdate`.
 
-### New lifecycle: `getDerivedStateFromProps` {#new-lifecycle-getderivedstatefromprops}
+### New lifecycle: `getDerivedStateFromProps` {/*new-lifecycle-getderivedstatefromprops*/}
 
 `embed:update-on-async-rendering/definition-getderivedstatefromprops.js`
 
@@ -57,7 +57,7 @@ Together with `componentDidUpdate`, this new lifecycle should cover all use case
 >
 > Both the older `componentWillReceiveProps` and the new `getDerivedStateFromProps` methods add significant complexity to components. This often leads to [bugs](/blog/2018/06/07/you-probably-dont-need-derived-state#common-bugs-when-using-derived-state). Consider **[simpler alternatives to derived state](/blog/2018/06/07/you-probably-dont-need-derived-state)** to make components predictable and maintainable.
 
-### New lifecycle: `getSnapshotBeforeUpdate` {#new-lifecycle-getsnapshotbeforeupdate}
+### New lifecycle: `getSnapshotBeforeUpdate` {/*new-lifecycle-getsnapshotbeforeupdate*/}
 
 `embed:update-on-async-rendering/definition-getsnapshotbeforeupdate.js`
 
@@ -69,7 +69,7 @@ You can find their type signatures [in this gist](https://gist.github.com/gaearo
 
 We'll look at examples of how both of these lifecycles can be used below.
 
-## Examples {#examples}
+## Examples {/*examples*/}
 
 - [Initializing state](#initializing-state)
 - [Fetching external data](#fetching-external-data)
@@ -84,7 +84,7 @@ We'll look at examples of how both of these lifecycles can be used below.
 >
 > For brevity, the examples below are written using the experimental class properties transform, but the same migration strategies apply without it.
 
-### Initializing state {#initializing-state}
+### Initializing state {/*initializing-state*/}
 
 This example shows a component with `setState` calls inside of `componentWillMount`:
 `embed:update-on-async-rendering/initializing-state-before.js`
@@ -92,7 +92,7 @@ This example shows a component with `setState` calls inside of `componentWillMou
 The simplest refactor for this type of component is to move state initialization to the constructor or to a property initializer, like so:
 `embed:update-on-async-rendering/initializing-state-after.js`
 
-### Fetching external data {#fetching-external-data}
+### Fetching external data {/*fetching-external-data*/}
 
 Here is an example of a component that uses `componentWillMount` to fetch external data:
 `embed:update-on-async-rendering/fetching-external-data-before.js`
@@ -112,7 +112,7 @@ There is a common misconception that fetching in `componentWillMount` lets you a
 >
 > When supporting server rendering, it's currently necessary to provide the data synchronously – `componentWillMount` was often used for this purpose but the constructor can be used as a replacement. The upcoming suspense APIs will make async data fetching cleanly possible for both client and server rendering.
 
-### Adding event listeners (or subscriptions) {#adding-event-listeners-or-subscriptions}
+### Adding event listeners (or subscriptions) {/*adding-event-listeners-or-subscriptions*/}
 
 Here is an example of a component that subscribes to an external event dispatcher when mounting:
 `embed:update-on-async-rendering/adding-event-listeners-before.js`
@@ -134,7 +134,7 @@ Rather than passing a subscribable `dataSource` prop as we did in the example ab
 >
 > Libraries like Relay/Apollo should manage subscriptions manually with the same techniques as `create-subscription` uses under the hood (as referenced [here](https://gist.github.com/bvaughn/d569177d70b50b58bff69c3c4a5353f3)) in a way that is most optimized for their library usage.
 
-### Updating `state` based on `props` {#updating-state-based-on-props}
+### Updating `state` based on `props` {/*updating-state-based-on-props*/}
 
 > Note:
 >
@@ -159,7 +159,7 @@ You may wonder why we don't just pass previous props as a parameter to `getDeriv
 >
 > If you're writing a shared component, the [`react-lifecycles-compat`](https://github.com/reactjs/react-lifecycles-compat) polyfill enables the new `getDerivedStateFromProps` lifecycle to be used with older versions of React as well. [Learn more about how to use it below.](#open-source-project-maintainers)
 
-### Invoking external callbacks {#invoking-external-callbacks}
+### Invoking external callbacks {/*invoking-external-callbacks*/}
 
 Here is an example of a component that calls an external function when its internal state changes:
 `embed:update-on-async-rendering/invoking-external-callbacks-before.js`
@@ -169,7 +169,7 @@ Sometimes people use `componentWillUpdate` out of a misplaced fear that by the t
 Either way, it is unsafe to use `componentWillUpdate` for this purpose in async mode, because the external callback might get called multiple times for a single update. Instead, the `componentDidUpdate` lifecycle should be used since it is guaranteed to be invoked only once per update:
 `embed:update-on-async-rendering/invoking-external-callbacks-after.js`
 
-### Side effects on props change {#side-effects-on-props-change}
+### Side effects on props change {/*side-effects-on-props-change*/}
 
 Similar to the [example above](#invoking-external-callbacks), sometimes components have side effects when `props` change.
 
@@ -179,7 +179,7 @@ Like `componentWillUpdate`, `componentWillReceiveProps` might get called multipl
 
 `embed:update-on-async-rendering/side-effects-when-props-change-after.js`
 
-### Fetching external data when `props` change {#fetching-external-data-when-props-change}
+### Fetching external data when `props` change {/*fetching-external-data-when-props-change*/}
 
 Here is an example of a component that fetches external data based on `props` values:
 `embed:update-on-async-rendering/updating-external-data-when-props-change-before.js`
@@ -191,7 +191,7 @@ The recommended upgrade path for this component is to move data updates into `co
 >
 > If you're using an HTTP library that supports cancellation, like [axios](https://www.npmjs.com/package/axios), then it's simple to cancel an in-progress request when unmounting. For native Promises, you can use an approach like [the one shown here](https://gist.github.com/bvaughn/982ab689a41097237f6e9860db7ca8d6).
 
-### Reading DOM properties before an update {#reading-dom-properties-before-an-update}
+### Reading DOM properties before an update {/*reading-dom-properties-before-an-update*/}
 
 Here is an example of a component that reads a property from the DOM before an update in order to maintain scroll position within a list:
 `embed:update-on-async-rendering/react-dom-properties-before-update-before.js`
@@ -208,11 +208,11 @@ The two lifecycles can be used together like this:
 >
 > If you're writing a shared component, the [`react-lifecycles-compat`](https://github.com/reactjs/react-lifecycles-compat) polyfill enables the new `getSnapshotBeforeUpdate` lifecycle to be used with older versions of React as well. [Learn more about how to use it below.](#open-source-project-maintainers)
 
-## Other scenarios {#other-scenarios}
+## Other scenarios {/*other-scenarios*/}
 
 While we tried to cover the most common use cases in this post, we recognize that we might have missed some of them. If you are using `componentWillMount`, `componentWillUpdate`, or `componentWillReceiveProps` in ways that aren't covered by this blog post, and aren't sure how to migrate off these legacy lifecycles, please [file a new issue against our documentation](https://github.com/reactjs/reactjs.org/issues/new) with your code examples and as much background information as you can provide. We will update this document with new alternative patterns as they come up.
 
-## Open source project maintainers {#open-source-project-maintainers}
+## Open source project maintainers {/*open-source-project-maintainers*/}
 
 Open source maintainers might be wondering what these changes mean for shared components. If you implement the above suggestions, what happens with components that depend on the new static `getDerivedStateFromProps` lifecycle? Do you also have to release a new major version and drop compatibility for React 16.2 and older?
 

--- a/beta/src/pages/blog/2018/03/29/react-v-16-3.md
+++ b/beta/src/pages/blog/2018/03/29/react-v-16-3.md
@@ -7,7 +7,7 @@ A few days ago, we [wrote a post about upcoming changes to our legacy lifecycle 
 
 Read on to learn more about the release.
 
-## Official Context API {#official-context-api}
+## Official Context API {/*official-context-api*/}
 
 For many years, React has offered an experimental API for context. Although it was a powerful tool, its use was discouraged because of inherent problems in the API, and because we always intended to replace the experimental API with a better one.
 
@@ -22,7 +22,7 @@ Here is an example illustrating how you might inject a "theme" using the new con
 
 [Learn more about the new context API here.](/docs/context)
 
-## `createRef` API {#createref-api}
+## `createRef` API {/*createref-api*/}
 
 Previously, React provided two ways of managing refs: the legacy string ref API and the callback API. Although the string ref API was the more convenient of the two, it had [several downsides](https://github.com/facebook/react/issues/1373) and so our official recommendation was to use the callback form instead.
 
@@ -37,7 +37,7 @@ Version 16.3 adds a new option for managing refs that offers the convenience of 
 
 [Learn more about the new `createRef` API here.](/docs/refs-and-the-dom)
 
-## `forwardRef` API {#forwardref-api}
+## `forwardRef` API {/*forwardref-api*/}
 
 Generally, React components are declarative, but sometimes imperative access to the component instances and the underlying DOM nodes is necessary. This is common for use cases like managing focus, selection, or animations. React provides [refs](/docs/refs-and-the-dom) as a way to solve this problem. However, component encapsulation poses some challenges with refs.
 
@@ -53,7 +53,7 @@ Ref forwarding is not limited to "leaf" components that render DOM nodes. If you
 
 [Learn more about the forwardRef API here.](/docs/forwarding-refs)
 
-## Component Lifecycle Changes {#component-lifecycle-changes}
+## Component Lifecycle Changes {/*component-lifecycle-changes*/}
 
 React's class component API has been around for years with little change. However, as we add support for more advanced features (such as [error boundaries](/docs/react-component#componentdidcatch) and the upcoming [async rendering mode](/blog/2018/03/01/sneak-peek-beyond-react-16)) we stretch this model in ways that it was not originally intended.
 
@@ -76,7 +76,7 @@ In addition to deprecating unsafe lifecycles, we are also adding a couple of new
 
 [Learn more about these lifecycle changes here.](/blog/2018/03/27/update-on-async-rendering)
 
-## `StrictMode` Component {#strictmode-component}
+## `StrictMode` Component {/*strictmode-component*/}
 
 `StrictMode` is a tool for highlighting potential problems in an application. Like `Fragment`, `StrictMode` does not render any visible UI. It activates additional checks and warnings for its descendants.
 

--- a/beta/src/pages/blog/2018/05/23/react-v-16-4.md
+++ b/beta/src/pages/blog/2018/05/23/react-v-16-4.md
@@ -7,7 +7,7 @@ The latest minor release adds support for an oft-requested feature: pointer even
 
 It also includes a bugfix for `getDerivedStateFromProps`. Check out the full [changelog](#changelog) below.
 
-## Pointer Events {#pointer-events}
+## Pointer Events {/*pointer-events*/}
 
 The following event types are now available in React DOM:
 
@@ -28,19 +28,19 @@ Please note that these events will only work in browsers that support the [Point
 
 Huge thanks to [Philipp Spiess](https://github.com/philipp-spiess) for contributing this change!
 
-## Bugfix for `getDerivedStateFromProps` {#bugfix-for-getderivedstatefromprops}
+## Bugfix for `getDerivedStateFromProps` {/*bugfix-for-getderivedstatefromprops*/}
 
 `getDerivedStateFromProps` is now called every time a component is rendered, regardless of the cause of the update. Previously, it was only called if the component was re-rendered by its parent, and would not fire as the result of a local `setState`. This was an oversight in the initial implementation that has now been corrected. The previous behavior was more similar to `componentWillReceiveProps`, but the improved behavior ensures compatibility with React's upcoming asynchronous rendering mode.
 
 **This bug fix will not affect most apps**, but it may cause issues with a small fraction of components. The rare cases where it does matter fall into one of two categories:
 
-### 1. Avoid Side Effects in `getDerivedStateFromProps` {#1-avoid-side-effects-in-getderivedstatefromprops}
+### 1. Avoid Side Effects in `getDerivedStateFromProps` {/*1-avoid-side-effects-in-getderivedstatefromprops*/}
 
 Like the render method, `getDerivedStateFromProps` should be a pure function of props and state. Side effects in `getDerivedStateFromProps` were never supported, but since it now fires more often than it used to, the recent change may expose previously undiscovered bugs.
 
 Side effectful code should be moved to other methods: for example, Flux dispatches typically belong inside the originating event handler, and manual DOM mutations belong inside componentDidMount or componentDidUpdate. You can read more about this in our recent post about [preparing for asynchronous rendering](/blog/2018/03/27/update-on-async-rendering).
 
-### 2. Compare Incoming Props to Previous Props When Computing Controlled Values {#2-compare-incoming-props-to-previous-props-when-computing-controlled-values}
+### 2. Compare Incoming Props to Previous Props When Computing Controlled Values {/*2-compare-incoming-props-to-previous-props-when-computing-controlled-values*/}
 
 The following code assumes `getDerivedStateFromProps` only fires on prop changes:
 
@@ -78,7 +78,7 @@ static getDerivedStateFromProps(props, state) {
 
 However, **code that "mirrors" props in state usually contains bugs**, whether you use the newer `getDerivedStateFromProps` or the legacy `componentWillReceiveProps`. We published a follow-up blog post that explains these problems in more detail, and suggests [simpler solutions that don't involve `getDerivedStateFromProps()`](/blog/2018/06/07/you-probably-dont-need-derived-state).
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.4.0 is available on the npm registry.
 
@@ -109,13 +109,13 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Add a new [experimental](https://github.com/reactjs/rfcs/pull/51) `React.unstable_Profiler` component for measuring performance. ([@bvaughn](https://github.com/bvaughn) in [#12745](https://github.com/facebook/react/pull/12745))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Add support for the Pointer Events specification. ([@philipp-spiess](https://github.com/philipp-spiess) in [#12507](https://github.com/facebook/react/pull/12507))
 - Properly call `getDerivedStateFromProps()` regardless of the reason for re-rendering. ([@acdlite](https://github.com/acdlite) in [#12600](https://github.com/facebook/react/pull/12600) and [#12802](https://github.com/facebook/react/pull/12802))
@@ -129,21 +129,21 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 - Improve how `forwardRef()` and context consumers are displayed in the component stack. ([@sophiebits](https://github.com/sophiebits) in [#12777](https://github.com/facebook/react/pull/12777))
 - Change internal event names. This can break third-party packages that rely on React internals in unsupported ways. ([@philipp-spiess](https://github.com/philipp-spiess) in [#12629](https://github.com/facebook/react/pull/12629))
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 
 - Fix the `getDerivedStateFromProps()` support to match the new React DOM behavior. ([@koba04](https://github.com/koba04) in [#12676](https://github.com/facebook/react/pull/12676))
 - Fix a `testInstance.parent` crash when the parent is a fragment or another special node. ([@gaearon](https://github.com/gaearon) in [#12813](https://github.com/facebook/react/pull/12813))
 - `forwardRef()` components are now discoverable by the test renderer traversal methods. ([@gaearon](https://github.com/gaearon) in [#12725](https://github.com/facebook/react/pull/12725))
 - Shallow renderer now ignores `setState()` updaters that return `null` or `undefined`. ([@koba04](https://github.com/koba04) in [#12756](https://github.com/facebook/react/pull/12756))
 
-### React ART {#react-art}
+### React ART {/*react-art*/}
 
 - Fix reading context provided from the tree managed by React DOM. ([@acdlite](https://github.com/acdlite) in [#12779](https://github.com/facebook/react/pull/12779))
 
-### React Call Return (Experimental) {#react-call-return-experimental}
+### React Call Return (Experimental) {/*react-call-return-experimental*/}
 
 - This experiment was deleted because it was affecting the bundle size and the API wasn't good enough. It's likely to come back in the future in some other form. ([@gaearon](https://github.com/gaearon) in [#12820](https://github.com/facebook/react/pull/12820))
 
-### React Reconciler (Experimental) {#react-reconciler-experimental}
+### React Reconciler (Experimental) {/*react-reconciler-experimental*/}
 
 - The [new host config shape](https://github.com/facebook/react/blob/c601f7a64640290af85c9f0e33c78480656b46bc/packages/react-noop-renderer/src/createReactNoop.js#L82-L285) is flat and doesn't use nested objects. ([@gaearon](https://github.com/gaearon) in [#12792](https://github.com/facebook/react/pull/12792))

--- a/beta/src/pages/blog/2018/06/07/you-probably-dont-need-derived-state.md
+++ b/beta/src/pages/blog/2018/06/07/you-probably-dont-need-derived-state.md
@@ -20,7 +20,7 @@ This blog post will cover the following topics:
 - [Preferred solutions](#preferred-solutions)
 - [What about memoization?](#what-about-memoization)
 
-## When to Use Derived State {#when-to-use-derived-state}
+## When to Use Derived State {/*when-to-use-derived-state*/}
 
 `getDerivedStateFromProps` exists for only one purpose. It enables a component to update its internal state as the result of **changes in props**. Our previous blog post provided some examples, like [recording the current scroll direction based on a changing offset prop](/blog/2018/03/27/update-on-async-rendering#updating-state-based-on-props) or [loading external data specified by a source prop](/blog/2018/03/27/update-on-async-rendering#fetching-external-data-when-props-change).
 
@@ -29,7 +29,7 @@ We did not provide many examples, because as a general rule, **derived state sho
 - If you're using derived state to memoize some computation based only on the current props, you don't need derived state. See [What about memoization?](#what-about-memoization) below.
 - If you're updating derived state unconditionally or updating it whenever props and state don't match, your component likely resets its state too frequently. Read on for more details.
 
-## Common Bugs When Using Derived State {#common-bugs-when-using-derived-state}
+## Common Bugs When Using Derived State {/*common-bugs-when-using-derived-state*/}
 
 The terms ["controlled"](/docs/forms#controlled-components) and ["uncontrolled"](/docs/uncontrolled-components) usually refer to form inputs, but they can also describe where any component's data lives. Data passed in as props can be thought of as **controlled** (because the parent component _controls_ that data). Data that exists only in internal state can be thought of as **uncontrolled** (because the parent can't directly change it).
 
@@ -37,7 +37,7 @@ The most common mistake with derived state is mixing these two; when a derived s
 
 Problems arise when any of these constraints are changed. This typically comes in two forms. Let's take a look at both.
 
-### Anti-pattern: Unconditionally copying props to state {#anti-pattern-unconditionally-copying-props-to-state}
+### Anti-pattern: Unconditionally copying props to state {/*anti-pattern-unconditionally-copying-props-to-state*/}
 
 A common misconception is that `getDerivedStateFromProps` and `componentWillReceiveProps` are only called when props "change". These lifecycles are called any time a parent component rerenders, regardless of whether the props are "different" from before. Because of this, it has always been unsafe to _unconditionally_ override state using either of these lifecycles. **Doing so will cause state updates to be lost.**
 
@@ -69,7 +69,7 @@ In this simple example, adding `shouldComponentUpdate` to rerender only when the
 
 Hopefully it's clear by now why **it is a bad idea to unconditionally copy props to state**. Before reviewing possible solutions, let's look at a related problematic pattern: what if we were to only update the state when the email prop changes?
 
-### Anti-pattern: Erasing state when props change {#anti-pattern-erasing-state-when-props-change}
+### Anti-pattern: Erasing state when props change {/*anti-pattern-erasing-state-when-props-change*/}
 
 Continuing the example above, we could avoid accidentally erasing state by only updating it when `props.email` changes:
 
@@ -102,9 +102,9 @@ There is still a subtle problem. Imagine a password manager app using the above 
 
 This design is fundamentally flawed, but it's also an easy mistake to make. ([I've made it myself!](https://twitter.com/brian_d_vaughn/status/959600888242307072)) Fortunately there are two alternatives that work better. The key to both is that **for any piece of data, you need to pick a single component that owns it as the source of truth, and avoid duplicating it in other components.** Let's take a look at each of the alternatives.
 
-## Preferred Solutions {#preferred-solutions}
+## Preferred Solutions {/*preferred-solutions*/}
 
-### Recommendation: Fully controlled component {#recommendation-fully-controlled-component}
+### Recommendation: Fully controlled component {/*recommendation-fully-controlled-component*/}
 
 One way to avoid the problems mentioned above is to remove state from our component entirely. If the email address only exists as a prop, then we don't have to worry about conflicts with state. We could even convert `EmailInput` to a lighter-weight function component:
 
@@ -116,7 +116,7 @@ function EmailInput(props) {
 
 This approach simplifies the implementation of our component, but if we still want to store a draft value, the parent form component will now need to do that manually. ([Click here to see a demo of this pattern.](https://codesandbox.io/s/7154w1l551))
 
-### Recommendation: Fully uncontrolled component with a `key` {#recommendation-fully-uncontrolled-component-with-a-key}
+### Recommendation: Fully uncontrolled component with a `key` {/*recommendation-fully-uncontrolled-component-with-a-key*/}
 
 Another alternative would be for our component to fully own the "draft" email state. In that case, our component could still accept a prop for the _initial_ value, but it would ignore subsequent changes to that prop:
 
@@ -148,7 +148,7 @@ In most cases, this is the best way to handle state that needs to be reset.
 >
 > While this may sound slow, the performance difference is usually insignificant. Using a key can even be faster if the components have heavy logic that runs on updates since diffing gets bypassed for that subtree.
 
-#### Alternative 1: Reset uncontrolled component with an ID prop {#alternative-1-reset-uncontrolled-component-with-an-id-prop}
+#### Alternative 1: Reset uncontrolled component with an ID prop {/*alternative-1-reset-uncontrolled-component-with-an-id-prop*/}
 
 If `key` doesn't work for some reason (perhaps the component is very expensive to initialize), a workable but cumbersome solution would be to watch for changes to "userID" in `getDerivedStateFromProps`:
 
@@ -182,7 +182,7 @@ This also provides the flexibility to only reset parts of our component's intern
 >
 > Even though the example above shows `getDerivedStateFromProps`, the same technique can be used with `componentWillReceiveProps`.
 
-#### Alternative 2: Reset uncontrolled component with an instance method {#alternative-2-reset-uncontrolled-component-with-an-instance-method}
+#### Alternative 2: Reset uncontrolled component with an instance method {/*alternative-2-reset-uncontrolled-component-with-an-instance-method*/}
 
 More rarely, you may need to reset state even if there's no appropriate ID to use as `key`. One solution is to reset the key to a random value or autoincrementing number each time you want to reset. One other viable alternative is to expose an instance method to imperatively reset the internal state:
 
@@ -206,7 +206,7 @@ Refs can be useful in certain cases like this one, but generally we recommend yo
 
 ---
 
-### Recap {#recap}
+### Recap {/*recap*/}
 
 To recap, when designing a component, it is important to decide whether its data will be controlled or uncontrolled.
 
@@ -218,7 +218,7 @@ For **uncontrolled** components, if you're trying to reset state when a particul
 - Alternative 1: To reset _only certain state fields_, watch for changes in a special property (e.g. `props.userID`).
 - Alternative 2: You can also consider fall back to an imperative instance method using refs.
 
-## What about memoization? {#what-about-memoization}
+## What about memoization? {/*what-about-memoization*/}
 
 We've also seen derived state used to ensure an expensive value used in `render` is recomputed only when the inputs change. This technique is known as [memoization](https://en.wikipedia.org/wiki/Memoization).
 
@@ -355,7 +355,7 @@ When using memoization, remember a couple of constraints:
 1. Typically you'll want to use a memoization helper with a **limited cache size** in order to prevent memory leaks over time. (In the example above, we used `memoize-one` because it only caches the most recent arguments and result.)
 1. None of the implementations shown in this section will work if `props.list` is recreated each time the parent component renders. But in most cases, this setup is appropriate.
 
-## In closing {#in-closing}
+## In closing {/*in-closing*/}
 
 In real world applications, components often contain a mix of controlled and uncontrolled behaviors. This is okay! If each value has a clear source of truth, you can avoid the anti-patterns mentioned above.
 

--- a/beta/src/pages/blog/2018/08/01/react-v-16-4-2.md
+++ b/beta/src/pages/blog/2018/08/01/react-v-16-4-2.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 We discovered a minor vulnerability that might affect some apps using ReactDOMServer. We are releasing a patch version for every affected React minor release so that you can upgrade with no friction. Read on for more details.
 
-## Short Description {#short-description}
+## Short Description {/*short-description*/}
 
 Today, we are releasing a fix for a vulnerability we discovered in the `react-dom/server` implementation. It was introduced with the version 16.0.0 and has existed in all subsequent releases until today.
 
@@ -13,11 +13,11 @@ This vulnerability **can only affect some server-rendered React apps.** Purely c
 
 While we were investigating this vulnerability, we found similar vulnerabilities in a few other popular front-end libraries. We have coordinated this release together with [Vue](https://github.com/vuejs/vue/releases/tag/v2.5.17) and [Preact](https://github.com/developit/preact-render-to-string/releases/tag/3.7.1) releases fixing the same issue. The tracking number for this vulnerability is `CVE-2018-6341`.
 
-## Mitigation {#mitigation}
+## Mitigation {/*mitigation*/}
 
 **We have prepared a patch release with a fix for every affected minor version.**
 
-### 16.0.x {#160x}
+### 16.0.x {/*160x*/}
 
 If you're using `react-dom/server` with this version:
 
@@ -27,7 +27,7 @@ Update to this version instead:
 
 - `react-dom@16.0.1` **(contains the mitigation)**
 
-### 16.1.x {#161x}
+### 16.1.x {/*161x*/}
 
 If you're using `react-dom/server` with one of these versions:
 
@@ -38,7 +38,7 @@ Update to this version instead:
 
 - `react-dom@16.1.2` **(contains the mitigation)**
 
-### 16.2.x {#162x}
+### 16.2.x {/*162x*/}
 
 If you're using `react-dom/server` with this version:
 
@@ -48,7 +48,7 @@ Update to this version instead:
 
 - `react-dom@16.2.1` **(contains the mitigation)**
 
-### 16.3.x {#163x}
+### 16.3.x {/*163x*/}
 
 If you're using `react-dom/server` with one of these versions:
 
@@ -60,7 +60,7 @@ Update to this version instead:
 
 - `react-dom@16.3.3` **(contains the mitigation)**
 
-### 16.4.x {#164x}
+### 16.4.x {/*164x*/}
 
 If you're using `react-dom/server` with one of these versions:
 
@@ -75,7 +75,7 @@ If you're using a newer version of `react-dom`, no action is required.
 
 Note that only the `react-dom` package needs to be updated.
 
-## Detailed Description {#detailed-description}
+## Detailed Description {/*detailed-description*/}
 
 Your app might be affected by this vulnerability only if both of these two conditions are true:
 
@@ -113,7 +113,7 @@ You would also see a warning about an invalid attribute name.
 
 Note that **we expect attribute names based on user input to be very rare in practice.** It doesn't serve any common practical use case, and has other potential security implications that React can't guard against.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.4.2 is available on the npm registry.
 
@@ -138,9 +138,9 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation.html).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React DOM Server {#react-dom-server}
+### React DOM Server {/*react-dom-server*/}
 
 * Fix a potential XSS vulnerability when the attacker controls an attribute name (`CVE-2018-6341`). This fix is available in the latest `react-dom@16.4.2`, as well as in previous affected minor versions: `react-dom@16.0.1`, `react-dom@16.1.2`, `react-dom@16.2.1`, and `react-dom@16.3.3`. ([@gaearon](https://github.com/gaearon) in [#13302](https://github.com/facebook/react/pull/13302))
 

--- a/beta/src/pages/blog/2018/09/10/introducing-the-react-profiler.md
+++ b/beta/src/pages/blog/2018/09/10/introducing-the-react-profiler.md
@@ -22,7 +22,7 @@ This blog post covers the following topics:
   - [No timing data to display for the selected commit](#no-timing-data-to-display-for-the-selected-commit)
 - [Deep dive video](#deep-dive-video)
 
-## Profiling an application {#profiling-an-application}
+## Profiling an application {/*profiling-an-application*/}
 
 DevTools will show a "Profiler" tab for applications that support the new profiling API:
 
@@ -47,9 +47,9 @@ When you are finished profiling, click the "Stop" button.
 Assuming your application rendered at least once while profiling, DevTools will show several ways to view the performance data.
 We'll [take a look at each of these below](#reading-performance-data).
 
-## Reading performance data {#reading-performance-data}
+## Reading performance data {/*reading-performance-data*/}
 
-### Browsing commits {#browsing-commits}
+### Browsing commits {/*browsing-commits*/}
 
 Conceptually, React does work in two phases:
 
@@ -67,7 +67,7 @@ You can click on a bar (or the left/right arrow buttons) to select a different 
 The color and height of each bar corresponds to how long that commit took to render.
 (Taller, yellow bars took longer than shorter, blue bars.)
 
-### Filtering commits {#filtering-commits}
+### Filtering commits {/*filtering-commits*/}
 
 The longer you profile, the more times your application will render.
 In some cases you may end up with _too many commits_ to easily process.
@@ -76,7 +76,7 @@ Use it to specify a threshold and the profiler will hide all commits that were _
 
 ![Filtering commits by time](/images/blog/introducing-the-react-profiler/filtering-commits.gif)
 
-### Flame chart {#flame-chart}
+### Flame chart {/*flame-chart*/}
 
 The flame chart view represents the state of your application for a particular commit.
 Each bar in the chart represents a React component (e.g. `App`, `Nav`).
@@ -114,7 +114,7 @@ In some cases, selecting a component and stepping between commits may also provi
 The above image shows that `state.scrollOffset` changed between commits.
 This is likely what caused the `List` component to re-render.
 
-### Ranked chart {#ranked-chart}
+### Ranked chart {/*ranked-chart*/}
 
 The ranked chart view represents a single commit.
 Each bar in the chart represents a React component (e.g. `App`, `Nav`).
@@ -129,7 +129,7 @@ The chart is ordered so that the components which took the longest to render are
 
 As with the flame chart, you can zoom in or out on a ranked chart by clicking on components.
 
-### Component chart {#component-chart}
+### Component chart {/*component-chart*/}
 
 Sometimes it's useful to see how many times a particular component rendered while you were profiling.
 The component chart provides this information in the form of a bar chart.
@@ -151,7 +151,7 @@ If the selected component did not render at all during the profiling session, th
 
 ![No render times for the selected component](/images/blog/introducing-the-react-profiler/no-render-times-for-selected-component.png)
 
-### Interactions {#interactions}
+### Interactions {/*interactions*/}
 
 React recently added another [experimental API](https://fb.me/react-interaction-tracing) for tracing the _cause_ of an update.
 "Interactions" traced with this API will also be shown in the profiler:
@@ -172,9 +172,9 @@ You can navigate between interactions and commits by clicking on them:
 
 The tracing API is still new and we will cover it in more detail in a future blog post.
 
-## Troubleshooting {#troubleshooting}
+## Troubleshooting {/*troubleshooting*/}
 
-### No profiling data has been recorded for the selected root {#no-profiling-data-has-been-recorded-for-the-selected-root}
+### No profiling data has been recorded for the selected root {/*no-profiling-data-has-been-recorded-for-the-selected-root*/}
 
 If your application has multiple "roots", you may see the following message after profiling:
 ![No profiling data has been recorded for the selected root](/images/blog/introducing-the-react-profiler/no-profiler-data-multi-root.png)
@@ -184,14 +184,14 @@ In this case, try selecting a different root in that panel to view profiling inf
 
 ![Select a root in the "Elements" panel to view its performance data](/images/blog/introducing-the-react-profiler/select-a-root-to-view-profiling-data.gif)
 
-### No timing data to display for the selected commit {#no-timing-data-to-display-for-the-selected-commit}
+### No timing data to display for the selected commit {/*no-timing-data-to-display-for-the-selected-commit*/}
 
 Sometimes a commit may be so fast that `performance.now()` doesn't give DevTools any meaningful timing information.
 In this case, the following message will be shown:
 
 ![No timing data to display for the selected commit](/images/blog/introducing-the-react-profiler/no-timing-data-for-commit.png)
 
-## Deep dive video {#deep-dive-video}
+## Deep dive video {/*deep-dive-video*/}
 
 The following video demonstrates how the React profiler can be used to detect and improve performance bottlenecks in an actual React application.
 

--- a/beta/src/pages/blog/2018/10/01/create-react-app-v2.md
+++ b/beta/src/pages/blog/2018/10/01/create-react-app-v2.md
@@ -15,7 +15,7 @@ Now that Create React App 2.0 is out of beta, let's see what's new and how you c
 >
 >Don't feel pressured to upgrade anything. If you're satisfied with the current feature set, its performance, and reliability, you can keep using the version you're currently at! It might also be a good idea to let the 2.0 release stabilize a little bit before switching to it in production.
 
-## What's New {#whats-new}
+## What's New {/*whats-new*/}
 
 Here's a short summary of what's new in this release:
 
@@ -34,13 +34,13 @@ Here's a short summary of what's new in this release:
 
 **All of these features work out of the box** -- to enable them, follow the below instructions.
 
-## Starting a Project with Create React App 2.0 {#starting-a-project-with-create-react-app-20}
+## Starting a Project with Create React App 2.0 {/*starting-a-project-with-create-react-app-20*/}
 
 You don't need to update anything special. Starting from today, when you run `create-react-app` it will use the 2.0 version of the template by default. Have fun!
 
 If you want to **use the old 1.x template** for some reason, you can do that by passing `--scripts-version=react-scripts@1.x` as an argument to `create-react-app`.
 
-## Updating a Project to Create React App 2.0 {#updating-a-project-to-create-react-app-20}
+## Updating a Project to Create React App 2.0 {/*updating-a-project-to-create-react-app-20*/}
 
 Upgrading a non-ejected project to Create React App 2.0 should usually be straightforward. Open `package.json` in the root of your project and find `react-scripts` there.
 
@@ -67,7 +67,7 @@ Here are a few more tips to get you started.
 >
 >Due to a possible bug in npm, you might see warnings about unsatisfied peer dependencies. You should be able to ignore them. As far as we're aware, this issue isn't present with Yarn.
 
-## Breaking Changes {#breaking-changes}
+## Breaking Changes {/*breaking-changes*/}
 
 Here's a short list of breaking changes in this release:
 
@@ -81,7 +81,7 @@ Here's a short list of breaking changes in this release:
 
 If either of these points affects you, [2.0.3 release notes](https://github.com/facebook/create-react-app/releases/tag/v2.0.3) contain more detailed instructions.
 
-## Learn More {#learn-more}
+## Learn More {/*learn-more*/}
 
 You can find the full changelog in the [release notes](https://github.com/facebook/create-react-app/releases/tag/v2.0.3). This was a large release, and we may have missed something. Please report any problems to our [issue tracker](https://github.com/facebook/create-react-app/issues/new) and we'll try to help.
 
@@ -89,6 +89,6 @@ You can find the full changelog in the [release notes](https://github.com/facebo
 >
 >If you've been using 2.x alpha versions, we provide [separate migration instructions](https://gist.github.com/gaearon/8650d1c70e436e5eff01f396dffc4114) for them.
 
-## Thanks {#thanks}
+## Thanks {/*thanks*/}
 
 This release wouldn't be possible without our wonderful community of contributors. We'd like to thank [Andreas Cederström](https://github.com/andriijas), [Clement Hoang](https://github.com/clemmy), [Brian Ng](https://github.com/existentialism), [Kent C. Dodds](https://github.com/kentcdodds), [Ade Viankakrisna Fadlil](https://github.com/viankakrisna), [Andrey Sitnik](https://github.com/ai), [Ro Savage](https://github.com/ro-savage), [Fabiano Brito](https://github.com/Fabianopb), [Ian Sutherland](https://github.com/iansu), [Pete Nykänen](https://github.com/petetnt), [Jeffrey Posnick](https://github.com/jeffposnick), [Jack Zhao](https://github.com/bugzpodder), [Tobias Koppers](https://github.com/sokra), [Henry Zhu](https://github.com/hzoo), [Maël Nison](https://github.com/arcanis), [XiaoYan Li](https://github.com/lixiaoyan), [Marko Trebizan](https://github.com/themre), [Marek Suscak](https://github.com/mareksuscak), [Mikhail Osher](https://github.com/miraage), and many others who provided feedback and testing for this release.

--- a/beta/src/pages/blog/2018/10/23/react-v-16-6.md
+++ b/beta/src/pages/blog/2018/10/23/react-v-16-6.md
@@ -7,7 +7,7 @@ Today we're releasing React 16.6 with a few new convenient features. A form of P
 
 Check out the full [changelog](#changelog) below.
 
-## [`React.memo`](/docs/react-api#reactmemo) {#reactmemo}
+## [`React.memo`](/docs/react-api#reactmemo) {/*reactmemo*/}
 
 Class components can bail out from rendering when their input props are the same using [`PureComponent`](/docs/react-api#reactpurecomponent) or [`shouldComponentUpdate`](/docs/react-component#shouldcomponentupdate). Now you can do the same with function components by wrapping them in [`React.memo`](/docs/react-api#reactmemo).
 
@@ -17,7 +17,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 });
 ```
 
-## [`React.lazy`](/docs/code-splitting#reactlazy): Code-Splitting with `Suspense` {#reactlazy-code-splitting-with-suspense}
+## [`React.lazy`](/docs/code-splitting#reactlazy): Code-Splitting with `Suspense` {/*reactlazy-code-splitting-with-suspense*/}
 
 You may have seen [Dan's talk about React Suspense at JSConf Iceland](/blog/2018/03/01/sneak-peek-beyond-react-16). Now you can use the Suspense component to do [code-splitting](/docs/code-splitting#reactlazy) by wrapping a dynamic import in a call to `React.lazy()`.
 
@@ -38,7 +38,7 @@ The Suspense component will also allow library authors to start building data fe
 
 > Note: This feature is not yet available for server-side rendering. Suspense support will be added in a later release.
 
-## [`static contextType`](/docs/context#classcontexttype) {#static-contexttype}
+## [`static contextType`](/docs/context#classcontexttype) {/*static-contexttype*/}
 
 In [React 16.3](/blog/2018/03/29/react-v-16-3) we introduced the official Context API as a replacement to the previous [Legacy Context](/docs/legacy-context) API.
 
@@ -70,7 +70,7 @@ class MyClass extends React.Component {
 }
 ```
 
-## [`static getDerivedStateFromError()`](/docs/react-component#static-getderivedstatefromerror) {#static-getderivedstatefromerror}
+## [`static getDerivedStateFromError()`](/docs/react-component#static-getderivedstatefromerror) {/*static-getderivedstatefromerror*/}
 
 React 16 introduced [Error Boundaries](/blog/2017/07/26/error-handling-in-react-16) for handling errors thrown in React renders. We already had the `componentDidCatch` lifecycle method which gets fired after an error has already happened. It's great for logging errors to the server. It also lets you show a different UI to the user by calling `setState`.
 
@@ -80,7 +80,7 @@ We're adding another error method that lets you render the fallback UI before th
 
 > Note: `getDerivedStateFromError()` is not yet available for server-side rendering. It is designed to work with server-side rendering in a future release. We're releasing it early so that you can start preparing to use it.
 
-## Deprecations in StrictMode {#deprecations-in-strictmode}
+## Deprecations in StrictMode {/*deprecations-in-strictmode*/}
 
 In [16.3](/blog/2018/03/29/react-v-16-3#strictmode-component) we introduced the [`StrictMode`](/docs/strict-mode) component. It lets you opt-in to early warnings for patterns that might cause problems in the future.
 
@@ -91,7 +91,7 @@ We've added two more APIs to the list of deprecated APIs in `StrictMode`. If you
 
 If you're having trouble upgrading, we'd like to hear your feedback.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.6.0 is available on the npm registry.
 
@@ -122,9 +122,9 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Add `React.memo()` as an alternative to `PureComponent` for functions. ([@acdlite](https://github.com/acdlite) in [#13748](https://github.com/facebook/react/pull/13748))
 - Add `React.lazy()` for code splitting components. ([@acdlite](https://github.com/acdlite) in [#13885](https://github.com/facebook/react/pull/13885))
@@ -133,7 +133,7 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 - Rename `unstable_AsyncMode` to `unstable_ConcurrentMode`. ([@trueadm](https://github.com/trueadm) in [#13732](https://github.com/facebook/react/pull/13732))
 - Rename `unstable_Placeholder` to `Suspense`, and `delayMs` to `maxDuration`. ([@gaearon](https://github.com/gaearon) in [#13799](https://github.com/facebook/react/pull/13799) and [@sebmarkbage](https://github.com/sebmarkbage) in [#13922](https://github.com/facebook/react/pull/13922))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Add `contextType` as a more ergonomic way to subscribe to context from a class. ([@bvaughn](https://github.com/bvaughn) in [#13728](https://github.com/facebook/react/pull/13728))
 - Add `getDerivedStateFromError` lifecycle method for catching errors in a future asynchronous server-side renderer. ([@bvaughn](https://github.com/bvaughn) in [#13746](https://github.com/facebook/react/pull/13746))
@@ -141,12 +141,12 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 - Fix gray overlay on iOS Safari. ([@philipp-spiess](https://github.com/philipp-spiess) in [#13778](https://github.com/facebook/react/pull/13778))
 - Fix a bug caused by overwriting `window.event` in development. ([@sergei-startsev](https://github.com/sergei-startsev) in [#13697](https://github.com/facebook/react/pull/13697))
 
-### React DOM Server {#react-dom-server}
+### React DOM Server {/*react-dom-server*/}
 
 - Add support for `React.memo()`. ([@alexmckenley](https://github.com/alexmckenley) in [#13855](https://github.com/facebook/react/pull/13855))
 - Add support for `contextType`. ([@alexmckenley](https://github.com/alexmckenley) and [@sebmarkbage](https://github.com/sebmarkbage) in [#13889](https://github.com/facebook/react/pull/13889))
 
-### Scheduler (Experimental) {#scheduler-experimental}
+### Scheduler (Experimental) {/*scheduler-experimental*/}
 
 - Rename the package to `scheduler`. ([@gaearon](https://github.com/gaearon) in [#13683](https://github.com/facebook/react/pull/13683))
 - Support priority levels, continuations, and wrapped callbacks. ([@acdlite](https://github.com/acdlite) in [#13720](https://github.com/facebook/react/pull/13720) and [#13842](https://github.com/facebook/react/pull/13842))

--- a/beta/src/pages/blog/2018/11/27/react-16-roadmap.md
+++ b/beta/src/pages/blog/2018/11/27/react-16-roadmap.md
@@ -9,7 +9,7 @@ You might have heard about features like "Hooks", "Suspense", and "Concurrent Re
 >
 > You can find an update to this roadmap in the [React 16.9 release blog post](/blog/2019/08/08/react-v16.9.0#an-update-to-the-roadmap).
 
-## tl;dr {#tldr}
+## tl;dr {/*tldr*/}
 
 We plan to split the rollout of new React features into the following milestones:
 
@@ -31,13 +31,13 @@ We expect to get more clarity on their timeline in the coming months.
 >
 > This post is just a roadmap -- there is nothing in it that requires your immediate attention. When each of these features are released, we'll publish a full blog post announcing them.
 
-## Release Timeline {#release-timeline}
+## Release Timeline {/*release-timeline*/}
 
 We have a single vision for how all of these features fit together, but we're releasing each part as soon as it is ready so that you can test and start using them sooner. The API design doesn't always make sense when looking at one piece in isolation; this post lays out the major parts of our plan to help you see the whole picture. (See our [versioning policy](/docs/faq-versioning) to learn more about our commitment to stability.)
 
 The gradual release strategy helps us refine the APIs, but the transitional period when some things aren't ready can be confusing. Let's look at what these different features mean for your app, how they relate to each other, and when you can expect to start learning and using them.
 
-### [React 16.6](/blog/2018/10/23/react-v-16-6) (shipped): The One with Suspense for Code Splitting {#react-166-shipped-the-one-with-suspense-for-code-splitting}
+### [React 16.6](/blog/2018/10/23/react-v-16-6) (shipped): The One with Suspense for Code Splitting {/*react-166-shipped-the-one-with-suspense-for-code-splitting*/}
 
 _Suspense_ refers to React's new ability to "suspend" rendering while components are waiting for something, and display a loading indicator. In React 16.6, Suspense supports only one use case: lazy loading components with `React.lazy()` and `<React.Suspense>`.
 
@@ -70,7 +70,7 @@ Code splitting is just the first step for Suspense. Our longer term vision for S
 
 **Recommendation:** If you only do client rendering, we recommend widely adopting `React.lazy()` and `<React.Suspense>` for code splitting React components. If you do server rendering, you'll have to wait with adoption until the new server renderer is ready.
 
-### React 16.x (~Q1 2019): The One with Hooks {#react-16x-q1-2019-the-one-with-hooks}
+### React 16.x (~Q1 2019): The One with Hooks {/*react-16x-q1-2019-the-one-with-hooks*/}
 
 _Hooks_ let you use features like state and lifecycle from function components. They also let you reuse stateful logic between components without introducing extra nesting in your tree.
 
@@ -102,7 +102,7 @@ Hooks represent our vision for the future of React. They solve both problems tha
 
 **Recommendation:** When you’re ready, we encourage you to start trying Hooks in new components you write. Make sure everyone on your team is on board with using them and familiar with this documentation. We don’t recommend rewriting your existing classes to Hooks unless you planned to rewrite them anyway (e.g. to fix bugs). Read more about the adoption strategy [here](/docs/hooks-faq#adoption-strategy).
 
-### React 16.x (~Q2 2019): The One with Concurrent Mode {#react-16x-q2-2019-the-one-with-concurrent-mode}
+### React 16.x (~Q2 2019): The One with Concurrent Mode {/*react-16x-q2-2019-the-one-with-concurrent-mode*/}
 
 _Concurrent Mode_ lets React apps be more responsive by rendering component trees without blocking the main thread. It is opt-in and allows React to interrupt a long-running render (for example, rendering a news feed story) to handle a high-priority event (for example, text input or hover). Concurrent Mode also improves the user experience of Suspense by skipping unnecessary loading states on fast connections.
 
@@ -136,7 +136,7 @@ Concurrent Mode is a big part of our vision for React. For CPU-bound work, it al
 
 **Recommendation:** If you wish to adopt Concurrent Mode in the future, wrapping some component subtrees in [`<React.StrictMode>`](https://reactjs.org/docs/strict-mode) and fixing the resulting warnings is a good first step. In general it's not expected that legacy code would immediately be compatible. For example, at Facebook we mostly intend to use the Concurrent Mode in the more recently developed codebases, and keep the legacy ones running in the synchronous mode for the near future.
 
-### React 16.x (~mid 2019): The One with Suspense for Data Fetching {#react-16x-mid-2019-the-one-with-suspense-for-data-fetching}
+### React 16.x (~mid 2019): The One with Suspense for Data Fetching {/*react-16x-mid-2019-the-one-with-suspense-for-data-fetching*/}
 
 As mentioned earlier, _Suspense_ refers to React's ability to "suspend" rendering while components are waiting for something, and display a loading indicator. In the already shipped React 16.6, the only supported use case for Suspense is code splitting. In this future minor release, we'd like to provide officially supported ways to use it for data fetching too. We'll provide a reference implementation of a basic "React Cache" that's compatible with Suspense, but you can also write your own. Data fetching libraries like Apollo and Relay will be able to integrate with Suspense by following a simple specification that we'll document.
 
@@ -183,13 +183,13 @@ Eventually we'd like most data fetching to happen through Suspense but it will t
 
 **Recommendation:** Wait for this minor React release in order to use Suspense for data fetching. Don’t try to use Suspense features in 16.6 for it; it’s not supported. However, your existing `<Suspense>` components for code splitting will be able to show loading states for data too when Suspense for Data Fetching becomes officially supported.
 
-## Other Projects {#other-projects}
+## Other Projects {/*other-projects*/}
 
-### Modernizing React DOM {#modernizing-react-dom}
+### Modernizing React DOM {/*modernizing-react-dom*/}
 
 We started an investigation into [simplifying and modernizing](https://github.com/facebook/react/issues/13525) ReactDOM, with a goal of reduced bundle size and aligning closer with the browser behavior. It is still early to say which specific bullet points will "make it" because the project is in an exploratory phase. We will communicate our progress on that issue.
 
-### Suspense for Server Rendering {#suspense-for-server-rendering}
+### Suspense for Server Rendering {/*suspense-for-server-rendering*/}
 
 We started designing a new server renderer that supports Suspense (including waiting for asynchronous data on the server without double rendering) and progressively loading and hydrating page content in chunks for best user experience. You can watch an overview of its early prototype in [this talk](https://www.youtube.com/watch?v=z-6JC0_cOns). The new server renderer is going to be our major focus in 2019, but it's too early to say anything about its release schedule. Its development, as always, [will happen on GitHub](https://github.com/facebook/react/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+fizz).
 

--- a/beta/src/pages/blog/2018/12/19/react-v-16-7.md
+++ b/beta/src/pages/blog/2018/12/19/react-v-16-7.md
@@ -5,13 +5,13 @@ author: [acdlite]
 
 Our latest release includes an important performance bugfix for `React.lazy`. Although there are no API changes, we're releasing it as a minor instead of a patch.
 
-## Why Is This Bugfix a Minor Instead of a Patch? {#why-is-this-bugfix-a-minor-instead-of-a-patch}
+## Why Is This Bugfix a Minor Instead of a Patch? {/*why-is-this-bugfix-a-minor-instead-of-a-patch*/}
 
 React follows [semantic versioning](/docs/faq-versioning). Typically, this means that we use patch versions for bugfixes, and minors for new (non-breaking) features. However, we reserve the option to release minor versions even if they do not include new features. The motivation is to reserve patches for changes that have a very low chance of breaking. Patches are the most important type of release because they sometimes contain critical bugfixes. That means patch releases have a higher bar for reliability. It's unacceptable for a patch to introduce additional bugs, because if people come to distrust patches, it compromises our ability to fix critical bugs when they arise — for example, to fix a security vulnerability.
 
 We never intend to ship bugs. React has a hard-earned reputation for stability, and we intend to keep it that way. We thoroughly test every version of React before releasing. This includes unit tests, generative (fuzzy) tests, integration tests, and internal dogfooding across tens of thousands of components. However, sometimes we make mistakes. That's why, going forward, our policy will be that if a release contains non-trivial changes, we will bump the minor version, even if the external behavior is the same. We'll also bump the minor when changing `unstable_`-prefixed APIs.
 
-## Can I Use Hooks Yet? {#can-i-use-hooks-yet}
+## Can I Use Hooks Yet? {/*can-i-use-hooks-yet*/}
 
 Not yet, but soon!
 
@@ -27,7 +27,7 @@ We've heard from many people who want to start using Hooks in their apps. We als
 
 Learn more about [our roadmap](/blog/2018/11/27/react-16-roadmap) in our previous post.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 React v16.7.0 is available on the npm registry.
 
@@ -58,16 +58,16 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Fix performance of `React.lazy` for large numbers of lazily-loaded components. ([@acdlite](http://github.com/acdlite) in [#14429](https://github.com/facebook/react/pull/14429))
 - Clear fields on unmount to avoid memory leaks. ([@trueadm](http://github.com/trueadm) in [#14276](https://github.com/facebook/react/pull/14276))
 - Fix bug with SSR and context when mixing `react-dom/server@16.6` and `react@<16.6`. ([@gaearon](http://github.com/gaearon) in [#14291](https://github.com/facebook/react/pull/14291))
 - Fix a performance regression in profiling mode. ([@bvaughn](http://github.com/bvaughn) in [#14383](https://github.com/facebook/react/pull/14383))
 
-### Scheduler (Experimental) {#scheduler-experimental}
+### Scheduler (Experimental) {/*scheduler-experimental*/}
 
 - Post to MessageChannel instead of window. ([@acdlite](http://github.com/acdlite) in [#14234](https://github.com/facebook/react/pull/14234))
 - Reduce serialization overhead. ([@developit](http://github.com/developit) in [#14249](https://github.com/facebook/react/pull/14249))

--- a/beta/src/pages/blog/2019/02/06/react-v16.8.0.md
+++ b/beta/src/pages/blog/2019/02/06/react-v16.8.0.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 With React 16.8, [React Hooks](/docs/hooks-intro.html) are available in a stable release!
 
-## What Are Hooks? {#what-are-hooks}
+## What Are Hooks? {/*what-are-hooks*/}
 
 Hooks let you use state and other React features without writing a class. You can also **build your own Hooks** to share reusable stateful logic between components.
 
@@ -19,11 +19,11 @@ If you've never heard of Hooks before, you might find these resources interestin
 
 **You don't have to learn Hooks right now.** Hooks have no breaking changes, and we have no plans to remove classes from React. The [Hooks FAQ](/docs/hooks-faq.html) describes the gradual adoption strategy.
 
-## No Big Rewrites {#no-big-rewrites}
+## No Big Rewrites {/*no-big-rewrites*/}
 
 We don't recommend rewriting your existing applications to use Hooks overnight. Instead, try using Hooks in some of the new components, and let us know what you think. Code using Hooks will work [side by side](/docs/hooks-intro.html#gradual-adoption-strategy) with existing code using classes.
 
-## Can I Use Hooks Today? {#can-i-use-hooks-today}
+## Can I Use Hooks Today? {/*can-i-use-hooks-today*/}
 
 Yes! Starting with 16.8.0, React includes a stable implementation of React Hooks for:
 
@@ -36,11 +36,11 @@ Note that **to enable Hooks, all React packages need to be 16.8.0 or higher**. H
 
 **React Native will support Hooks in the [0.59 release](https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-457735214).**
 
-## Tooling Support {#tooling-support}
+## Tooling Support {/*tooling-support*/}
 
 React Hooks are now supported by React DevTools. They are also supported in the latest Flow and TypeScript definitions for React. We strongly recommend enabling a new [lint rule called `eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) to enforce best practices with Hooks. It will soon be included into Create React App by default.
 
-## What's Next {#whats-next}
+## What's Next {/*whats-next*/}
 
 We described our plan for the next months in the recently published [React Roadmap](/blog/2018/11/27/react-16-roadmap.html).
 
@@ -48,7 +48,7 @@ Note that React Hooks don't cover *all* use cases for classes yet but they're [v
 
 Even while Hooks were in alpha, the React community created many interesting [examples](https://codesandbox.io/react-hooks) and [recipes](https://usehooks.com) using Hooks for animations, forms, subscriptions, integrating with other libraries, and so on. We're excited about Hooks because they make code reuse easier, helping you write your components in a simpler way and make great user experiences. We can't wait to see what you'll create next!
 
-## Testing Hooks {#testing-hooks}
+## Testing Hooks {/*testing-hooks*/}
 
 We have added a new API called `ReactTestUtils.act()` in this release. It ensures that the behavior in your tests matches what happens in the browser more closely. We recommend to wrap any code rendering and triggering updates to your components into `act()` calls. Testing libraries can also wrap their APIs with it (for example, [`react-testing-library`](https://testing-library.com/react)'s `render` and `fireEvent` utilities do this).
 
@@ -97,13 +97,13 @@ If you need to test a custom Hook, you can do so by creating a component in your
 
 To reduce the boilerplate, we recommend using [`react-testing-library`](https://testing-library.com/react) which is designed to encourage writing tests that use your components as the end users do.
 
-## Thanks {#thanks}
+## Thanks {/*thanks*/}
 
 We'd like to thank everybody who commented on the [Hooks RFC](https://github.com/reactjs/rfcs/pull/68) for sharing their feedback. We've read all of your comments and made some adjustments to the final API based on them.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
-### React {#react}
+### React {/*react*/}
 
 React v16.8.0 is available on the npm registry.
 
@@ -128,7 +128,7 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation.html).
 
-### ESLint Plugin for React Hooks {#eslint-plugin-for-react-hooks}
+### ESLint Plugin for React Hooks {/*eslint-plugin-for-react-hooks*/}
 
 >Note
 >
@@ -161,14 +161,14 @@ Then add it to your ESLint configuration:
 }
 ```
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react-1}
+### React {/*react-1*/}
 
 * Add [Hooks](https://reactjs.org/docs/hooks-intro.html) — a way to use state and other React features without writing a class. ([@acdlite](https://github.com/acdlite) et al. in [#13968](https://github.com/facebook/react/pull/13968))
 * Improve the `useReducer` Hook lazy initialization API. ([@acdlite](https://github.com/acdlite) in [#14723](https://github.com/facebook/react/pull/14723))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 * Bail out of rendering on identical values for `useState` and `useReducer` Hooks. ([@acdlite](https://github.com/acdlite) in [#14569](https://github.com/facebook/react/pull/14569))
 * Don’t compare the first argument passed to `useEffect`/`useMemo`/`useCallback` Hooks. ([@acdlite](https://github.com/acdlite) in [#14594](https://github.com/facebook/react/pull/14594))
@@ -178,19 +178,19 @@ Then add it to your ESLint configuration:
 * Warn about mismatching Hook order in development. ([@threepointone](https://github.com/threepointone) in [#14585](https://github.com/facebook/react/pull/14585) and [@acdlite](https://github.com/acdlite) in [#14591](https://github.com/facebook/react/pull/14591))
 * Effect clean-up functions must return either `undefined` or a function. All other values, including `null`, are not allowed. [@acdlite](https://github.com/acdlite) in [#14119](https://github.com/facebook/react/pull/14119)
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 
 * Support Hooks in the shallow renderer. ([@trueadm](https://github.com/trueadm) in [#14567](https://github.com/facebook/react/pull/14567))
 * Fix wrong state in `shouldComponentUpdate` in the presence of `getDerivedStateFromProps` for Shallow Renderer. ([@chenesan](https://github.com/chenesan) in [#14613](https://github.com/facebook/react/pull/14613))
 * Add `ReactTestRenderer.act()` and `ReactTestUtils.act()` for batching updates so that tests more closely match real behavior. ([@threepointone](https://github.com/threepointone) in [#14744](https://github.com/facebook/react/pull/14744))
 
-### ESLint Plugin: React Hooks {#eslint-plugin-react-hooks}
+### ESLint Plugin: React Hooks {/*eslint-plugin-react-hooks*/}
 
 * Initial [release](https://www.npmjs.com/package/eslint-plugin-react-hooks). ([@calebmer](https://github.com/calebmer) in [#13968](https://github.com/facebook/react/pull/13968))
 * Fix reporting after encountering a loop. ([@calebmer](https://github.com/calebmer) and [@Yurickh](https://github.com/Yurickh) in [#14661](https://github.com/facebook/react/pull/14661))
 * Don't consider throwing to be a rule violation. ([@sophiebits](https://github.com/sophiebits) in [#14040](https://github.com/facebook/react/pull/14040))
 
-## Hooks Changelog Since Alpha Versions {#hooks-changelog-since-alpha-versions}
+## Hooks Changelog Since Alpha Versions {/*hooks-changelog-since-alpha-versions*/}
 
 The above changelog contains all notable changes since our last **stable** release (16.7.0). [As with all our minor releases](/docs/faq-versioning.html), none of the changes break backwards compatibility.
 

--- a/beta/src/pages/blog/2019/02/23/is-react-translated-yet.md
+++ b/beta/src/pages/blog/2019/02/23/is-react-translated-yet.md
@@ -13,19 +13,19 @@ In addition, the following three languages have completed translating most of th
 
 Special congratulations to [Alejandro Ñáñez Ortiz](https://github.com/alejandronanez), [Rainer Martínez Fraga](https://github.com/carburo), [David Morales](https://github.com/dmorales), [Miguel Alejandro Bolivar Portilla](https://github.com/Darking360), and all the contributors to the Spanish translation for being the first to _completely_ translate the core pages of the docs!
 
-## Why Localization Matters {#why-localization-matters}
+## Why Localization Matters {/*why-localization-matters*/}
 
 React already has many meetups and conferences around the world, but many programmers don't use English as their primary language. We’d love to support local communities who use React by making our documentation available in most popular languages.
 
 In the past, React community members have created unofficial translations for [Chinese](https://github.com/discountry/react), [Arabic](https://wiki.hsoub.com/React), and [Korean](https://github.com/reactjs/ko.reactjs.org/issues/4); by making an official channel for these translated docs we're hoping to make them easier to find and help make sure that non-English-speaking users of React aren't left behind.
 
-## Contributing {#contributing}
+## Contributing {/*contributing*/}
 
 If you would like to help out on a current translation, check out the [Languages](/languages) page and click on the "Contribute" link for your language.
 
 Can't find your language? If you'd like to maintain your language's translation fork, follow the instructions in the [translation repo](https://github.com/reactjs/reactjs.org-translation#starting-a-new-translation)!
 
-## Backstory {#backstory}
+## Backstory {/*backstory*/}
 
 Hi everyone! I'm [Nat](https://twitter.com/tesseralis)! You may know me as the [polyhedra lady](https://www.youtube.com/watch?v=Ew-UzGC8RqQ). For the past few weeks, I've been helping the React team coordinate their translation effort. Here's how I did it.
 
@@ -45,7 +45,7 @@ After the trial period, we were ready to accept more languages. I created [a scr
 
 Because of the automation, the rest of the maintenance went mostly smoothly. We eventually created a [Slack channel](https://rt-slack-invite.herokuapp.com) to make it easier for translators to share information, and I released a guide solidifying the [responsibilities of maintainers](https://github.com/reactjs/reactjs.org-translation/blob/master/maintainer-guide.md). Allowing translators to talk with each other was a great boon -- for example, the Arabic, Persian, and Hebrew translations were able to talk to each other in order to get [right-to-left text](https://en.wikipedia.org/wiki/Right-to-left) working!
 
-## The Bot {#the-bot}
+## The Bot {/*the-bot*/}
 
 The most challenging part was getting the bot to sync changes from the English version of the site. Initially we were using the [che-tsumi](https://github.com/vuejs-jp/che-tsumi) bot created by the Japanese Vue translation team, but we soon decided to build our own bot to suit our needs. In particular, the che-tsumi bot works by [cherry picking](https://git-scm.com/docs/git-cherry-pick) new commits. This ended up causing a cavalade of new issues that were interconnected, especially when [Hooks were released](/blog/2019/02/06/react-v16.8.0).
 
@@ -63,7 +63,7 @@ There were other smaller issues that I ran into. I tried using the [Heroku Sched
 
 There are, as always, improvements I want to make to the bot. Right now it doesn't check whether there is an outstanding pull request before pushing another one. It's still hard to tell the exact change that happened in the original source, and it's possible to miss out on a needed translation change. But I trust the maintainers we've chosen to work through these issues, and the bot is [open source](https://github.com/reactjs/reactjs.org-translation) if anyone wants to help me make these improvements!
 
-## Thanks {#thanks}
+## Thanks {/*thanks*/}
 
 Finally, I would like to extend my gratitude to the following people and groups:
 

--- a/beta/src/pages/blog/2019/08/08/react-v16.9.0.md
+++ b/beta/src/pages/blog/2019/08/08/react-v16.9.0.md
@@ -5,9 +5,9 @@ author: [gaearon, bvaughn]
 
 Today we are releasing React 16.9. It contains several new features, bugfixes, and new deprecation warnings to help prepare for a future major release.
 
-## New Deprecations {#new-deprecations}
+## New Deprecations {/*new-deprecations*/}
 
-### Renaming Unsafe Lifecycle Methods {#renaming-unsafe-lifecycle-methods}
+### Renaming Unsafe Lifecycle Methods {/*renaming-unsafe-lifecycle-methods*/}
 
 [Over a year ago](/blog/2018/03/27/update-on-async-rendering), we announced that unsafe lifecycle methods are getting renamed:
 
@@ -38,7 +38,7 @@ The new names like `UNSAFE_componentWillMount` **will keep working in both React
 >
 > Learn more about our [versioning policy and commitment to stability](/docs/faq-versioning#commitment-to-stability).
 
-### Deprecating `javascript:` URLs {#deprecating-javascript-urls}
+### Deprecating `javascript:` URLs {/*deprecating-javascript-urls*/}
 
 URLs starting with `javascript:` are a dangerous attack surface because it's easy to accidentally include unsanitized output in a tag like `<a href>` and create a security hole:
 
@@ -54,7 +54,7 @@ const userProfile = {
 
 **In a future major release,** React will throw an error if it encounters a `javascript:` URL.
 
-### Deprecating "Factory" Components {#deprecating-factory-components}
+### Deprecating "Factory" Components {/*deprecating-factory-components*/}
 
 Before compiling JavaScript classes with Babel became popular, React had support for a "factory" component that returns an object with a `render` method:
 
@@ -74,9 +74,9 @@ This pattern was almost never used in the wild, and supporting it causes React t
 
 We don't expect most codebases to be affected by this.
 
-## New Features {#new-features}
+## New Features {/*new-features*/}
 
-### Async [`act()`](/docs/test-utils#act) for Testing {#async-act-for-testing}
+### Async [`act()`](/docs/test-utils#act) for Testing {/*async-act-for-testing*/}
 
 [React 16.8](/blog/2019/02/06/react-v16.8.0) introduced a new testing utility called [`act()`](/docs/test-utils#act) to help you write tests that better match the browser behavior. For example, multiple state updates inside a single `act()` get batched. This matches how React already works when handling real browser events, and helps prepare your components for the future in which React will batch updates more often.
 
@@ -100,7 +100,7 @@ We've heard there wasn't enough information about how to write tests with `act()
 
 Please let us know [on the issue tracker](https://github.com/facebook/react/issues) if you bump into any other scenarios where `act()` doesn't work well for you, and we'll try to help.
 
-### Performance Measurements with [`<React.Profiler>`](/docs/profiler) {#performance-measurements-with-reactprofiler}
+### Performance Measurements with [`<React.Profiler>`](/docs/profiler) {/*performance-measurements-with-reactprofiler*/}
 
 In React 16.5, we introduced a new [React Profiler for DevTools](/blog/2018/09/10/introducing-the-react-profiler) that helps find performance bottlenecks in your application. **In React 16.9, we are also adding a _programmatic_ way to gather measurements** called `<React.Profiler>`. We expect that most smaller apps won't use it, but it can be handy to track performance regressions over time in larger apps.
 
@@ -129,7 +129,7 @@ To learn more about the `Profiler` and the parameters passed to the `onRender` c
 > To opt into production profiling, React provides a special production build with profiling enabled.
 > Read more about how to use this build at [fb.me/react-profiling](https://fb.me/react-profiling).
 
-## Notable Bugfixes {#notable-bugfixes}
+## Notable Bugfixes {/*notable-bugfixes*/}
 
 This release contains a few other notable improvements:
 
@@ -141,7 +141,7 @@ This release contains a few other notable improvements:
 
 We're thankful to all the contributors who helped surface and fix these and other issues. You can find the full changelog [below](#changelog).
 
-## An Update to the Roadmap {#an-update-to-the-roadmap}
+## An Update to the Roadmap {/*an-update-to-the-roadmap*/}
 
 In [November 2018](/blog/2018/11/27/react-16-roadmap), we have posted this roadmap for the 16.x releases:
 
@@ -159,7 +159,7 @@ Now that React Hooks are rolled out, the work on Concurrent Mode and Suspense fo
 
 With this new understanding, here's what we plan to do next.
 
-### One Release Instead of Two {#one-release-instead-of-two}
+### One Release Instead of Two {/*one-release-instead-of-two*/}
 
 Concurrent Mode and Suspense [power the new Facebook website](https://developers.facebook.com/videos/2019/building-the-new-facebookcom-with-react-graphql-and-relay/) that's in active development, so we are confident that they're close to a stable state technically. We also now better understand the concrete steps before they are ready for open source adoption.
 
@@ -167,23 +167,23 @@ Originally we thought we would split Concurrent Mode and Suspense for Data Fetch
 
 We don't want to overpromise the release date again. Given that we rely on both of them in production code, we expect to provide a 16.x release with opt-in support for them this year.
 
-### An Update on Data Fetching {#an-update-on-data-fetching}
+### An Update on Data Fetching {/*an-update-on-data-fetching*/}
 
 While React is not opinionated about how you fetch data, the first release of Suspense for Data Fetching will likely focus on integrating with _opinionated data fetching libraries_. For example, at Facebook we are using upcoming Relay APIs that integrate with Suspense. We will document how other opinionated libraries like Apollo can support a similar integration.
 
 In the first release, we _don't_ intend to focus on the ad-hoc "fire an HTTP request" solution we used in earlier demos (also known as "React Cache"). However, we expect that both we and the React community will be exploring that space in the months after the initial release.
 
-### An Update on Server Rendering {#an-update-on-server-rendering}
+### An Update on Server Rendering {/*an-update-on-server-rendering*/}
 
 We have started the work on the [new Suspense-capable server renderer](/blog/2018/11/27/react-16-roadmap#suspense-for-server-rendering), but we _don't_ expect it to be ready for the initial release of Concurrent Mode. This release will, however, provide a temporary solution that lets the existing server renderer emit HTML for Suspense fallbacks immediately, and then render their real content on the client. This is the solution we are currently using at Facebook ourselves until the streaming renderer is ready.
 
-### Why Is It Taking So Long? {#why-is-it-taking-so-long}
+### Why Is It Taking So Long? {/*why-is-it-taking-so-long*/}
 
 We've shipped the individual pieces leading up to Concurrent Mode as they became stable, including [new context API](/blog/2018/03/29/react-v-16-3), [lazy loading with Suspense](/blog/2018/10/23/react-v-16-6), and [Hooks](/blog/2019/02/06/react-v16.8.0). We are also eager to release the other missing parts, but [trying them at scale](/docs/design-principles#dogfooding) is an important part of the process. The honest answer is that it just took more work than we expected when we started. As always, we appreciate your questions and feedback on [Twitter](https://twitter.com/reactjs) and in our [issue tracker](https://github.com/facebook/react/issues).
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
-### React {#react}
+### React {/*react*/}
 
 React v16.9.0 is available on the npm registry.
 
@@ -214,14 +214,14 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Add `<React.Profiler>` API for gathering performance measurements programmatically. ([@bvaughn](https://github.com/bvaughn) in [#15172](https://github.com/facebook/react/pull/15172))
 - Remove `unstable_ConcurrentMode` in favor of `unstable_createRoot`. ([@acdlite](https://github.com/acdlite) in [#15532](https://github.com/facebook/react/pull/15532))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Deprecate old names for the `UNSAFE_*` lifecycle methods. ([@bvaughn](https://github.com/bvaughn) in [#15186](https://github.com/facebook/react/pull/15186) and [@threepointone](https://github.com/threepointone) in [#16103](https://github.com/facebook/react/pull/16103))
 - Deprecate `javascript:` URLs as a common attack surface. ([@sebmarkbage](https://github.com/sebmarkbage) in [#15047](https://github.com/facebook/react/pull/15047))
@@ -238,11 +238,11 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 - Fix hiding Suspense fallback nodes when there is an `!important` style. ([@acdlite](https://github.com/acdlite) in [#15861](https://github.com/facebook/react/pull/15861) and [#15882](https://github.com/facebook/react/pull/15882))
 - Slightly improve hydration performance. ([@bmeurer](https://github.com/bmeurer) in [#15998](https://github.com/facebook/react/pull/15998))
 
-### React DOM Server {#react-dom-server}
+### React DOM Server {/*react-dom-server*/}
 
 - Fix incorrect output for camelCase custom CSS property names. ([@bedakb](https://github.com/bedakb) in [#16167](https://github.com/facebook/react/pull/16167))
 
-### React Test Utilities and Test Renderer {#react-test-utilities-and-test-renderer}
+### React Test Utilities and Test Renderer {/*react-test-utilities-and-test-renderer*/}
 
 - Add `act(async () => ...)` for testing asynchronous state updates. ([@threepointone](https://github.com/threepointone) in [#14853](https://github.com/facebook/react/pull/14853))
 - Add support for nesting `act` from different renderers. ([@threepointone](https://github.com/threepointone) in [#16039](https://github.com/facebook/react/pull/16039) and [#16042](https://github.com/facebook/react/pull/16042))

--- a/beta/src/pages/blog/2019/08/15/new-react-devtools.md
+++ b/beta/src/pages/blog/2019/08/15/new-react-devtools.md
@@ -5,7 +5,7 @@ author: [bvaughn]
 
 We are excited to announce a new release of the React Developer Tools, available today in Chrome, Firefox, and (Chromium) Edge!
 
-## What's changed? {#whats-changed}
+## What's changed? {/*whats-changed*/}
 
 A lot has changed in version 4!
 At a high level, this new version should offer significant performance gains and an improved navigation experience.
@@ -15,7 +15,7 @@ It also offers full support for React Hooks, including inspecting nested objects
 
 [Visit the interactive tutorial](https://react-devtools-tutorial.now.sh/) to try out the new version or [see the changelog](https://github.com/facebook/react/blob/master/packages/react-devtools/CHANGELOG.md#400-august-15-2019) for demo videos and more details.
 
-## Which versions of React are supported? {#which-versions-of-react-are-supported}
+## Which versions of React are supported? {/*which-versions-of-react-are-supported*/}
 
 **`react-dom`**
 
@@ -28,7 +28,7 @@ It also offers full support for React Hooks, including inspecting nested objects
 - `0`-`0.61.x`: Not supported
 - `0.62`: Supported
 
-## How do I get the new DevTools? {#how-do-i-get-the-new-devtools}
+## How do I get the new DevTools? {/*how-do-i-get-the-new-devtools*/}
 
 React DevTools is available as an extension for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/).
 If you have already installed the extension, it should update automatically within the next couple of hours.
@@ -39,14 +39,14 @@ If you use the standalone shell (e.g. in React Native or Safari), you can instal
 npm install -g react-devtools@^4
 ```
 
-## Where did all of the DOM elements go? {#where-did-all-of-the-dom-elements-go}
+## Where did all of the DOM elements go? {/*where-did-all-of-the-dom-elements-go*/}
 
 The new DevTools provides a way to filter components from the tree to make it easier to navigate deeply nested hierarchies.
 Host nodes (e.g. HTML `<div>`, React Native `<View>`) are _hidden by default_, but this filter can be disabled:
 
 ![DevTools component filters](/images/blog/devtools-component-filters.gif)
 
-## How do I get the old version back? {#how-do-i-get-the-old-version-back}
+## How do I get the old version back? {/*how-do-i-get-the-old-version-back*/}
 
 If you are working with React Native version 60 (or older) you can install the previous release of DevTools from NPM:
 
@@ -72,7 +72,7 @@ yarn build:extension
 # Follow the on-screen instructions to complete installation
 ```
 
-## Thank you! {#thank-you}
+## Thank you! {/*thank-you*/}
 
 We'd like to thank everyone who tested the early release of DevTools version 4.
 Your feedback helped improve this initial release significantly.

--- a/beta/src/pages/blog/2019/10/22/react-release-channels.md
+++ b/beta/src/pages/blog/2019/10/22/react-release-channels.md
@@ -13,7 +13,7 @@ Because the source of truth for React is our [public GitHub repository](https://
 
 We would like to make it even easier for developers to test prerelease builds of React, so we're formalizing our process with three separate release channels.
 
-## Release Channels {#release-channels}
+## Release Channels {/*release-channels*/}
 
 > The information in this post is also available on our [Release Channels](/docs/release-channels) page. We will update that document whenever there are changes to our release process.
 
@@ -29,7 +29,7 @@ All releases are published to npm, but only Latest uses [semantic versioning](/d
 
 By publishing prereleases to the same registry that we use for stable releases, we are able to take advantage of the many tools that support the npm workflow, like [unpkg](https://unpkg.com) and [CodeSandbox](https://codesandbox.io).
 
-### Latest Channel {#latest-channel}
+### Latest Channel {/*latest-channel*/}
 
 Latest is the channel used for stable React releases. It corresponds to the `latest` tag on npm. It is the recommended channel for all React apps that are shipped to real users.
 
@@ -37,7 +37,7 @@ Latest is the channel used for stable React releases. It corresponds to the `lat
 
 You can expect updates to Latest to be extremely stable. Versions follow the semantic versioning scheme. Learn more about our commitment to stability and incremental migration in our [versioning policy](/docs/faq-versioning).
 
-### Next Channel {#next-channel}
+### Next Channel {/*next-channel*/}
 
 The Next channel is a prerelease channel that tracks the master branch of the React repository. We use prereleases in the Next channel as release candidates for the Latest channel. You can think of Next as a superset of Latest that is updated more frequently.
 
@@ -47,7 +47,7 @@ The degree of change between the most recent Next release and the most recent La
 
 Releases in Next are published with the `next` tag on npm. Versions are generated from a hash of the build's contents, e.g. `0.0.0-1022ee0ec`.
 
-#### Using the Next Channel for Integration Testing {#using-the-next-channel-for-integration-testing}
+#### Using the Next Channel for Integration Testing {/*using-the-next-channel-for-integration-testing*/}
 
 The Next channel is designed to support integration testing between React and other projects.
 
@@ -74,7 +74,7 @@ If you're the author of a third party React framework, library, developer tool, 
 
 A project that uses this workflow is Next.js. (No pun intended! Seriously!) You can refer to their [CircleCI configuration](https://github.com/zeit/next.js/blob/c0a1c0f93966fe33edd93fb53e5fafb0dcd80a9e/.circleci/config.yml) as an example.
 
-### Experimental Channel {#experimental-channel}
+### Experimental Channel {/*experimental-channel*/}
 
 Like Next, the Experimental channel is a prerelease channel that tracks the master branch of the React repository. Unlike Next, Experimental releases include additional features and APIs that are not ready for wider release.
 
@@ -84,7 +84,7 @@ Experimental releases may be significantly different than releases to Next and L
 
 Releases in Experimental are published with the `experimental` tag on npm. Versions are generated from a hash of the build's contents, e.g. `0.0.0-experimental-1022ee0ec`.
 
-#### What Goes Into an Experimental Release? {#what-goes-into-an-experimental-release}
+#### What Goes Into an Experimental Release? {/*what-goes-into-an-experimental-release*/}
 
 Experimental features are ones that are not ready to be released to the wider public, and may change drastically before they are finalized. Some experiments may never be finalized -- the reason we have experiments is to test the viability of proposed changes.
 
@@ -92,7 +92,7 @@ For example, if the Experimental channel had existed when we announced Hooks, we
 
 You may find it valuable to run integration tests against Experimental. This is up to you. However, be advised that Experimental is even less stable than Next. **We do not guarantee any stability between Experimental releases.**
 
-#### How Can I Learn More About Experimental Features? {#how-can-i-learn-more-about-experimental-features}
+#### How Can I Learn More About Experimental Features? {/*how-can-i-learn-more-about-experimental-features*/}
 
 Experimental features may or may not be documented. Usually, experiments aren't documented until they are close to shipping in Next or Stable.
 

--- a/beta/src/pages/blog/2019/11/06/building-great-user-experiences-with-concurrent-mode-and-suspense.md
+++ b/beta/src/pages/blog/2019/11/06/building-great-user-experiences-with-concurrent-mode-and-suspense.md
@@ -11,7 +11,7 @@ At React Conf 2019 we announced an [experimental release](/docs/concurrent-mode-
 
 This post is **aimed at library authors**. If you're primarily an application developer, you might still find some interesting ideas here, but don't feel like you have to read it in its entirety.
 
-## Talk Videos {#talk-videos}
+## Talk Videos {/*talk-videos*/}
 
 If you prefer to watch videos, some of the ideas from this blog post have been referenced in several React Conf 2019 presentations:
 
@@ -21,7 +21,7 @@ If you prefer to watch videos, some of the ideas from this blog post have been r
 
 This post presents a deeper dive on implementing a data fetching library with Suspense.
 
-## Putting User Experience First {#putting-user-experience-first}
+## Putting User Experience First {/*putting-user-experience-first*/}
 
 The React team and community has long placed a deserved emphasis on developer experience: ensuring that React has good error messages, focusing on components as a way to reason locally about app behavior, crafting APIs that are predictable and encourage correct usage by design, etc. But we haven't provided enough guidance on the best ways to achieve a great _user_ experience in large apps.
 
@@ -33,7 +33,7 @@ Thanks to this project, we're more confident than ever that Concurrent Mode and 
 
 Relay Hooks -- and GraphQL -- won't be for everyone, and that's ok! Through our work on these APIs we've identified a set of more general patterns for using Suspense. **Even if Relay isn't the right fit for you, we think the key patterns we've introduced with Relay Hooks can be adapted to other frameworks.**
 
-## Best Practices for Suspense {#best-practices-for-suspense}
+## Best Practices for Suspense {/*best-practices-for-suspense*/}
 
 It's tempting to focus only on the total startup time for an app -- but it turns out that users' perception of performance is determined by more than the absolute loading time. For example, when comparing two apps with the same absolute startup time, our research shows that users will generally perceive the one with fewer intermediate loading states and fewer layout changes as having loaded faster. Suspense is a powerful tool for carefully orchestrating an elegant loading sequence with a few, well-defined states that progressively reveal content. But improving perceived performance only goes so far -- our apps still shouldn't take forever to fetch all of their code, data, images, and other assets.
 
@@ -43,7 +43,7 @@ It turns out that this approach has some limitations. Consider a page that shows
 
 There's also another often-overlooked downside to this approach. If `<Post>` eagerly requires (or imports) the `<CommentList>` component, our app will have to wait to show the post _body_ while the code for the _comments_ is downloading. We could lazily load `<CommentList>`, but then that would delay fetching comments data and increase the time to show the full page. How do we resolve this problem without compromising on the user experience?
 
-## Render As You Fetch {#render-as-you-fetch}
+## Render As You Fetch {/*render-as-you-fetch*/}
 
 The fetch-on-render approach is widely used by React apps today and can certainly be used to create great apps. But can we do even better? Let's step back and consider our goal.
 
@@ -59,7 +59,7 @@ This might sound difficult to achieve -- but these constraints are actually incr
 3. Load data incrementally
 4. Treat code like data
 
-### Parallel Data and View Trees {#parallel-data-and-view-trees}
+### Parallel Data and View Trees {/*parallel-data-and-view-trees*/}
 
 One of the most appealing things about the fetch-on-render pattern is that it colocates _what_ data a component needs with _how_ to render that data. This colocation is great -- an example of how it makes sense to group code by concerns and not by technologies. All the issues we saw above were due to _when_ we fetch data in this approach: upon rendering. We need to be able to fetch data _before_ we've rendered the component. The only way to achieve that is by extracting the data dependencies into parallel data and view trees.
 
@@ -96,7 +96,7 @@ Although the GraphQL is written within the component, Relay has a build step (Re
 
 The key is that regardless of the technology we're using to load our data -- GraphQL, REST, etc -- we can separate _what_ data to load from how and when to actually load it. But once we do that, how and when _do_ we fetch our data?
 
-### Fetch in Event Handlers {#fetch-in-event-handlers}
+### Fetch in Event Handlers {/*fetch-in-event-handlers*/}
 
 Imagine that we're about to navigate from a list of a user's posts to the page for a specific post. We'll need to download the code for that page -- `Post.js` -- and also fetch its data.
 
@@ -173,7 +173,7 @@ Once we've implemented the ability to start loading code and data for a view ind
 
 Best of all, we can centralize that logic in a few key places -- a router or core UI components -- and get any performance benefits automatically throughout our app. Of course preloading isn't always beneficial. It's something an application would tune based on the user's device or network speed to avoid eating up user's data plans. But the pattern here makes it easier to centralize the implementation of preloading and the decision of whether to enable it or not.
 
-### Load Data Incrementally {#load-data-incrementally}
+### Load Data Incrementally {/*load-data-incrementally*/}
 
 The above patterns -- parallel data/view trees and fetching in event handlers -- let us start loading all the data for a view earlier. But we still want to be able to show more important parts of the view without waiting for _all_ of our data. At Facebook we've implemented support for this in GraphQL and Relay in the form of some new GraphQL directives (annotations that affect how/when data is delivered, but not what data). These new directives, called `@defer` and `@stream`, allow us to retrieve data incrementally. For example, consider our `<Post>` component from above. We want to show the body without waiting for the comments to be ready. We can achieve this with `@defer` and `<Suspense>`:
 
@@ -208,17 +208,17 @@ function Post(props) {
 
 Here, our GraphQL server will stream back the results, first returning the `author` and `title` fields and then returning the comment data when it's ready. We wrap `<CommentList>` in a `<Suspense>` boundary so that we can render the post body before `<CommentList>` and its data are ready. This same pattern can be applied to other frameworks as well. For example, apps that call a REST API might make parallel requests to fetch the body and comments data for a post to avoid blocking on all the data being ready.
 
-### Treat Code Like Data {#treat-code-like-data}
+### Treat Code Like Data {/*treat-code-like-data*/}
 
 But there's one thing that's still missing. We've shown how to preload _data_ for a route -- but what about code? The example above cheated a bit and used `React.lazy`. However, `React.lazy` is, as the name implies, _lazy_. It won't start downloading code until the lazy component is actually rendered -- it's "fetch-on-render" for code!
 
 To solve this, the React team is considering APIs that would allow bundle splitting and eager preloading for code as well. That would allow a user to pass some form of lazy component to a router, and for the router to trigger loading the code alongside its data as early as possible.
 
-## Putting It All Together {#putting-it-all-together}
+## Putting It All Together {/*putting-it-all-together*/}
 
 To recap, achieving a great loading experience means that we need to **start loading code and data as early as possible, but without waiting for all of it to be ready**. Parallel data and view trees allow us to load the data for a view in parallel with loading the view (code) itself. Fetching in an event handler means we can start loading data as early as possible, and even optimistically preload a view when we have enough confidence that a user will navigate to it. Loading data incrementally allows us to load important data earlier without delaying the fetching of less important data. And treating code as data -- and preloading it with similar APIs -- allows us to load it earlier too.
 
-## Using These Patterns {#using-these-patterns}
+## Using These Patterns {/*using-these-patterns*/}
 
 These patterns aren't just ideas -- we've implemented them in Relay Hooks and are using them in production throughout the new facebook.com (which is currently in beta testing). If you're interested in using or learning more about these patterns, here are some resources:
 

--- a/beta/src/pages/blog/2020/02/26/react-v16.13.0.md
+++ b/beta/src/pages/blog/2020/02/26/react-v16.13.0.md
@@ -7,9 +7,9 @@ redirect_from:
 
 Today we are releasing React 16.13.0. It contains bugfixes and new deprecation warnings to help prepare for a future major release.
 
-## New Warnings {#new-warnings}
+## New Warnings {/*new-warnings*/}
 
-### Warnings for some updates during render {#warnings-for-some-updates-during-render}
+### Warnings for some updates during render {/*warnings-for-some-updates-during-render*/}
 
 A React component should not cause side effects in other components during rendering.
 
@@ -21,7 +21,7 @@ Warning: Cannot update a component from inside the function body of a different 
 
 **This warning will help you find application bugs caused by unintentional state changes.** In the rare case that you intentionally want to change the state of another component as a result of rendering, you can wrap the `setState` call into `useEffect`.
 
-### Warnings for conflicting style rules {#warnings-for-conflicting-style-rules}
+### Warnings for conflicting style rules {/*warnings-for-conflicting-style-rules*/}
 
 When dynamically applying a `style` that contains longhand and shorthand versions of CSS properties, particular combinations of updates can cause inconsistent styling. For example:
 
@@ -40,7 +40,7 @@ You might expect this `<div>` to always have a red background, no matter the val
 
 **React now detects conflicting style rules and logs a warning.** To fix the issue, don't mix shorthand and longhand versions of the same CSS property in the `style` prop.
 
-### Warnings for some deprecated string refs {#warnings-for-some-deprecated-string-refs}
+### Warnings for some deprecated string refs {/*warnings-for-some-deprecated-string-refs*/}
 
 [String Refs is an old legacy API](/docs/refs-and-the-dom#legacy-api-string-refs) which is discouraged and is going to be deprecated in the future:
 
@@ -105,7 +105,7 @@ class ClassParent extends React.Component {
 >
 > If you use Create React App or have the "react" preset with Babel 7+, you already have this plugin installed by default.
 
-### Deprecating `React.createFactory` {#deprecating-reactcreatefactory}
+### Deprecating `React.createFactory` {/*deprecating-reactcreatefactory*/}
 
 [`React.createFactory`](/docs/react-api#createfactory) is a legacy helper for creating React elements. This release adds a deprecation warning to the method. It will be removed in a future major version.
 
@@ -117,15 +117,15 @@ let createFactory = (type) => React.createElement.bind(null, type);
 
 It does exactly the same thing.
 
-### Deprecating `ReactDOM.unstable_createPortal` in favor of `ReactDOM.createPortal` {#deprecating-reactdomunstable_createportal-in-favor-of-reactdomcreateportal}
+### Deprecating `ReactDOM.unstable_createPortal` in favor of `ReactDOM.createPortal` {/*deprecating-reactdomunstable_createportal-in-favor-of-reactdomcreateportal*/}
 
 When React 16 was released, `createPortal` became an officially supported API.
 
 However, we kept `unstable_createPortal` as a supported alias to keep the few libraries that adopted it working. We are now deprecating the unstable alias. Use `createPortal` directly instead of `unstable_createPortal`. It has exactly the same signature.
 
-## Other Improvements {#other-improvements}
+## Other Improvements {/*other-improvements*/}
 
-### Component stacks in hydration warnings {#component-stacks-in-hydration-warnings}
+### Component stacks in hydration warnings {/*component-stacks-in-hydration-warnings*/}
 
 React adds component stacks to its development warnings, enabling developers to isolate bugs and debug their programs. This release adds component stacks to a number of development warnings that didn't previously have them. As an example, consider this hydration warning from the previous versions:
 
@@ -137,7 +137,7 @@ While it's pointing out an error with the code, it's not clear where the error e
 
 This makes it clear where the problem is, and lets you locate and fix the bug faster.
 
-### Notable bugfixes {#notable-bugfixes}
+### Notable bugfixes {/*notable-bugfixes*/}
 
 This release contains a few other notable improvements:
 
@@ -151,9 +151,9 @@ This release contains a few other notable improvements:
 
 We’re thankful to all the contributors who helped surface and fix these and other issues. You can find the full changelog [below](#changelog).
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
-### React {#react}
+### React {/*react*/}
 
 React v16.13.0 is available on the npm registry.
 
@@ -184,14 +184,14 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 - Warn when a string ref is used in a manner that's not amenable to a future codemod ([@lunaruan](https://github.com/lunaruan) in [#17864](https://github.com/facebook/react/pull/17864))
 - Deprecate `React.createFactory()` ([@trueadm](https://github.com/trueadm) in [#17878](https://github.com/facebook/react/pull/17878))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 - Warn when changes in `style` may cause an unexpected collision ([@sophiebits](https://github.com/sophiebits) in [#14181](https://github.com/facebook/react/pull/14181), [#18002](https://github.com/facebook/react/pull/18002))
 - Warn when a function component is updated during another component's render phase ([@acdlite](<(https://github.com/acdlite)>) in [#17099](https://github.com/facebook/react/pull/17099))
@@ -202,7 +202,7 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 - Don't call `toString()` of `dangerouslySetInnerHTML` ([@sebmarkbage](https://github.com/sebmarkbage) in [#17773](https://github.com/facebook/react/pull/17773))
 - Show component stacks in more warnings ([@gaearon](https://github.com/gaearon) in [#17922](https://github.com/facebook/react/pull/17922), [#17586](https://github.com/facebook/react/pull/17586))
 
-### Concurrent Mode (Experimental) {#concurrent-mode-experimental}
+### Concurrent Mode (Experimental) {/*concurrent-mode-experimental*/}
 
 - Warn for problematic usages of `ReactDOM.createRoot()` ([@trueadm](https://github.com/trueadm) in [#17937](https://github.com/facebook/react/pull/17937))
 - Remove `ReactDOM.createRoot()` callback params and added warnings on usage ([@bvaughn](https://github.com/bvaughn) in [#17916](https://github.com/facebook/react/pull/17916))

--- a/beta/src/pages/blog/2020/08/10/react-v17-rc.md
+++ b/beta/src/pages/blog/2020/08/10/react-v17-rc.md
@@ -5,7 +5,7 @@ author: [gaearon,rachelnabors]
 
 Today, we are publishing the first Release Candidate for React 17. It has been two and a half years since [the previous major release of React](/blog/2017/09/26/react-v16.0.html), which is a long time even by our standards! In this blog post, we will describe the role of this major release, what changes you can expect in it, and how you can try this release.
 
-## No New Features {#no-new-features}
+## No New Features {/*no-new-features*/}
 
 The React 17 release is unusual because it doesn't add any new developer-facing features. Instead, this release is primarily focused on **making it easier to upgrade React itself**.
 
@@ -13,7 +13,7 @@ We're actively working on the new React features, but they're not a part of this
 
 In particular, **React 17 is a "stepping stone" release** that makes it safer to embed a tree managed by one version of React inside a tree managed by a different version of React.
 
-## Gradual Upgrades {#gradual-upgrades}
+## Gradual Upgrades {/*gradual-upgrades*/}
 
 For the past seven years, React upgrades have been "all-or-nothing". Either you stay on an old version, or you upgrade your whole app to a new version. There was no in-between.
 
@@ -29,7 +29,7 @@ This doesn't mean you *have to* do gradual upgrades. For most apps, upgrading al
 
 To enable gradual updates, we've needed to make some changes to the React event system. React 17 is a major release because these changes are potentially breaking. In practice, we've only had to change fewer than twenty components out of 100,000+ so **we expect that most apps can upgrade to React 17 without too much trouble**. [Tell us](https://github.com/facebook/react/issues) if you run into problems.
 
-### Demo of Gradual Upgrades {#demo-of-gradual-upgrades}
+### Demo of Gradual Upgrades {/*demo-of-gradual-upgrades*/}
 
 We've prepared an [example repository](https://github.com/reactjs/react-gradual-upgrade-demo/) demonstrating how to lazy-load an older version of React if necessary. This demo uses Create React App, but it should be possible to follow a similar approach with any other tool. We welcome demos using other tooling as pull requests.
 
@@ -37,7 +37,7 @@ We've prepared an [example repository](https://github.com/reactjs/react-gradual-
 >
 >We've **postponed other changes** until after React 17. The goal of this release is to enable gradual upgrades. If upgrading to React 17 were too difficult, it would defeat its purpose.
 
-## Changes to Event Delegation {#changes-to-event-delegation}
+## Changes to Event Delegation {/*changes-to-event-delegation*/}
 
 Technically, it has always been possible to nest apps developed with different versions of React. However, it was rather fragile because of how the React event system worked.
 
@@ -85,7 +85,7 @@ We've confirmed that [numerous](https://github.com/facebook/react/issues/7094) [
 >
 >You might be wondering whether this breaks [Portals](/docs/portals.html) outside of the root container. The answer is that React *also* listens to events on portal containers, so this is not an issue.
 
-#### Fixing Potential Issues {#fixing-potential-issues}
+#### Fixing Potential Issues {/*fixing-potential-issues*/}
 
 As with any breaking change, it is likely some code would need to be adjusted. At Facebook, we had to adjust about 10 modules in total (out of many thousands) to work with this change.
 
@@ -109,11 +109,11 @@ document.addEventListener('click', function() {
 
 Note how this strategy is more resilient overall -- for example, it will probably fix existing bugs in your code that happen when `e.stopPropagation()` is called outside of a React event handler. In other words, **event propagation in React 17 works closer to the regular DOM**.
 
-## Other Breaking Changes {#other-breaking-changes}
+## Other Breaking Changes {/*other-breaking-changes*/}
 
 We've kept the breaking changes in React 17 to the minimum. For example, it doesn't remove any of the methods that have been deprecated in the previous releases. However, it does include a few other breaking changes that have been relatively safe in our experience. In total, we've had to adjust fewer than 20 out of 100,000+ our components because of them.
 
-### Aligning with Browsers {#aligning-with-browsers}
+### Aligning with Browsers {/*aligning-with-browsers*/}
 
 We've made a couple of smaller changes related to the event system:
 
@@ -127,7 +127,7 @@ These changes align React closer with the browser behavior and improve interoper
 >
 >Although React 17 switched from `focus` to `focusin` *under the hood* for the `onFocus` event, note that this has **not** affected the bubbling behavior. In React, `onFocus` event has always bubbled, and it continues to do so in React 17 because generally it is a more useful default. See [this sandbox](https://codesandbox.io/s/strange-albattani-7tqr7?file=/src/App.js) for the different checks you can add for different particular use cases.
 
-### No Event Pooling {#no-event-pooling}
+### No Event Pooling {/*no-event-pooling*/}
 
 React 17 removes the "event pooling" optimization from React. It doesn't improve performance in modern browsers and confuses even experienced React users:
 
@@ -147,7 +147,7 @@ This is because React reused the event objects between different events for perf
 
 This is a behavior change, which is why we're marking it as breaking, but in practice we haven't seen it break anything at Facebook. (Maybe it even fixed a few bugs!) Note that `e.persist()` is still available on the React event object, but now it doesn't do anything.
 
-### Effect Cleanup Timing {#effect-cleanup-timing}
+### Effect Cleanup Timing {/*effect-cleanup-timing*/}
 
 We are making the timing of the `useEffect` cleanup function more consistent.
 
@@ -174,7 +174,7 @@ This mirrors how the effects themselves run more closely. In the  rare cases whe
 
 Additionally, React 17 executes the cleanup functions in the same order as the effects, according to their position in the tree. Previously, this order was occasionally different.
 
-#### Potential Issues {#potential-issues}
+#### Potential Issues {/*potential-issues*/}
 
 We've only seen a couple of components break with this change, although reusable libraries may need to test it more thoroughly. One example of problematic code may look like this:
 
@@ -201,7 +201,7 @@ useEffect(() => {
 
 We don't expect this to be a common problem because [our `eslint-plugin-react-hooks/exhaustive-deps` lint rule](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) (make sure you use it!) has always warned about this.
 
-### Consistent Errors for Returning Undefined {#consistent-errors-for-returning-undefined}
+### Consistent Errors for Returning Undefined {/*consistent-errors-for-returning-undefined*/}
 
 In React 16 and earlier, returning `undefined` has always been an error:
 
@@ -241,7 +241,7 @@ let Button = memo(() => {
 
 For the cases where you want to render nothing intentionally, return `null` instead.
 
-### Native Component Stacks {#native-component-stacks}
+### Native Component Stacks {/*native-component-stacks*/}
 
 When you throw an error in the browser, the browser gives you a stack trace with JavaScript function names and their locations. However, JavaScript stacks are often not enough to diagnose a problem because the React tree hierarchy can be just as important. You want to know not just that a `Button` threw an error, but *where in the React tree* that `Button` is.
 
@@ -255,7 +255,7 @@ If you're curious, you can read more details in [this pull request](https://gith
 
 The part that constitutes a breaking change is that for this to work, React re-executes parts of some of the React functions and React class constructors above in the stack after an error is captured. Since render functions and class constructors shouldn't have side effects (which is also important for server rendering), this should not pose any practical problems.
 
-### Removing Private Exports {#removing-private-exports}
+### Removing Private Exports {/*removing-private-exports*/}
 
 Finally, the last notable breaking change is that we've removed some React internals that were previously exposed to other projects. In particular, [React Native for Web](https://github.com/necolas/react-native-web) used to depend on some internals of the event system, but that dependency was fragile and used to break.
 
@@ -265,7 +265,7 @@ This means that the older versions of React Native for Web won't be compatible w
 
 Additionally, we've removed the `ReactTestUtils.SimulateNative` helper methods. They have never been documented, didn't do quite what their names implied, and didn't work with the changes we've made to the event system. If you want a convenient way to fire native browser events in tests, check out the [React Testing Library](https://testing-library.com/docs/dom-testing-library/api-events) instead.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 We encourage you to try React 17.0 Release Candidate soon and [raise any issues](https://github.com/facebook/react/issues) for the problems you might encounter in the migration. **Keep in mind that a release candidate is more likely to contain bugs than a stable release, so don't deploy it to production yet.**
 
@@ -290,15 +290,15 @@ We also provide UMD builds of React via a CDN:
 
 Refer to the documentation for [detailed installation instructions](/docs/installation.html).
 
-## Changelog {#changelog}
+## Changelog {/*changelog*/}
 
-### React {#react}
+### React {/*react*/}
 
 * Add `react/jsx-runtime` and `react/jsx-dev-runtime` for the [new JSX transform](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154). ([@lunaruan](https://github.com/lunaruan) in [#18299](https://github.com/facebook/react/pull/18299))
 * Build component stacks from native error frames. ([@sebmarkbage](https://github.com/sebmarkbage) in [#18561](https://github.com/facebook/react/pull/18561))
 * Allow to specify `displayName` on context for improved stacks. ([@eps1lon](https://github.com/eps1lon) in [#18224](https://github.com/facebook/react/pull/18224))
 
-### React DOM {#react-dom}
+### React DOM {/*react-dom*/}
 
 * Delegate events to roots instead of `document`. ([@trueadm](https://github.com/trueadm) in [#18195](https://github.com/facebook/react/pull/18195) and [others](https://github.com/facebook/react/pulls?q=is%3Apr+author%3Atrueadm+modern+event+is%3Amerged))
 * Clean up all effects before running any next effects. ([@bvaughn](https://github.com/bvaughn) in [#17947](https://github.com/facebook/react/pull/17947))
@@ -332,16 +332,16 @@ Refer to the documentation for [detailed installation instructions](/docs/instal
 * Use delegation for `onSubmit` and `onReset` events. ([@gaearon](https://github.com/gaearon) in [#19333](https://github.com/facebook/react/pull/19333))
 * Improve memory usage. ([@trueadm](https://github.com/trueadm) in [#18970](https://github.com/facebook/react/pull/18970))
 
-### React DOM Server {#react-dom-server}
+### React DOM Server {/*react-dom-server*/}
 
 * Make `useCallback` behavior consistent with `useMemo` for the server renderer. ([@alexmckenley](https://github.com/alexmckenley) in [#18783](https://github.com/facebook/react/pull/18783))
 * Fix state leaking when a function component throws. ([@pmaccart](https://github.com/pmaccart) in [#19212](https://github.com/facebook/react/pull/19212))
 
-### React Test Renderer {#react-test-renderer}
+### React Test Renderer {/*react-test-renderer*/}
 
 * Improve `findByType` error message. ([@henryqdineen](https://github.com/henryqdineen) in [#17439](https://github.com/facebook/react/pull/17439))
 
-### Concurrent Mode (Experimental) {#concurrent-mode-experimental}
+### Concurrent Mode (Experimental) {/*concurrent-mode-experimental*/}
 
 * Revamp the priority batching heuristics. ([@acdlite](https://github.com/acdlite) in [#18796](https://github.com/facebook/react/pull/18796))
 * Add the `unstable_` prefix before the experimental APIs. ([@acdlite](https://github.com/acdlite) in [#18825](https://github.com/facebook/react/pull/18825))

--- a/beta/src/pages/community/acknowledgements.md
+++ b/beta/src/pages/community/acknowledgements.md
@@ -2,7 +2,7 @@
 title: Acknowledgements
 ---
 
-## React {#react}
+## React {/*react*/}
 
 React was originally created by [Jordan Walke](https://github.com/jordwalke). Today, React has a [dedicated full-time team working on it](/community/team.html), as well as over a thousand [open source contributors](https://github.com/facebook/react/blob/main/AUTHORS). We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
 
@@ -45,21 +45,21 @@ This list is not exhaustive.
 
 We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino) and [Adam Wolff](https://github.com/wolffiex) for their guidance and support over the years. We are also thankful to all the volunteers who [translated React into other languages](https://translations.reactjs.org/).
 
-## React Docs {#react-docs}
+## React Docs {/*react-docs*/}
 
-### Documentation {#documentation}
+### Documentation {/*documentation*/}
 
 * [Rachel Nabors](https://twitter.com/RachelNabors): editing, writing, illustrating
 * [Dan Abramov](https://twitter.com/dan_abramov): writing, curriculum design
 * [Sylwia Vargas](https://twitter.com/SylwiaVargas): example code
 
-### Design {#design}
+### Design {/*design*/}
 
 * [Dan Lebowitz](https://twitter.com/lebo): design
 * [Razvan Gradinar](https://dribbble.com/GradinarRazvan): design
 * [Maggie Appleton](https://maggieappleton.com/): diagram system
 
-### Development {#development}
+### Development {/*development*/}
 
 * [Jared Palmer](https://twitter.com/jaredpalmer): site development
 * [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)): site development
@@ -68,7 +68,7 @@ We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino)
 
 We'd also like to thank countless alpha testers and community members who gave us feedback along the way.
 
-## Additional Thanks {#additional-thanks}
+## Additional Thanks {/*additional-thanks*/}
 
 Additionally, we're grateful to:
 

--- a/beta/src/pages/community/index.md
+++ b/beta/src/pages/community/index.md
@@ -8,11 +8,11 @@ React has a community of millions of developers. On this page we've listed some 
 
 </Intro>
 
-## Code of Conduct {#code-of-conduct}
+## Code of Conduct {/*code-of-conduct*/}
 
 Before participating in React's communities, [please read our Code of Conduct](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md). We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) and we expect that all community members adhere to the guidelines within.
 
-## Stack Overflow {#stack-overflow}
+## Stack Overflow {/*stack-overflow*/}
 
 Stack Overflow is a popular forum to ask code-level questions or if you're stuck with a specific error. Read through the [existing questions](https://stackoverflow.com/questions/tagged/reactjs) tagged with **reactjs** or [ask your own](https://stackoverflow.com/questions/ask?tags=reactjs)!
 
@@ -20,7 +20,7 @@ Stack Overflow is a popular forum to ask code-level questions or if you're stuck
 
 TODO: decide on the criteria for inclusion before uncommenting.
 
-## Popular Discussion Forums {#popular-discussion-forums}
+## Popular Discussion Forums {/*popular-discussion-forums*/}
 
 There are many online forums which are a great place for discussion about best practices and application architecture as well as the future of React. If you have an answerable code-level question, Stack Overflow is usually a better fit.
 
@@ -33,6 +33,6 @@ Each community consists of many thousands of React users.
 
 -->
 
-## News {#news}
+## News {/*news*/}
 
 For the latest news about React, [follow **@reactjs** on Twitter](https://twitter.com/reactjs) and the [official React blog](/blog/) on this website.

--- a/beta/src/pages/community/meet-the-team.md
+++ b/beta/src/pages/community/meet-the-team.md
@@ -7,13 +7,13 @@ React development is led by a small dedicated team working full time at Facebook
 
 </Intro>
 
-## React Core {#react-core}
+## React Core {/*react-core*/}
 
 The React Core team members work full time on the core component APIs, the engine that powers React DOM and React Native, React DevTools, and the React documentation website.
 
 Current members of the React team are listed in alphabetical order below.
 
-### Andrew Clark {#andrew-clark}
+### Andrew Clark {/*andrew-clark*/}
 
 ![Andrew Clark](../images/team/acdlite.jpg)
 
@@ -21,7 +21,7 @@ Current members of the React team are listed in alphabetical order below.
 
 Andrew got started with web development by making sites with WordPress, and eventually tricked himself into doing JavaScript. His favorite pastime is karaoke. Andrew is either a Disney villain or a Disney princess, depending on the day.
 
-### Brian Vaughn {#brian-vaughn}
+### Brian Vaughn {/*brian-vaughn*/}
 
 ![Brian Vaughn](../images/team/bvaughn.jpg)
 
@@ -29,7 +29,7 @@ Andrew got started with web development by making sites with WordPress, and even
 
 Brian studied art in college and did programming on the side to pay for his education. Eventually, he realized that he enjoys working on open source. Brian has one [one-person band](https://soundcloud.com/brianvaughn/) and two [two-person](https://soundcloud.com/pilotlessdrone) [bands](https://soundcloud.com/pinwurm). He also takes care of the cutest cat in the world.
 
-### Dan Abramov {#dan-abramov}
+### Dan Abramov {/*dan-abramov*/}
 
 ![Dan Abramov](../images/team/gaearon.jpg)
 
@@ -37,7 +37,7 @@ Brian studied art in college and did programming on the side to pay for his educ
 
 Dan got into programming after he accidentally discovered Visual Basic inside Microsoft PowerPoint. He has found his true calling in turning [Sebastian](#sebastian-markbåge)'s tweets into long-form blog posts. Dan occasionally wins at Fortnite by hiding in a bush until the game ends.
 
-### Luna Ruan {#luna-ruan}
+### Luna Ruan {/*luna-ruan*/}
 
 ![Luna](../images/team/lunaruan.jpg)
 
@@ -45,7 +45,7 @@ Dan got into programming after he accidentally discovered Visual Basic inside Mi
 
 Luna learned programming because she thought it meant creating video games. Instead, she ended up working on the Pinterest web app, and now on React itself. Luna doesn't want to make video games anymore, but she plans to do creative writing if she ever gets bored.
 
-### Marco Salazar {#marco-salazar}
+### Marco Salazar {/*marco-salazar*/}
 
 ![Marco](../images/team/salazarm.jpeg)
 
@@ -53,7 +53,7 @@ Luna learned programming because she thought it meant creating video games. Inst
 
 Marco's first programming language was Assembly because he could use it to hack video games. Now online games are much more secure so he settles for playing fairly (mostly). In his spare time he plays games on his treadmill desk and makes art that he never finishes. Hopefully his PRs don't have the same fate.
 
-### Rachel Nabors {#rachel-nabors}
+### Rachel Nabors {/*rachel-nabors*/}
 
 ![Rachel](../images/team/rnabors.jpg)
 
@@ -61,7 +61,7 @@ Marco's first programming language was Assembly because he could use it to hack 
 
 Rachel wrote a [book about UI animation](https://abookapart.com/products/animation-at-work) once and worked with MDN and the W3C on the web animations API. Now she is busy with education materials and community engineering on the React team. Secretly, she is an award-winning cartoonist for teenage girls. Catch her making fancy tea with lukewarm water in the microkitchen.
 
-### Rick Hanlon {#rick-hanlon}
+### Rick Hanlon {/*rick-hanlon*/}
 
 ![Ricky](../images/team/rickhanlonii.jpg)
 
@@ -69,7 +69,7 @@ Rachel wrote a [book about UI animation](https://abookapart.com/products/animati
 
 Ricky majored in theoretical math and somehow found himself on the React Native team for a couple years before joining the React team. When he's not programming you can find him snowboarding, biking, climbing, golfing, or closing GitHub issues that do not match the issue template.
 
-### Sebastian Markbåge {#sebastian-markbåge}
+### Sebastian Markbåge {#sebastian-markbåge} {/*sebastian-markbåge-sebastian-markbåge*/} {/*sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge*/} {/*sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge*/}
 
 ![Sebastian](../images/team/sebmarkbage.jpg)
 
@@ -77,7 +77,7 @@ Ricky majored in theoretical math and somehow found himself on the React Native 
 
 Sebastian majored in psychology. He's usually quiet. Even when he says something, it often doesn't make sense to the rest of us until a few months later. The correct way to pronounce his surname is "mark-boa-geh" but he settled for "mark-beige" out of pragmatism -- and that's how he approaches React.
 
-### Seth Webster {#seth-webster}
+### Seth Webster {/*seth-webster*/}
 
 ![Seth](../images/team/sethwebster.jpg)
 
@@ -85,7 +85,7 @@ Sebastian majored in psychology. He's usually quiet. Even when he says something
 
 Seth started programming as a kid growing up in Tucson, AZ. After school, he was bitten by the music bug and was a touring musician for about 10 years before returning to *work*, starting with Intuit. In his spare time, he loves [taking pictures](https://www.sethwebster.com) and flying for animal rescues in the northeastern United States.
 
-## Past contributors {#past-contributors}
+## Past contributors {/*past-contributors*/}
 
 You can find the past team members and other people who significantly contributed to React over the years on the [acknowledgements](/community/acknowledgements) page.
 

--- a/beta/src/pages/community/meet-the-team.md
+++ b/beta/src/pages/community/meet-the-team.md
@@ -69,7 +69,7 @@ Rachel wrote a [book about UI animation](https://abookapart.com/products/animati
 
 Ricky majored in theoretical math and somehow found himself on the React Native team for a couple years before joining the React team. When he's not programming you can find him snowboarding, biking, climbing, golfing, or closing GitHub issues that do not match the issue template.
 
-### Sebastian Markbåge {#sebastian-markbåge} {/*sebastian-markbåge-sebastian-markbåge*/} {/*sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge*/} {/*sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge-sebastian-markbåge*/}
+### Sebastian Markbåge {/*sebastian-markbåge*/}
 
 ![Sebastian](../images/team/sebmarkbage.jpg)
 
@@ -88,4 +88,3 @@ Seth started programming as a kid growing up in Tucson, AZ. After school, he was
 ## Past contributors {/*past-contributors*/}
 
 You can find the past team members and other people who significantly contributed to React over the years on the [acknowledgements](/community/acknowledgements) page.
-

--- a/beta/src/pages/index.md
+++ b/beta/src/pages/index.md
@@ -6,7 +6,7 @@ permalink: index.html
 
 <HomepageHero />
 
-## What is this site? {#what-is-this-site}
+## What is this site? {/*what-is-this-site*/}
 
 We are rewriting the React documentation with a few differences:
 
@@ -16,21 +16,21 @@ We are rewriting the React documentation with a few differences:
 
 This beta website contains the current draft of the new docs.
 
-## This is a work in progress! {#this-is-a-work-in-progress}
+## This is a work in progress! {/*this-is-a-work-in-progress*/}
 
 This is a **beta website**. There will be bugs, performance issues, and missing content.
 
-## How much content is ready? {#how-much-content-is-ready}
+## How much content is ready? {/*how-much-content-is-ready*/}
 
 * [Learn React](/learn): ~70% finished.
 * [API Reference](/reference): ~5% finished.
 
 You can track our progress [on GitHub](https://github.com/reactjs/reactjs.org/issues/3308).
 
-## How can I provide feedback? {#how-can-i-provide-feedback}
+## How can I provide feedback? {/*how-can-i-provide-feedback*/}
 
 Please use [this GitHub issue](https://github.com/reactjs/reactjs.org/issues/3308) or [this anonymous form](https://www.surveymonkey.co.uk/r/Y6GH986) for high-level feedback. Additionally, each page has a Feedback button in the corner. If you spot something that doesn't make sense, please tell us!
 
-## Will this site replace the main site? {#will-this-site-replace-the-main-site}
+## Will this site replace the main site? {/*will-this-site-replace-the-main-site*/}
 
 We aim to switch this site to be the main one once we reach content parity with the [existing React documentation](https://reactjs.org/). The old React website will be archived at a subdomain so you'll still be able to access it. Old content links will redirect to the archived subdomain, which will have a notice about outdated content.

--- a/beta/src/pages/learn/add-react-to-a-website.md
+++ b/beta/src/pages/learn/add-react-to-a-website.md
@@ -8,11 +8,11 @@ React has been designed from the start for gradual adoption, and you can use as 
 
 </Intro>
 
-## Add React in one minute {#add-react-in-one-minute}
+## Add React in one minute {/*add-react-in-one-minute*/}
 
 You can add a React component to an existing HTML page in under a minute. Try this out with your own website or [an empty HTML file](https://gist.github.com/rachelnabors/7b33305bf33776354797a2e3c1445186/archive/859eac2f7079c9e1f0a6eb818a9684a464064d80.zip)—all you need is an internet connection and a text editor like Notepad (or VSCode—check out our guide on [how to set yours up](/learn/editor-setup/))!
 
-### Step 1: Add an element to the HTML {#step-1-add-an-element-to-the-html}
+### Step 1: Add an element to the HTML {/*step-1-add-an-element-to-the-html*/}
 
 In the HTML page you want to edit, add an HTML element like an empty `<div>` tag with a unique `id` to mark the spot where you want to display something with React.
 
@@ -26,7 +26,7 @@ You can place a "container" element like this `<div>` anywhere inside the `<body
 <!-- ... existing HTML ... -->
 ```
 
-### Step 2: Add the Script Tags {#step-2-add-the-script-tags}
+### Step 2: Add the Script Tags {/*step-2-add-the-script-tags*/}
 
 In the HTML page, right before the closing `</body>` tag, add three `<script>` tags for the following files:
 
@@ -48,7 +48,7 @@ When deploying, replace "development.js" with "production.min.js".
 </body>
 ```
 
-### Step 3: Create a React component {#step-3-create-a-react-component}
+### Step 3: Create a React component {/*step-3-create-a-react-component*/}
 
 Create a file called **like_button.js** next to your HTML page, add this code snippet, and save the file. This code defines a React component called `LikeButton`. [You can learn more about making components in our guides.](/learn/your-first-component)
 
@@ -72,7 +72,7 @@ function LikeButton() {
 }
 ```
 
-### Step 4: Add your React Component to the page {#step-4-add-your-react-component-to-the-page}
+### Step 4: Add your React Component to the page {/*step-4-add-your-react-component-to-the-page*/}
 
 Lastly, add two lines to the bottom of **like_button.js**. These two lines of code find the `<div>` you added to your HTML in the first step and then display the "Like" button React component inside of it.
 
@@ -86,7 +86,7 @@ ReactDOM.render(React.createElement(LikeButton), domContainer);
 - [View the full example source code](https://gist.github.com/rachelnabors/c64b3aeace8a191cf5ea6fb5202e66c9)
 - [Download the full example (2KB zipped)](https://gist.github.com/rachelnabors/c64b3aeace8a191cf5ea6fb5202e66c9/archive/7b41a88cb1027c9b5d8c6aff5212ecd3d0493504.zip)
 
-#### You can reuse components! {#you-can-reuse-components}
+#### You can reuse components! {/*you-can-reuse-components*/}
 
 You might want to display a React component in multiple places on the same HTML page. This is most useful while React-powered parts of the page are isolated from each other. You can do this by calling `ReactDOM.render()` multiple times with multiple container elements.
 
@@ -107,7 +107,7 @@ ReactDOM.render(
 
 Check out [an example that displays the "Like" button three times and passes some data to it](https://gist.github.com/rachelnabors/c0ea05cc33fbe75ad9bbf78e9044d7f8)!
 
-### Step 5: Minify JavaScript for production {#step-5-minify-javascript-for-production}
+### Step 5: Minify JavaScript for production {/*step-5-minify-javascript-for-production*/}
 
 Unminified JavaScript can significantly slow down page load times for your users. Before deploying your website to production, it's a good idea to minify its scripts.
 
@@ -119,7 +119,7 @@ Unminified JavaScript can significantly slow down page load times for your users
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js" crossorigin></script>
 ```
 
-## Try React with JSX {#try-react-with-jsx}
+## Try React with JSX {/*try-react-with-jsx*/}
 
 The examples above rely on features that are natively supported by browsers. This is why **like_button.js** uses a JavaScript function call to tell React what to display:
 
@@ -137,7 +137,7 @@ These two code snippets are equivalent. JSX is popular syntax for describing mar
 
 > You can play with transforming HTML markup into JSX using [this online converter](https://babeljs.io/en/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=DwIwrgLhD2B2AEcDCAbAlgYwNYF4DeAFAJTw4B88EAFmgM4B0tAphAMoQCGETBe86WJgBMAXJQBOYJvAC-RGWQBQ8FfAAyaQYuAB6cFDhkgA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=7.4.3).
 
-### Try JSX {#try-jsx}
+### Try JSX {/*try-jsx*/}
 
 The quickest way to try JSX in your project is to add the Babel compiler to your page's `<head>` along with React and ReactDOM like so:
 
@@ -192,7 +192,7 @@ Here is [an example HTML file with JSX](https://raw.githubusercontent.com/reactj
 
 This approach is fine for learning and creating simple demos. However, it makes your website slow and **isn't suitable for production**. When you're ready to move forward, remove this new `<script>` tag and the `type="text/babel"` attributes you've added. Instead, in the next section you will set up a JSX preprocessor to convert all your `<script>` tags automatically.
 
-### Add JSX to a project {#add-jsx-to-a-project}
+### Add JSX to a project {/*add-jsx-to-a-project*/}
 
 Adding JSX to a project doesn't require complicated tools like a [bundler](/learn/start-a-new-react-project#custom-toolchains) or a development server. Adding a JSX preprocessor is a lot like adding a CSS preprocessor.
 
@@ -205,7 +205,7 @@ You only need npm to install the JSX preprocessor. You won't need it for anythin
 
 Congratulations! You just added a **production-ready JSX setup** to your project.
 
-### Run the JSX Preprocessor {#run-the-jsx-preprocessor}
+### Run the JSX Preprocessor {/*run-the-jsx-preprocessor*/}
 
 You can preprocess JSX so that every time you save a file with JSX in it, the transform will be re-run, converting the JSX file into a new, plain JavaScript file.
 

--- a/beta/src/pages/learn/adding-interactivity.md
+++ b/beta/src/pages/learn/adding-interactivity.md
@@ -20,7 +20,7 @@ Some things on the screen update in response to user input. For example, clickin
 
 </YouWillLearn>
 
-## Responding to events {#responding-to-events}
+## Responding to events {/*responding-to-events*/}
 
 React lets you add event handlers to your JSX. Event handlers are your own functions that will be triggered in response to user interactions like clicking, hovering, focusing on form inputs, and so on.
 
@@ -72,7 +72,7 @@ Read **[Responding to Events](/learn/responding-to-events)** to learn how to add
 
 </LearnMore>
 
-## State: a component's memory {#state-a-components-memory}
+## State: a component's memory {/*state-a-components-memory*/}
 
 Components often need to change what's on the screen as a result of an interaction. Typing into the form should update the input field, clicking "next" on an image carousel should change which image is displayed, clicking "buy" puts a product in the shopping cart. Components need to "remember" things: the current input value, the current image, the shopping cart. In React, this kind of component-specific memory is called state.
 
@@ -228,7 +228,7 @@ Read **[State: A Component's Memory](/learn/state-a-components-memory)** to lear
 
 </LearnMore>
 
-## Render and commit {#render-and-commit}
+## Render and commit {/*render-and-commit*/}
 
 Before your components are displayed on the screen, they must be rendered by React. Understanding the steps in this process will help you think about how your code executes and explain its behavior.
 
@@ -250,7 +250,7 @@ Read **[Render and Commit](/learn/render-and-commit)** to learn the lifecycle of
 
 </LearnMore>
 
-## State as a snapshot {#state-as-a-snapshot}
+## State as a snapshot {/*state-as-a-snapshot*/}
 
 Unlike regular JavaScript variables, React state behaves more like a snapshot. Setting it does not change the state variable you already have, but instead triggers a re-render. This can be surprising at first!
 
@@ -313,7 +313,7 @@ Read **[State as a Snapshot](/learn/state-as-a-snapshot)** to learn why state ap
 
 </LearnMore>
 
-## Queueing a series of state changes {#queueing-a-series-of-state-changes}
+## Queueing a series of state changes {/*queueing-a-series-of-state-changes*/}
 
 This component is buggy: clicking "+3" increments the score only once.
 
@@ -401,7 +401,7 @@ Read **[Queueing a Series of State Changes](/learn/queueing-a-series-of-state-ch
 
 </LearnMore>
 
-## Updating objects in state {#updating-objects-in-state}
+## Updating objects in state {/*updating-objects-in-state*/}
 
 State can hold any kind of JavaScript value, including objects. But you shouldn't change objects and arrays that you hold in the React state directly. Instead, when you want to update an object and array, you need to create a new one (or make a copy of an existing one), and then update the state to use that copy.
 
@@ -632,7 +632,7 @@ Read **[Updating Objects in State](/learn/updating-objects-in-state)** to learn 
 
 </LearnMore>
 
-## Updating arrays in state {#updating-arrays-in-state}
+## Updating arrays in state {/*updating-arrays-in-state*/}
 
 Arrays are another type of mutable JavaScript objects you can store in state and should treat as read-only. Just like with objects, when you want to update an array stored in state, you need to create a new one (or make a copy of an existing one), and then set state to use the new array:
 
@@ -792,7 +792,7 @@ Read **[Updating Arrays in State](/learn/updating-arrays-in-state)** to learn ho
 
 </LearnMore>
 
-## What's next? {#whats-next}
+## What's next? {/*whats-next*/}
 
 Head over to [Responding to Events](/learn/responding-to-events) to start reading this chapter page by page!
 

--- a/beta/src/pages/learn/choosing-the-state-structure.md
+++ b/beta/src/pages/learn/choosing-the-state-structure.md
@@ -16,7 +16,7 @@ Structuring state well can make a difference between a component that is pleasan
 
 </YouWillLearn>
 
-## Principles for structuring state {#principles-for-structuring-state}
+## Principles for structuring state {/*principles-for-structuring-state*/}
 
 When you write a component that holds some state, you'll have to make choices about how many state variables to use and what the shape of their data should be. While it's possible to write correct programs even with a suboptimal state structure, there are a few principles that can guide you to make better choices:
 
@@ -30,7 +30,7 @@ The goal behind these principles is to *make state easy to update without introd
 
 Now let's see how these principles apply in action.
 
-## Group related state {#group-related-state}
+## Group related state {/*group-related-state*/}
 
 You might sometimes be unsure between using a single or multiple state variables.
 
@@ -100,7 +100,7 @@ If your state variable is an object, remember that [you can't update only one fi
 
 </Gotcha>
 
-## Avoid contradictions in state {#avoid-contradictions-in-state}
+## Avoid contradictions in state {/*avoid-contradictions-in-state*/}
 
 Here is a hotel feedback form with `isSending` and `isSent` state variables:
 
@@ -222,7 +222,7 @@ const isSent = status === 'sent';
 
 But they're not state variables, so you don't need to worry about them getting out of sync with each other.
 
-## Avoid redundant state {#avoid-redundant-state}
+## Avoid redundant state {/*avoid-redundant-state*/}
 
 If you can calculate some information from the component's props or its existing state variables during rendering, you **should not** put that information into that component's state.
 
@@ -372,7 +372,7 @@ function Message({ initialColor }) {
 
 </DeepDive>
 
-## Avoid duplication in state {#avoid-duplication-in-state}
+## Avoid duplication in state {/*avoid-duplication-in-state*/}
 
 This menu list component lets you choose a single travel snack out of several:
 
@@ -567,7 +567,7 @@ The duplication is gone, and you only keep the essential state!
 
 Now if you edit the *selected* item, the message below will update immediately. This is because `setItems` triggers a re-render, and `items.find(...)` would find the item with the updated title. You didn't need to hold *the selected item* in state, because only the *selected ID* is essential. The rest could be calculated during render.
 
-## Avoid deeply nested state {#avoid-deeply-nested-state}
+## Avoid deeply nested state {/*avoid-deeply-nested-state*/}
 
 Imagine a travel plan consisting of planets, continents, and countries. You might be tempted to structure its state using nested objects and arrays, like in this example:
 
@@ -1853,7 +1853,7 @@ Sometimes, you can also reduce state nesting by moving some of the nested state 
 
 <Challenges>
 
-### Fix a component that's not updating {#fix-a-component-thats-not-updating}
+### Fix a component that's not updating {/*fix-a-component-thats-not-updating*/}
 
 This `Clock` component receives two props: `color` and `time`. When you select a different color in the select box, the `Clock` component receives a different `color` prop from its parent component. However, for some reason, the displayed color doesn't update. Why? Fix the problem.
 
@@ -2016,7 +2016,7 @@ export default function App() {
 
 </Solution>
 
-### Fix a broken packing list {#fix-a-broken-packing-list}
+### Fix a broken packing list {/*fix-a-broken-packing-list*/}
 
 This packing list has a footer that shows how many items are packed, and how many items there are overall. It seems to work at first, but it is buggy. For example, if you mark a place as completed and then delete it, the counter will not be updated correctly. Fix the counter so that it's always correct.
 
@@ -2302,7 +2302,7 @@ Notice how the event handlers are only concerned with calling `setItems` after t
 
 </Solution>
 
-### Fix the disappearing selection {#fix-the-disappearing-selection}
+### Fix the disappearing selection {/*fix-the-disappearing-selection*/}
 
 There is a list of `letters` in state. When you hover or focus a particular letter, it gets highlighted. The currently highlighted letter is stored in the `highlightedLetter` state variable. You can "star" and "unstar" invidual letters, which updates the `letters` array in state.
 
@@ -2522,7 +2522,7 @@ li { border-radius: 5px; }
 
 </Solution>
 
-### Implement multiple selection {#implement-multiple-selection}
+### Implement multiple selection {/*implement-multiple-selection*/}
 
 In this example, each `Letter` has an `isSelected` prop and an `onToggle` handler that marks it as selected. This works, but the state is stored as a `selectedId` (either `null` or an ID), so only one letter can get selected at any given time.
 

--- a/beta/src/pages/learn/conditional-rendering.md
+++ b/beta/src/pages/learn/conditional-rendering.md
@@ -16,7 +16,7 @@ Your components will often need to display different things depending on differe
 
 </YouWillLearn>
 
-## Conditionally returning JSX {#conditionally-returning-jsx}
+## Conditionally returning JSX {/*conditionally-returning-jsx*/}
 
 Let’s say you have a `PackingList` component rendering several `Item`s, which can be marked as packed or not:
 
@@ -104,7 +104,7 @@ Try editing what gets returned in either case, and see how the result changes!
 
 Notice how you're creating branching logic with JavaScript's `if` and `return` statements. In React, control flow (like conditions) is handled by JavaScript.
 
-### Conditionally returning nothing with `null` {#conditionally-returning-nothing-with-null}
+### Conditionally returning nothing with `null` {/*conditionally-returning-nothing-with-null*/}
 
 In some situations, you won't want to render anything at all. For example, say you don't want to show packed items at all. A component must return something. In this case, you can return `null`:
 
@@ -154,7 +154,7 @@ export default function PackingList() {
 
 In practice, returning `null` from a component isn't common because it might surprise a developer trying to render it. More often, you would conditionally include or exclude the component in the parent component's JSX. Here's how to do that!
 
-## Conditionally including JSX {#conditionally-including-jsx}
+## Conditionally including JSX {/*conditionally-including-jsx*/}
 
 In the previous example, you controlled which (if any!) JSX tree would be returned by the component. You may already have noticed some duplication in the render output:
 
@@ -179,7 +179,7 @@ return <li className="item">{name}</li>;
 
 While this duplication isn't harmful, it could make your code harder to maintain. What if you want to change the `className`? You'd have to do it in two places in your code! In such a situation, you could conditionally include a little JSX to make your code more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-### Conditional (ternary) operator (`? :`) {#conditional-ternary-operator--}
+### Conditional (ternary) operator (`? :`) {/*conditional-ternary-operator--*/}
 
 JavaScript has a compact syntax for writing a conditional expression -- the [conditional operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) or "ternary operator."
 
@@ -256,7 +256,7 @@ export default function PackingList() {
 
 This style works well for simple conditions, but use it in moderation. If your components get messy with too much nested conditional markup, consider extracting child components to clean things up. In React, markup is a part of your code, so you can use tools like variables and functions to tidy up complex expressions.
 
-### Logical AND operator (`&&`) {#logical-and-operator-}
+### Logical AND operator (`&&`) {/*logical-and-operator-*/}
 
 Another common shortcut you'll encounter is the [JavaScript logical AND (`&&`) operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND#:~:text=The%20logical%20AND%20(%20%26%26%20)%20operator,it%20returns%20a%20Boolean%20value.). Inside React components, it often comes up when you want to render some JSX when the condition is true, **or render nothing otherwise.** With `&&`, you could conditionally render the checkmark only if `isPacked` is `true`:
 
@@ -323,7 +323,7 @@ To fix it, make the left side a boolean: `messageCount > 0 && <p>New messages</p
 
 </Gotcha>
 
-### Conditionally assigning JSX to a variable {#conditionally-assigning-jsx-to-a-variable}
+### Conditionally assigning JSX to a variable {/*conditionally-assigning-jsx-to-a-variable*/}
 
 When the shortcuts get in the way of writing plain code, try using an `if` statement and a variable. You can reassign variables defined with [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let), so start by providing the default content you want to display, the name:
 
@@ -452,7 +452,7 @@ If you're not familiar with JavaScript, this variety of styles might seem overwh
 
 <Challenges>
 
-### Show an icon for incomplete items with `? :` {#show-an-icon-for-incomplete-items-with--}
+### Show an icon for incomplete items with `? :` {/*show-an-icon-for-incomplete-items-with--*/}
 
 Use the conditional operator (`cond ? a : b`) to render a ❌ if `isPacked` isn’t `true`.
 
@@ -532,7 +532,7 @@ export default function PackingList() {
 
 </Solution>
 
-### Show the item importance with `&&` {#show-the-item-importance-with-}
+### Show the item importance with `&&` {/*show-the-item-importance-with-*/}
 
 In this example, each `Item` receives a numerical `importance` prop. Use the `&&` operator to render "_(Importance: X)_" in italics, but only for items that have non-zero difficulty. Your item list should end up looking like this:
 
@@ -628,7 +628,7 @@ In this solution, two separate conditions are used to insert a space between the
 
 </Solution>
 
-### Refactor a series of `? :` to `if` and variables {#refactor-a-series-of---to-if-and-variables}
+### Refactor a series of `? :` to `if` and variables {/*refactor-a-series-of---to-if-and-variables*/}
 
 This `Drink` component uses a series of `? :` conditions to show different information depending on whether the `name` prop is `"tea"` or `"coffee"`. The problem is that the information about each drink is spread across multiple conditions. Refactor this code to use a single `if` statement instead of three `? :` conditions.
 

--- a/beta/src/pages/learn/describing-the-ui.md
+++ b/beta/src/pages/learn/describing-the-ui.md
@@ -21,7 +21,7 @@ React is a JavaScript library for rendering user interfaces (UI). UI is built fr
 
 </YouWillLearn>
 
-## Your first component {#your-first-component}
+## Your first component {/*your-first-component*/}
 
 React applications are built from isolated pieces of UI called "components". A React component is a JavaScript function that you can sprinkle with markup. Components can be as small as a button, or as large as an entire page. Here is a `Gallery` component rendering three `Profile` components:
 
@@ -61,7 +61,7 @@ Read **[Your First Component](/learn/your-first-component)** to learn how to dec
 
 </LearnMore>
 
-## Importing and exporting components {#importing-and-exporting-components}
+## Importing and exporting components {/*importing-and-exporting-components*/}
 
 You can declare many components in one file, but large files can get difficult to navigate. To solve this, you can *export* a component into its own file, and then *import* that component from another file:
 
@@ -116,7 +116,7 @@ Read **[Importing and Exporting Components](/learn/importing-and-exporting-compo
 
 </LearnMore>
 
-## Writing markup with JSX {#writing-markup-with-jsx}
+## Writing markup with JSX {/*writing-markup-with-jsx*/}
 
 Each React component is a JavaScript function that may contain some markup that React renders into the browser. React components use a syntax extension called JSX to represent that markup. JSX looks a lot like HTML, but it is a bit stricter and can display dynamic information.
 
@@ -185,7 +185,7 @@ Read **[Writing Markup with JSX](/learn/writing-markup-with-jsx)** to learn how 
 
 </LearnMore>
 
-## JavaScript in JSX with curly braces {#javascript-in-jsx-with-curly-braces}
+## JavaScript in JSX with curly braces {/*javascript-in-jsx-with-curly-braces*/}
 
 JSX lets you write HTML-like markup inside a JavaScript file, keeping rendering logic and content in the same place. Sometimes you will want to add a little JavaScript logic or reference a dynamic property inside that markup. In this situation, you can use curly braces in your JSX to "open a window" to JavaScript:
 
@@ -233,7 +233,7 @@ Read **[JavaScript in JSX with Curly Braces](/learn/javascript-in-jsx-with-curly
 
 </LearnMore>
 
-## Passing props to a component {#passing-props-to-a-component}
+## Passing props to a component {/*passing-props-to-a-component*/}
 
 React components use *props* to communicate with each other. Every parent component can pass some information to its child components by giving them props. Props might remind you of HTML attributes, but you can pass any JavaScript value through them, including objects, arrays, functions, and even JSX!
 
@@ -314,7 +314,7 @@ Read **[Passing Props to a Component](/learn/passing-props-to-a-component)** to 
 
 </LearnMore>
 
-## Conditional rendering {#conditional-rendering}
+## Conditional rendering {/*conditional-rendering*/}
 
 Your components will often need to display different things depending on different conditions. In React, you can conditionally render JSX using JavaScript syntax like `if` statements, `&&`, and `? :` operators.
 
@@ -362,7 +362,7 @@ Read **[Conditional Rendering](/learn/conditional-rendering)** to learn the diff
 
 </LearnMore>
 
-## Rendering lists {#rendering-lists}
+## Rendering lists {/*rendering-lists*/}
 
 You will often want to display multiple similar components from a collection of data. You can use JavaScript's `filter()` and `map()` with React to filter and transform your array of data into an array of components.
 
@@ -462,7 +462,7 @@ Read **[Rendering Lists](/learn/rendering-lists)** to learn how to render a list
 
 </LearnMore>
 
-## Keeping components pure {#keeping-components-pure}
+## Keeping components pure {/*keeping-components-pure*/}
 
 Some JavaScript functions are “pure.” A pure function:
 
@@ -523,7 +523,7 @@ Read **[Keeping Components Pure](/learn/keeping-components-pure)** to learn how 
 
 </LearnMore>
 
-## What's next? {#whats-next}
+## What's next? {/*whats-next*/}
 
 Head over to [Your First Component](/learn/your-first-component) to start reading this chapter page by page!
 

--- a/beta/src/pages/learn/editor-setup.md
+++ b/beta/src/pages/learn/editor-setup.md
@@ -8,7 +8,7 @@ A properly configured editor can make code clearer to read and faster to write. 
 
 </Intro>
 
-## Your editor {#your-editor}
+## Your editor {/*your-editor*/}
 
 [VS Code](https://code.visualstudio.com/) is one of the most popular editors in use today. It has a large marketplace of extensions and integrates well with popular services like GitHub. Most of the features listed below can be added to VS Code as extensions as well, making it highly configurable!
 
@@ -18,18 +18,18 @@ Other popular text editors used in the React community include:
 * [Sublime Text](https://www.sublimetext.com/)—has support for JSX and TypeScript, syntax highlighting and autocomplete built in.
 * [Vim](https://www.vim.org/)—a highly configurable text editor built to make creating and changing any kind of text very efficient. It is included as "vi" with most UNIX systems and with Apple OS X.
 
-## Recommended text editor features {#recommended-text-editor-features}
+## Recommended text editor features {/*recommended-text-editor-features*/}
 
 Some editors come with these features built in, but others might require adding an extension. Check to see what support your editor of choice provides to be sure!
 
-### Linting {#linting}
+### Linting {/*linting*/}
 
 Code linters find problems in your code as you write, helping you fix them early. [ESLint](https://eslint.org/) is a popular, open source linter for JavaScript. 
 
 * [Install ESLint with the recommended configuration for React](https://www.npmjs.com/package/eslint-config-react-app) (be sure you have [Node installed!](https://nodejs.org/en/download/current/))
 * [Integrate ESLint in VSCode with the official extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 
-### Formatting {#formatting}
+### Formatting {/*formatting*/}
 
 The last thing you want to do when sharing your code with another contributor is get into an discussion about [tabs vs spaces](https://www.google.com/search?q=tabs+vs+spaces)! Fortunately, [Prettier](https://prettier.io/) will clean up your code by reformatting it to conform to preset, configurable rules. Run Prettier, and all your tabs will be converted to spaces—and your indentation, quotes, etc will also all be changed to conform to the configuration. In the ideal setup, Prettier will run when you save your file, quickly making these edits for you.
 
@@ -40,7 +40,7 @@ You can install the [Prettier extension in VSCode](https://marketplace.visualstu
 3. Paste in `ext install esbenp.prettier-vscode`
 4. Press enter
 
-#### Formatting on save {#formatting-on-save}
+#### Formatting on save {/*formatting-on-save*/}
 
 Ideally, you should format your code on every save. VS Code has settings for this!
 

--- a/beta/src/pages/learn/extracting-state-logic-into-a-reducer.md
+++ b/beta/src/pages/learn/extracting-state-logic-into-a-reducer.md
@@ -17,7 +17,7 @@ Components with many state updates spread across many event handlers can get ove
 
 </YouWillLearn>
 
-## Consolidate state logic with a reducer {#consolidate-state-logic-with-a-reducer}
+## Consolidate state logic with a reducer {/*consolidate-state-logic-with-a-reducer*/}
 
 As your components grow in complexity, it can get harder to see all the different ways that a component's state gets updated at a glance. For example, the `TaskBoard` component below holds an array of `tasks` in state and uses three different event handlers to add, remove, and edit tasks:
 
@@ -188,7 +188,7 @@ Reducers are a different way to handle state. You can migrate from `useState` to
 2. **Write** a reducer function.
 3. **Use** the reducer from your component.
 
-### Step 1: Move from setting state to dispatching actions {#step-1-move-from-setting-state-to-dispatching-actions}
+### Step 1: Move from setting state to dispatching actions {/*step-1-move-from-setting-state-to-dispatching-actions*/}
 
 Your event handlers currently specify *what to do* by setting state:
 
@@ -280,7 +280,7 @@ dispatch({
 
 </Convention>
 
-### Step 2: Write a reducer function {#step-2-write-a-reducer-function}
+### Step 2: Write a reducer function {/*step-2-write-a-reducer-function*/}
 
 A reducer function is where you will put your state logic. It takes two arguments, the current state and the action object, and it returns the next state:
 
@@ -451,7 +451,7 @@ You probably won't need to do this yourself, but this is similar to what React d
 
 </DeepDive>
 
-### Step 3: Use the reducer from your component {#step-3-use-the-reducer-from-your-component}
+### Step 3: Use the reducer from your component {/*step-3-use-the-reducer-from-your-component*/}
 
 Finally, you need to hook up the `tasksReducer` to your component. Make sure to import the `useReducer` Hook from React:
 
@@ -869,7 +869,7 @@ ul, li { margin: 0; padding: 0; }
 
 Component logic can be easier to read when you separate concerns like this. Now the event handlers only specify *what happened* by dispatching actions, and the reducer function determines *how the state updates* in response to them.
 
-## Comparing `useState` and `useReducer` {#comparing-usestate-and-usereducer}
+## Comparing `useState` and `useReducer` {/*comparing-usestate-and-usereducer*/}
 
 Reducers are not without downsides! Here's a few ways you can compare them:
 
@@ -881,14 +881,14 @@ Reducers are not without downsides! Here's a few ways you can compare them:
 
 We recommend using a reducer if you often encounter bugs due to incorrect state updates in some component, and want to introduce more structure to its code. You don't have to use reducers for everything: feel free to mix and match! You can even `useState` and `useReducer` in the same component.
 
-## Writing reducers well {#writing-reducers-well}
+## Writing reducers well {/*writing-reducers-well*/}
 
 Keep these two tips in mind when writing reducers:
 
 * **Reducers must be pure.** Similar to [state updater functions](/learn/queueing-a-series-of-state-updates), reducers run during rendering! (Actions are queued until the next render.) This means that reducers [must be pure](/learn/keeping-components-pure)—same inputs always result in the same output. They should not send requests, schedule timeouts, or perform any side effects (operations that impact things outside the component). They should update [objects](/learn/updating-objects-in-state) and [arrays](/learn/updating-arrays-in-state) without mutations.
 * **Actions describe "what happened," not "what to do."** For example, if a user presses "Reset" on a form with five fields managed by a reducer, it makes more sense to dispatch one `reset_form` action rather than five separate `set_field` actions. If you log every action in a reducer, that log should be clear enough for you to reconstruct what interactions or responses happened in what order. This helps with debugging!
 
-## Writing concise reducers with Immer {#writing-concise-reducers-with-immer}
+## Writing concise reducers with Immer {/*writing-concise-reducers-with-immer*/}
 
 Just like with [updating objects](/learn/updating-objects-in-state#write-concise-update-logic-with-immer) and [arrays](/learn/updating-arrays-in-state#write-concise-update-logic-with-immer) in regular state, you can use the Immer library to make reducers more concise. Here, [`useImmerReducer`](https://github.com/immerjs/use-immer#useimmerreducer) lets you mutate the state with `push` or `arr[i] =` assignment:
 
@@ -1115,7 +1115,7 @@ Reducers must be pure, so they shouldn't mutate state. But Immer provides you wi
 
 <Challenges>
 
-### Dispatch actions from event handlers {#dispatch-actions-from-event-handlers}
+### Dispatch actions from event handlers {/*dispatch-actions-from-event-handlers*/}
 
 Currently, the event handlers in `ContactList.js` and `Chat.js` have `// TODO` comments. This is why typing into the input doesn't work, and clicking on the buttons doesn't change the selected recipient.
 
@@ -1467,7 +1467,7 @@ textarea {
 
 </Solution>
 
-### Clear the input on sending a message {#clear-the-input-on-sending-a-message}
+### Clear the input on sending a message {/*clear-the-input-on-sending-a-message*/}
 
 Currently, pressing "Send" doesn't do anything. Add an event handler to the "Send" button that will:
 
@@ -1970,7 +1970,7 @@ With either solution, it's important that you **don't** place the `alert` inside
 
 </Solution>
 
-### Restore input values when switching between tabs {#restore-input-values-when-switching-between-tabs}
+### Restore input values when switching between tabs {/*restore-input-values-when-switching-between-tabs*/}
 
 In this example, switching between different recipients always clears the text input:
 
@@ -2385,7 +2385,7 @@ Notably, you didn't need to change any of the event handlers to implement this d
 
 </Solution>
 
-### Implement `useReducer` from scratch {#implement-usereducer-from-scratch}
+### Implement `useReducer` from scratch {/*implement-usereducer-from-scratch*/}
 
 In the earlier examples, you imported the `useReducer` Hook from React. This time, you will implement *the `useReducer` Hook itself!* Here is a stub to get your started. It shouldn't take more than 10 lines of code.
 

--- a/beta/src/pages/learn/importing-and-exporting-components.md
+++ b/beta/src/pages/learn/importing-and-exporting-components.md
@@ -18,7 +18,7 @@ The magic of components lies in their reusability: you can create components tha
 
 </YouWillLearn>
 
-## The root component file {#the-root-component-file}
+## The root component file {/*the-root-component-file*/}
 
 In [Your First Component](/learn/your-first-component), you made a `Profile` component and a `Gallery` component that renders it:
 
@@ -54,7 +54,7 @@ img { margin: 0 10px 10px 0; height: 90px; }
 
 These currently live in a **root component file,** named `App.js` in this example. In [Create React App](https://create-react-app.dev/), your app lives in `src/App.js`. Depending on your setup, your root component could be in another file, though. If you use a framework with file-based routing, such as Next.js, your root component will be different for every page.
 
-## Exporting and importing a component {#exporting-and-importing-a-component}
+## Exporting and importing a component {/*exporting-and-importing-a-component*/}
 
 What if you want to change the landing screen in the future and put a list of science books there? Or place all the profiles somewhere else? It makes sense to move `Gallery` and `Profile` out of the root component file. This will make them more modular and reusable in other files. You can move a component in three steps:
 
@@ -145,7 +145,7 @@ When you write a _default_ import, you can put any name you want after `import`.
 
 </DeepDive>
 
-## Exporting and importing multiple components from the same file {#exporting-and-importing-multiple-components-from-the-same-file}
+## Exporting and importing multiple components from the same file {/*exporting-and-importing-multiple-components-from-the-same-file*/}
 
 What if you want to show just one `Profile` instead of a gallery? You can export the `Profile` component, too. But `Gallery.js` already has a *default* export, and you can't have _two_ default exports. You could create a new file with a default export, or you could add a *named* export for `Profile`. **A file can only have one default export, but it can have numerous named exports!**
 
@@ -241,7 +241,7 @@ On this page you learned:
 
 <Challenges>
 
-### Split the components further {#split-the-components-further}
+### Split the components further {/*split-the-components-further*/}
 
 Currently, `Gallery.js` exports both `Profile` and `Gallery`, which is a bit confusing.
 

--- a/beta/src/pages/learn/index.md
+++ b/beta/src/pages/learn/index.md
@@ -19,7 +19,7 @@ Welcome to the React documentation! Here is an overview of what you can find on 
 
 </YouWillLearn>
 
-## Introduction {#introduction}
+## Introduction {/*introduction*/}
 
 This is a tiny React app. To get your first taste of React, **edit the code below** and make it display your name:
 
@@ -43,7 +43,7 @@ export default function App() {
 
 </Sandpack>
 
-### What is React? {#what-is-react}
+### What is React? {/*what-is-react*/}
 
 React is a JavaScript library for building user interfaces.
 
@@ -51,13 +51,13 @@ React stands at the intersection of design and programming. **It lets you take a
 
 React does not prescribe how you build your entire application. It helps you define and compose components, but stays out of your way in other questions. This means that you will either pick one of the ecosystem solutions for problems like routing, styling, and data fetching, or [use a framework](/learn/start-a-new-react-project#building-with-react-and-a-framework) that provides great defaults.
 
-### What can you do with React? {#what-can-you-do-with-react}
+### What can you do with React? {/*what-can-you-do-with-react*/}
 
 Quite a lot, really! People use React to create all kinds of user interfaces--from small controls like buttons and dropdowns to entire apps. **These docs will teach you to use React on the web.** However, most of what you'll learn here applies equally for [React Native](https://reactnative.dev/) which lets you build apps for Android, iOS, and even [Windows and macOS](https://microsoft.github.io/react-native-windows/).
 
 If you're curious which products you use everyday are built with React, you can install the [React Developer Tools](/learn/react-developer-tools). Whenever you visit an app or a website built with React (like this one!), its icon will light up in the toolbar.
 
-### React uses JavaScript {#react-uses-javascript}
+### React uses JavaScript {/*react-uses-javascript*/}
 
 With React, you will describe your visual logic in JavaScript. This takes some practice. If you're learning JavaScript and React at the same time, you're not alone--but at times, it will be a little bit more challenging! On the upside, **much of learning React is really learning JavaScript,** which means you will take your learnings far beyond React.
 
@@ -85,7 +85,7 @@ When you're ready to start a project, there are several options. You can write R
 
 </DeepDive>
 
-## Learn React {#learn-react}
+## Learn React {/*learn-react*/}
 
 There are a few ways to get started:
 
@@ -95,7 +95,7 @@ There are a few ways to get started:
 
 To save you time, we provide **a brief overview of each chapter** below.
 
-### Chapter 1 overview: Describing the UI {#chapter-1-overview-describing-the-ui}
+### Chapter 1 overview: Describing the UI {/*chapter-1-overview-describing-the-ui*/}
 
 React applications are built from isolated pieces of UI called ["components"](/learn/your-first-component). A React component is a JavaScript function that you can sprinkle with markup. Components can be as small as a button, or as large as an entire page. Here, a *parent* `Gallery` component renders three *child* `Profile` components:
 
@@ -256,7 +256,7 @@ Read **[Describing the UI](/learn/describing-the-ui)** to learn how to make thin
 
 </LearnMore>
 
-### Chapter 2 overview: Adding interactivity {#chapter-2-overview-adding-interactivity}
+### Chapter 2 overview: Adding interactivity {/*chapter-2-overview-adding-interactivity*/}
 
 Components often need to change what’s on the screen as a result of an interaction. Typing into the form should update the input field, clicking “next” on an image carousel should change which image is displayed, clicking “buy” puts a product in the shopping cart. Components need to “remember” things: the current input value, the current image, the shopping cart. In React, this kind of component-specific memory is called [*state*](/learn/state-a-components-memory).
 
@@ -528,7 +528,7 @@ Read **[Adding Interactivity](/learn/adding-interactivity)** to learn how to upd
 
 </LearnMore>
 
-### Chapter 3 overview: Managing state {#chapter-3-overview-managing-state}
+### Chapter 3 overview: Managing state {/*chapter-3-overview-managing-state*/}
 
 You'll often face a choice of _what exactly_ to put into state. Should you use one state variable or many? An object or an array? How should you [structure your state](/learn/choosing-the-state-structure)? The most important principle is to **avoid redundant state**. If some information never changes, it shouldn't be in state. If some information is received from parent by props, it shouldn't be in state. And if you can compute something from other props or state, it shouldn't be in state either!
 
@@ -706,7 +706,7 @@ Read **[Managing State](/learn/managing-state)** to learn how to keep your compo
 
 </LearnMore>
 
-## Next steps {#next-steps}
+## Next steps {/*next-steps*/}
 
 This page was fast-paced! If you've read this far, you have already seen 80% of React you will use on daily basis.
 

--- a/beta/src/pages/learn/installation.md
+++ b/beta/src/pages/learn/installation.md
@@ -17,7 +17,7 @@ React has been designed from the start for gradual adoption, and you can use as 
 
 </YouWillLearn>
 
-## Try React {#try-react}
+## Try React {/*try-react*/}
 
 You don't need to install anything to play with React. Try editing this sandbox!
 
@@ -38,18 +38,18 @@ export default function App() {
 We use sandboxes throughout these docs as teaching aids. Sandboxes can help familiarize you with how React works and help you decide if React is right for you. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [Stackblitz](https://stackblitz.com/fork/react), or [CodePen](
 https://codepen.io/pen/?template=wvdqJJm).
 
-### Try React locally {#try-react-locally}
+### Try React locally {/*try-react-locally*/}
 
 To try React locally on your computer, [download this HTML page](https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html). Open it in your editor and in your browser!
 
-## Add React to a page {#add-react-to-a-page}
+## Add React to a page {/*add-react-to-a-page*/}
 
 If you're working with an existing site and just need to add a little bit of React, you can [add React with a script tag.](/learn/add-react-to-a-website)
 
-## Start a React project {#start-a-react-project}
+## Start a React project {/*start-a-react-project*/}
 
 If you're ready to [start a standalone project](/learn/start-a-new-react-project) with React, you can set up a minimal toolchain for a pleasant developer experience. You can also start with a framework that makes a lot of decisions for you out of the box.
 
-## Next steps {#next-steps}
+## Next steps {/*next-steps*/}
 
 Where you start depends on how you like to learn, what you need to accomplish, and where you want to go next! Why not read [Thinking in React](/learn/thinking-in-react)--our introductory tutorial? Or you can jump to [Describing the UI](/learn/describing-the-ui) to play with more examples and learn each topic step by step. There is no wrong way to learn React!

--- a/beta/src/pages/learn/javascript-in-jsx-with-curly-braces.md
+++ b/beta/src/pages/learn/javascript-in-jsx-with-curly-braces.md
@@ -17,7 +17,7 @@ JSX lets you write HTML-like markup inside a JavaScript file, keeping rendering 
 
 </YouWillLearn>
 
-## Passing strings with quotes {#passing-strings-with-quotes}
+## Passing strings with quotes {/*passing-strings-with-quotes*/}
 
 When you want to pass a string attribute to JSX, you put it in single or double quotes:
 
@@ -69,7 +69,7 @@ export default function Avatar() {
 
 Notice the difference between `className="avatar"`, which specifies an `"avatar"` CSS class name that makes the image round, and `src={avatar}` that reads the value of the JavaScript variable called `avatar`. That's because curly braces let you work with JavaScript right there in your markup!
 
-## Using curly braces: A window into the JavaScript world {#using-curly-braces-a-window-into-the-javascript-world}
+## Using curly braces: A window into the JavaScript world {/*using-curly-braces-a-window-into-the-javascript-world*/}
 
 JSX is a special way of writing JavaScript. That means it’s possible to use JavaScript inside it—with curly braces `{ }`. The example below first declares a name for the scientist, `name`, then embeds it with curly braces inside the `<h1>`:
 
@@ -111,14 +111,14 @@ export default function TodoList() {
 
 </Sandpack>
 
-### Where to use curly braces {#where-to-use-curly-braces}
+### Where to use curly braces {/*where-to-use-curly-braces*/}
 
 You can only use curly braces in two ways inside JSX:
 
 1. **As text** directly inside a JSX tag: `<h1>{name}'s To Do List</h1>` works, but `<{tag}>Gregorio Y. Zara's To Do List</{tag}>`  will not.
 2. **As attributes** immediately following the `=` sign: `src={avatar}` will read the `avatar` variable, but `src="{avatar}"` will pass the string `{avatar}`.
 
-## Using "double curlies": CSS and other objects in JSX {#using-double-curlies-css-and-other-objects-in-jsx}
+## Using "double curlies": CSS and other objects in JSX {/*using-double-curlies-css-and-other-objects-in-jsx*/}
 
 In addition to strings, numbers, and other JavaScript expressions, you can even pass objects in JSX. Objects are also denoted with curly braces, like `{ name: "Hedy Lamarr", inventions: 5 }`. Therefore, to pass a JS object in JSX, you must wrap the object in another pair of curly braces: `person={{ name: "Hedy Lamarr", inventions: 5 }}`.
 
@@ -169,7 +169,7 @@ Inline `style` properties are written in camelCase. For example, HTML `<ul style
 
 </Gotcha>
 
-## More fun with JavaScript objects and curly braces {#more-fun-with-javascript-objects-and-curly-braces}
+## More fun with JavaScript objects and curly braces {/*more-fun-with-javascript-objects-and-curly-braces*/}
 
 You can move several expressions into one object, and reference them in your JSX inside curly braces:
 
@@ -245,7 +245,7 @@ Now you know almost everything about JSX:
 
 <Challenges>
 
-### Fix the mistake {#fix-the-mistake}
+### Fix the mistake {/*fix-the-mistake*/}
 
 This code crashes with an error saying `Objects are not valid as a React child`:
 
@@ -337,7 +337,7 @@ body > div > div { padding: 20px; }
 
 </Solution>
 
-### Extract information into an object {#extract-information-into-an-object}
+### Extract information into an object {/*extract-information-into-an-object*/}
 
 Extract the image URL into the `person` object.
 
@@ -424,7 +424,7 @@ body > div > div { padding: 20px; }
 
 </Solution>
 
-### Write an expression inside JSX curly braces {#write-an-expression-inside-jsx-curly-braces}
+### Write an expression inside JSX curly braces {/*write-an-expression-inside-jsx-curly-braces*/}
 
 In the object below, the full image URL is split into four parts: base URL,  `imageId`, `imageSize`, and file extension.
 

--- a/beta/src/pages/learn/keeping-components-pure.md
+++ b/beta/src/pages/learn/keeping-components-pure.md
@@ -16,7 +16,7 @@ Some JavaScript functions are "pure." Pure functions only perform a calculation 
 
 </YouWillLearn>
 
-## Purity: Components as formulas {#purity-components-as-formulas}
+## Purity: Components as formulas {/*purity-components-as-formulas*/}
 
 In computer science (and especially the world of functional programming), [a pure function](https://wikipedia.org/wiki/Pure_function) is a function with the following characteristics:
 
@@ -85,7 +85,7 @@ You could think of your components as recipes: if you follow them and don't intr
 
 <Illustration src="/images/docs/illustrations/i_puritea-recipe.png" alt="A tea recipe for x people: take x cups of water, add 2x spoons of spices, and x spoons of tea!" />
 
-## Side Effects: (un)intended consequences {#side-effects-unintended-consequences}
+## Side Effects: (un)intended consequences {/*side-effects-unintended-consequences*/}
 
 React's rendering process must always be pure. Components should only *return* their JSX, and not *change* any objects or variables that existed before rendering—that would make them impure!
 
@@ -159,7 +159,7 @@ Strict Mode has no effect in production, so it won't slow down the app for your 
 
 </DeepDive>
 
-### Local mutation: Your component's little secret {#local-mutation-your-components-little-secret}
+### Local mutation: Your component's little secret {/*local-mutation-your-components-little-secret*/}
 
 In the above example, the problem was that the component changed a *preexisting* variable while rendering. This is often called a **"mutation"** to make it sound a bit scarier. Pure functions don't mutate variables outside of the function's scope or objects that were created before the call—that makes them impure!
 
@@ -187,7 +187,7 @@ If the `cups` variable or the `[]` array were created outside the `TeaGathering`
 
 However, it's fine because you've created them *during the same render*, inside `TeaGathering`. No code outside of `TeaGathering` will ever know that this happened. This is called **"local mutation"**—it's like your component's little secret.
 
-## Where you _can_ cause side effects {#where-you-_can_-cause-side-effects}
+## Where you _can_ cause side effects {/*where-you-_can_-cause-side-effects*/}
 
 While functional programming relies heavily on purity, at some point, somewhere, _something_ has to change. That's kind of the point of programming! These changes—updating the screen, starting an animation, changing the data—are called **side effects**. They're things that happen _"on the side,"_ not during rendering.
 
@@ -225,7 +225,7 @@ Every new React feature we're building takes advantage of purity. From data fetc
   
 <Challenges>
 
-### Fix a broken clock {#fix-a-broken-clock}
+### Fix a broken clock {/*fix-a-broken-clock*/}
 
 This component tries to set the `<h1>`'s CSS class to `"night"` during the time from midnight to six hours in the morning, and `"day"` at all other times. However, it doesn't work. Can you fix this component?
 
@@ -362,7 +362,7 @@ In this example, the side effect (modifying the DOM) was not necessary at all. Y
 
 </Solution>
 
-### Fix a broken profile {#fix-a-broken-profile}
+### Fix a broken profile {/*fix-a-broken-profile*/}
 
 Two `Profile` components are rendered side by side with different data. Press "Collapse" on the first profile, and then "Expand" it. You'll notice that both profiles now show the same person. This is a bug.
 
@@ -571,7 +571,7 @@ Remember that React does not guarantee that component functions will execute in 
 
 </Solution>
 
-### Fix a broken story tray {#fix-a-broken-story-tray}
+### Fix a broken story tray {/*fix-a-broken-story-tray*/}
 
 The CEO of your company is asking you to add "stories" to your online clock app, and you can't say no. You've written a `StoryTray` component that accepts a list of `stories`, followed by a "Create Story" placeholder.
 

--- a/beta/src/pages/learn/managing-state.md
+++ b/beta/src/pages/learn/managing-state.md
@@ -20,7 +20,7 @@ As your application grows, it helps to be more intentional about how your state 
 
 </YouWillLearn>
 
-## Reacting to input with state {#reacting-to-input-with-state}
+## Reacting to input with state {/*reacting-to-input-with-state*/}
 
 With React, you won't modify the UI from code directly. For example, you won't write commands like "disable the button", "enable the button", "show the success message", etc. Instead, you will describe the UI you want to see for the different visual states of your component ("initial state", "typing state", "success state"), and then trigger the state changes in response to user input. This is similar to how designers think about UI.
 
@@ -112,7 +112,7 @@ Read **[Reacting to Input with State](/learn/reacting-to-input-with-state)** to 
 
 </LearnMore>
 
-## Choosing the state structure {#choosing-the-state-structure}
+## Choosing the state structure {/*choosing-the-state-structure*/}
 
 Structuring state well can make a difference between a component that is pleasant to modify and debug, and one that is a constant source of bugs. The most important principle is that state shouldn't contain redundant or duplicated information. If there's some unnecessary state, it's easy to forget to update it, and introduce bugs!
 
@@ -229,7 +229,7 @@ Read **[Choosing the State Structure](/learn/choosing-the-state-structure)** to 
 
 </LearnMore>
 
-## Sharing state between components {#sharing-state-between-components}
+## Sharing state between components {/*sharing-state-between-components*/}
 
 Sometimes, you want the state of two components to always change together. To do it, remove state from both of them, move it to their closest common parent, and then pass it down to them via props. This is known as "lifting state up", and it's one of the most common things you will do writing React code.
 
@@ -300,7 +300,7 @@ Read **[Sharing State Between Components](/learn/sharing-state-between-component
 
 </LearnMore>
 
-## Preserving and resetting state {#preserving-and-resetting-state}
+## Preserving and resetting state {/*preserving-and-resetting-state*/}
 
 When you re-render a component, React needs to decide which parts of the tree to keep (and update), and which parts to discard or re-create from scratch. In most cases, React's automatic behavior works well enough. By default, React preserves the parts of the tree that "match up" with the previously rendered component tree.
 
@@ -500,7 +500,7 @@ Read **[Preserving and Resetting State](/learn/preserving-and-resetting-state)**
 
 </LearnMore>
 
-## Extracting state logic into a reducer {#extracting-state-logic-into-a-reducer}
+## Extracting state logic into a reducer {/*extracting-state-logic-into-a-reducer*/}
 
 Components with many state updates spread across many event handlers can get overwhelming. For these cases, you can consolidate all the state update logic outside your component in a single function, called "reducer." Your event handlers become concise because they only specify the user "actions." At the bottom of the file, the reducer function specifies how the state should update in response to each action!
 
@@ -697,7 +697,7 @@ Read **[Extracting State Logic into a Reducer](/learn/extracting-state-logic-int
 
 </LearnMore>
 
-## Passing data deeply with context {#passing-data-deeply-with-context}
+## Passing data deeply with context {/*passing-data-deeply-with-context*/}
 
 Usually, you will pass information from a parent component to a child component via props. But passing props can become inconvenient if you need to pass some prop through many components, or if many components need the same information. Context lets the parent component make some information available to any component in the tree below it—no matter how deep it is—without passing it explicitly through props.
 
@@ -799,7 +799,7 @@ Read **[Passing Data Deeply with Context](/learn/passing-data-deeply-with-contex
 
 </LearnMore>
 
-## Scaling up with reducer and context {#scaling-up-with-reducer-and-context}
+## Scaling up with reducer and context {/*scaling-up-with-reducer-and-context*/}
 
 Reducers let you consolidate a component’s state update logic. Context lets you pass information deep down to other components. You can combine reducers and context together to manage state of a complex screen.
 
@@ -1010,7 +1010,7 @@ Read **[Scaling Up with Reducer and Context](/learn/scaling-up-with-reducer-and-
 
 </LearnMore>
 
-## What's next? {#whats-next}
+## What's next? {/*whats-next*/}
 
 Head over to [Reacting to Input with State](/learn/reacting-to-input-with-state) to start reading this chapter page by page!
 

--- a/beta/src/pages/learn/manipulating-the-dom-with-refs.md
+++ b/beta/src/pages/learn/manipulating-the-dom-with-refs.md
@@ -17,7 +17,7 @@ Because React handles updating the [DOM](https://developer.mozilla.org/docs/Web/
 
 </YouWillLearn>
 
-## Getting a ref to the node {#getting-a-ref-to-the-node}
+## Getting a ref to the node {/*getting-a-ref-to-the-node*/}
 
 To access a DOM node managed by React, first, import the `useRef` Hook:
 
@@ -44,7 +44,7 @@ The `useRef` Hook returns an object with a single property called `current`. Ini
 myRef.current.scrollIntoView();
 ```
 
-### Example: Focusing a text input {#example-focusing-a-text-input}
+### Example: Focusing a text input {/*example-focusing-a-text-input*/}
 
 In this example, clicking the button will focus the input:
 
@@ -82,7 +82,7 @@ To implement this:
 
 While DOM manipulation is the most common use case for refs, the `useRef` Hook can be used for storing other things outside React, like timer IDs. Similarly to state, refs remain between renders. You can even think of refs as state variables that don't trigger re-renders when you set them! You can learn more about refs in [Referencing Values with Refs](/learn/referencing-values-with-refs).
 
-### Example: Scrolling to an element {#example-scrolling-to-an-element}
+### Example: Scrolling to an element {/*example-scrolling-to-an-element*/}
 
 You can have more than a single ref in a component. In this example, there is a carousel of three images and three buttons to center them in the view port by calling the browser [`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method the corresponding DOM node:
 
@@ -336,7 +336,7 @@ This lets you read individual DOM nodes from the Map later.
 
 </DeepDive>
 
-## Accessing another component's DOM nodes {#accessing-another-components-dom-nodes}
+## Accessing another component's DOM nodes {/*accessing-another-components-dom-nodes*/}
 
 When you put a ref on a built-in component that outputs a browser element like `<input />`, React will set that ref's `current` property to the corresponding DOM node (such as the actual `<input />` in the browser).
 
@@ -472,7 +472,7 @@ Here, `realInputRef` inside `MyInput` holds the actual input DOM node. However, 
 
 </DeepDive>
 
-## When React attaches the refs {#when-react-attaches-the-refs}
+## When React attaches the refs {/*when-react-attaches-the-refs*/}
 
 In React, every update is split in [two phases](/learn/render-and-commit#step-3-react-commits-changes-to-the-dom):
 
@@ -618,7 +618,7 @@ for (let i = 0; i < 20; i++) {
 
 </DeepDive>
 
-## Best practices for DOM manipulation with refs {#best-practices-for-dom-manipulation-with-refs}
+## Best practices for DOM manipulation with refs {/*best-practices-for-dom-manipulation-with-refs*/}
 
 Refs are an escape hatch. You should only use them when you have to "step outside React." Common examples of this include managing focus, scroll position, or calling browser APIs that React does not expose.
 
@@ -688,7 +688,7 @@ However, this doesn't mean that you can't do it at all. It requires caution. **Y
 
 <Challenges>
 
-### Play and pause the video {#play-and-pause-the-video}
+### Play and pause the video {/*play-and-pause-the-video*/}
 
 In this example, the button toggles a state variable to switch between a playing and a paused state. However, in order to actually play or pause the video, toggling state is not enough. You also need to call [`play()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [`pause()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause) on the DOM element for the `<video>`. Add a ref to it, and make the button work.
 
@@ -775,7 +775,7 @@ button { display: block }
 
 </Solution>
 
-### Focus the search field {#focus-the-search-field}
+### Focus the search field {/*focus-the-search-field*/}
 
 Make it so that clicking the "Search" button puts focus into the field.
 
@@ -839,7 +839,7 @@ button { display: block; margin-bottom: 10px; }
 
 </Solution>
 
-### Scrolling an image carousel {#scrolling-an-image-carousel}
+### Scrolling an image carousel {/*scrolling-an-image-carousel*/}
 
 This image carousel has a "Next" button that switches the active image. Make the gallery scroll horizontally to the active image on click. You will want to call [`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) on the DOM node of the active image:
 
@@ -1065,7 +1065,7 @@ img {
 
 </Solution>
 
-### Focus the search field with separate components {#focus-the-search-field-with-separate-components}
+### Focus the search field with separate components {/*focus-the-search-field-with-separate-components*/}
 
 Make it so that clicking the "Search" button puts focus into the field. Note that each component is defined in a separate file and shouldn't be moved out of it. How do you connect them together?
 

--- a/beta/src/pages/learn/passing-data-deeply-with-context.md
+++ b/beta/src/pages/learn/passing-data-deeply-with-context.md
@@ -17,7 +17,7 @@ Usually, you will pass information from a parent component to a child component 
 
 </YouWillLearn>
 
-## The problem with passing props {#the-problem-with-passing-props}
+## The problem with passing props {/*the-problem-with-passing-props*/}
 
 [Passing props](/learn/passing-props-to-a-component) is a great way to explicitly pipe data through your UI tree to the components that use it. But it can become verbose and inconvenient when you need to pass some prop deeply through the tree, or if many components need the same prop. The nearest common ancestor could be far removed from the components that need data, and [lifting state up](/learn/sharing-state-between-components) that high can lead to a situation sometimes called "prop drilling."
 
@@ -25,7 +25,7 @@ Usually, you will pass information from a parent component to a child component 
 
 Wouldn't it be great if there were a way to "teleport" data to the components in the tree that need it without passing props? With React's context feature, there is!
 
-## Context: an alternative to passing props {#context-an-alternative-to-passing-props}
+## Context: an alternative to passing props {/*context-an-alternative-to-passing-props*/}
 
 Context lets a parent component provide data to the entire tree below it. There are many uses for context. Here is one example. Consider this `Heading` component that accepts a `level` for its size:
 
@@ -197,7 +197,7 @@ Context lets a parent--even a distant one!--provide some data to the entire tree
 
 <img alt="Context provides data to the entire tree" src="/images/docs/sketches/s_providing-context.png" />
 
-### Step 1: Create the context {#step-1-create-the-context}
+### Step 1: Create the context {/*step-1-create-the-context*/}
 
 First, you need to create the context. You'll need to **export it from a file** so that your components can use it:
 
@@ -281,7 +281,7 @@ export const LevelContext = createContext(1);
 
 The only argument to `createContext` is the _default_ value. Here, `1` refers to the biggest heading level, but you could pass any kind of value (even an object). You will see the significance of the default value in the next step.
 
-### Step 2: Use the context {#step-2-use-the-context}
+### Step 2: Use the context {/*step-2-use-the-context*/}
 
 Import the `useContext` Hook from React and your context:
 
@@ -417,7 +417,7 @@ Notice this example doesn't quite work, yet! All the headers have the same size 
 
 If you don't provide the context, React will use the default value you've specified in the previous step. In this example, you specified `1` as the argument to `createContext`, so `useContext(LevelContext)` returns `1`, setting all those headings to `<h1>`. Let's fix this problem by having each `Section` provide its own context.
 
-### Step 3: Provide the context {#step-3-provide-the-context}
+### Step 3: Provide the context {/*step-3-provide-the-context*/}
 
 The `Section` component currently renders its children:
 
@@ -541,7 +541,7 @@ It's the same result as the original code, but you did not need to pass the `lev
 2. `Section` wraps its children into `<LevelContext.Provider value={level}>`.
 3. `Header` asks the closest value of `LevelContext` above with `useContext(LevelContext)`.
 
-## Using and providing context from the same component {#using-and-providing-context-from-the-same-component}
+## Using and providing context from the same component {/*using-and-providing-context-from-the-same-component*/}
 
 Currently, you still have to specify each section's `level` manually:
 
@@ -670,7 +670,7 @@ Now both `Heading` and `Section` read the `LevelContext` to figure out how "deep
 
 >This example uses heading levels because they show visually how nested components can override context. But context is useful for many other use cases too. You can use it to pass down any information needed by the entire subtree: the current color theme, the currently logged in user, and so on.
 
-## Context passes through intermediate components {#context-passes-through-intermediate-components}
+## Context passes through intermediate components {/*context-passes-through-intermediate-components*/}
 
 You can insert as many components as you like between the component that provides context and the one that uses it. This includes both built-in components like `<div>` and components you might build yourself.
 
@@ -807,7 +807,7 @@ How context works might remind you of [CSS property inheritance](https://develop
 
 In CSS, different properties like `color` and `background-color` don't override each other. You can set all  `<div>`'s `color` to red without impacting `background-color`. Similarly, **different React contexts don't override each other**. Each context that you make with `createContext()` is completely separate from other ones, and ties together components using and providing *that particular* context. One component may use or provide many different contexts without a problem.
 
-## Before you use context {#before-you-use-context}
+## Before you use context {/*before-you-use-context*/}
 
 Context is very tempting to use! However, this also means it's too easy to overuse it. **Just because you need to pass some props several levels deep doesn't mean you should put that information into context.**
 
@@ -818,7 +818,7 @@ Here's a few alternatives you should consider before using context:
 
 If neither of these approaches works well for you, consider context.
 
-## Use cases for context {#use-cases-for-context}
+## Use cases for context {/*use-cases-for-context*/}
 
 * **Theming:** If your app lets the user change its appearance (e.g. dark mode), you can put a context provider at the top of your app, and use that context in components that need to adjust their visual look.
 * **Current account:** Many components might need to know the currently logged in user. Putting it in context makes it convenient to read it anywhere in the tree. Some apps also let you operate multiple accounts at the same time (e.g. to leave a comment as a different user). In those cases, it can be convenient to wrap a part of the UI into a nested provider with a different current account value.
@@ -846,7 +846,7 @@ In general, if some information is needed by distant components in different par
 
 <Challenges>
 
-### Replace prop drilling with context {#replace-prop-drilling-with-context}
+### Replace prop drilling with context {/*replace-prop-drilling-with-context*/}
 
 In this example, toggling the checkbox changes the `imageSize` prop passed to each `<PlaceImage>`. The checkbox state is held in the top-level `App` component, but each `<PlaceImage>` needs to be aware of it.
 

--- a/beta/src/pages/learn/passing-props-to-a-component.md
+++ b/beta/src/pages/learn/passing-props-to-a-component.md
@@ -18,7 +18,7 @@ React components use **props** to communicate with each other. Every parent comp
 
 </YouWillLearn>
 
-## Familiar props {#familiar-props}
+## Familiar props {/*familiar-props*/}
 
 Props are the information that you pass to a JSX tag. For example, `className`, `src`, `alt`, `width`, and `height` are some of the props you can pass to an `<img>`:
 
@@ -53,7 +53,7 @@ body { min-height: 120px; }
 
 The props you can pass to an `<img>` tag are predefined (ReactDOM conforms to [the HTML standard](https://www.w3.org/TR/html52/semantics-embedded-content.html#the-img-element)). But you can pass any props to *your own* components, such as `<Avatar>`, to customize them. Here's how!
 
-## Passing props to a component {#passing-props-to-a-component}
+## Passing props to a component {/*passing-props-to-a-component*/}
 
 In this code, the `Profile` component isn't passing any props to its child component, `Avatar`:
 
@@ -67,7 +67,7 @@ export default function Profile() {
 
 You can give `Avatar` some props in two steps.
 
-### Step 1: Pass props to the child component {#step-1-pass-props-to-the-child-component}
+### Step 1: Pass props to the child component {/*step-1-pass-props-to-the-child-component*/}
 
 First, pass some props to `Avatar`. For example, let's pass two props: `person` (an object), and `size` (a number):
 
@@ -86,7 +86,7 @@ export default function Profile() {
 
 Now you can read these props inside the `Avatar` component.
 
-### Step 2: Read props inside the child component {#step-2-read-props-inside-the-child-component}
+### Step 2: Read props inside the child component {/*step-2-read-props-inside-the-child-component*/}
 
 You can read these props by listing their names `person, size` separated by the commas inside `({` and `})` directly after `function Avatar`. This lets you use them inside the `Avatar` code, like you would with a variable.
 
@@ -200,7 +200,7 @@ function Avatar(props) {
 
 </Gotcha>
 
-## Specifying a default value for a prop {#specifying-a-default-value-for-a-prop}
+## Specifying a default value for a prop {/*specifying-a-default-value-for-a-prop*/}
 
 If you want to give a prop a default value to fall back on when no value is specified, you can do it with the destructuring by putting `=` and the default value right after the parameter:
 
@@ -214,7 +214,7 @@ Now, if `<Avatar person={...} />` is rendered with no `size` prop, the `size` wi
 
 The default value is only used if the `size` prop is missing or if you pass `size={undefined}`. But if you pass `size={null}` or `size={0}`, the default value will **not** be used.
 
-## Forwarding props with the JSX spread syntax {#forwarding-props-with-the-jsx-spread-syntax}
+## Forwarding props with the JSX spread syntax {/*forwarding-props-with-the-jsx-spread-syntax*/}
 
 Sometimes, passing props gets very repetitive:
 
@@ -249,7 +249,7 @@ This forwards all of `Profile`'s props to the `Avatar` without listing each of t
 
 **Use spread syntax with restraint.** If you're using it in every other component, something is wrong. Often, it indicates that you should split your components and pass children as JSX. More on that next!
 
-## Passing JSX as children {#passing-jsx-as-children}
+## Passing JSX as children {/*passing-jsx-as-children*/}
 
 It is common to nest built-in browser tags:
 
@@ -349,7 +349,7 @@ You can think of a component with a `children` prop as having a "hole" that can 
 
 <Illustration src="/images/docs/illustrations/i_children-prop.png" alt='A puzzle-like Card tile with a slot for "children" pieces like text and Avatar' />
 
-## How props change over time {#how-props-change-over-time}
+## How props change over time {/*how-props-change-over-time*/}
 
 The `Clock` component below receives two props from its parent component: `color` and `time`. (The parent component's code is omitted because it uses [state](/learn/state-a-components-memory), which we won't dive into just yet.)
 
@@ -425,7 +425,7 @@ However, props are [immutable](https://en.wikipedia.org/wiki/Immutable_object)â€
 
 <Challenges>
 
-### Extract a component {#extract-a-component}
+### Extract a component {/*extract-a-component*/}
 
 This `Gallery` component contains some very similar markup for two profiles. Extract a `Profile` component out of it to reduce the duplication. You'll need to choose what props to pass to it.
 
@@ -727,7 +727,7 @@ Although the syntax looks slightly different because you're describing propertie
 
 </Solution>
 
-### Adjust the image size based on a prop {#adjust-the-image-size-based-on-a-prop}
+### Adjust the image size based on a prop {/*adjust-the-image-size-based-on-a-prop*/}
 
 In this example, `Avatar` receives a numeric `size` prop which determines the `<img>` width and height. The `size` prop is set to `40` in this example. However, if you open the image in a new tab, you'll notice that the image itself is larger (`160` pixels). The real image size is determined by which thumbnail size you're requesting.
 
@@ -919,7 +919,7 @@ Props let you encapsulate logic like this inside the `Avatar` component (and cha
 
 </Solution>
 
-### Passing JSX in a `children` prop {#passing-jsx-in-a-children-prop}
+### Passing JSX in a `children` prop {/*passing-jsx-in-a-children-prop*/}
 
 Extract a `Card` component from the markup below, and use the `children` prop to pass different JSX to it:
 

--- a/beta/src/pages/learn/preserving-and-resetting-state.md
+++ b/beta/src/pages/learn/preserving-and-resetting-state.md
@@ -17,7 +17,7 @@ State is isolated between components. React keeps track of which state belongs t
 
 </YouWillLearn>
 
-## The UI tree {#the-ui-tree}
+## The UI tree {/*the-ui-tree*/}
 
 Browsers use many tree structures to model UI. The [DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction) represents HTML elements, the [CSSOM](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model) does the same for CSS. There's even an [Accessibility tree](https://developer.mozilla.org/docs/Glossary/Accessibility_tree)!
 
@@ -25,7 +25,7 @@ React also uses tree structures to manage and model the UI you make. React makes
 
 <img alt="React takes components, turns them into UI tree structures, and ReactDOM turns them into HTML in your browser using the DOM." src="/images/docs/sketches/s_react-dom-tree.png" />
 
-## State is tied to a position in the tree {#state-is-tied-to-a-position-in-the-tree}
+## State is tied to a position in the tree {/*state-is-tied-to-a-position-in-the-tree*/}
 
 When you give a component state, you might think the state "lives" inside the component. But the state is actually held inside React. React associates each piece of state it's holding with the correct component by where that component sits in the UI tree.
 
@@ -244,7 +244,7 @@ When you tick "Render the second counter," a second `Counter` and its state are 
 
 **React preserves a component's state for as long as it's being rendered at its position in the UI tree.** If it gets removed, or a different component gets rendered at the same position, React discards its state.
 
-## Same component at the same position preserves state {#same-component-at-the-same-position-preserves-state}
+## Same component at the same position preserves state {/*same-component-at-the-same-position-preserves-state*/}
 
 In this example, there are two different `<Counter />` tags:
 
@@ -446,7 +446,7 @@ You can think of them as having the same "address": the first child of the first
 
 </Gotcha>
 
-## Different components at the same position reset state {#different-components-at-the-same-position-reset-state}
+## Different components at the same position reset state {/*different-components-at-the-same-position-reset-state*/}
 
 In this example, ticking the checkbox will replace `<Counter>` with a `<p>`:
 
@@ -667,7 +667,7 @@ Every time you click the button, the input state disappears! This is because a *
 
 </Gotcha>
 
-## Resetting state at the same position {#resetting-state-at-the-same-position}
+## Resetting state at the same position {/*resetting-state-at-the-same-position*/}
 
 By default, React preserves state of a component while it stays at the same position. Usually, this is exactly what you want, so it makes sense as the default behavior. But sometimes, you may want to reset a component's state. Consider this app that lets two players keep track of their scores during each turn:
 
@@ -751,7 +751,7 @@ There are two ways to reset state when switching between them:
 2. Give each component an explicit identity with `key`
 
 
-### Option 1: Rendering a component in different positions {#option-1-rendering-a-component-in-different-positions}
+### Option 1: Rendering a component in different positions {/*option-1-rendering-a-component-in-different-positions*/}
 
 If you want these two `Counter`s to be independent, you can render them in two different positions:
 
@@ -833,7 +833,7 @@ h1 {
 
 This solution is convenient when you only have a few independent components rendered in the same place. In this example, you only have two, so it's not a hassle to render both separately in the JSX.
 
-### Option 2: Resetting state with a key {#option-2-resetting-state-with-a-key}
+### Option 2: Resetting state with a key {/*option-2-resetting-state-with-a-key*/}
 
 There is also another, more generic, way to reset a component's state.
 
@@ -925,7 +925,7 @@ Specifying a `key` tells React to use the `key` itself as part of the position, 
 
 > Remember that keys are not globally unique. They only specify the position *within the parent*.
 
-### Resetting a form with a key {#resetting-a-form-with-a-key}
+### Resetting a form with a key {/*resetting-a-form-with-a-key*/}
 
 Resetting state with a key is particularly useful when dealing with forms.
 
@@ -1154,7 +1154,7 @@ No matter which strategy you pick, a chat _with Alice_ is conceptually distinct 
 
 <Challenges>
 
-### Fix disappearing input text {#fix-disappearing-input-text}
+### Fix disappearing input text {/*fix-disappearing-input-text*/}
 
 This example shows a message when you press the button. However, pressing the button also accidentally resets the input. Why does this happen? Fix it so that pressing the button does not reset the input text.
 
@@ -1305,7 +1305,7 @@ This way, `Form` is always the second child, so it stays in the same position an
 
 </Solution>
 
-### Swap two form fields {#swap-two-form-fields}
+### Swap two form fields {/*swap-two-form-fields*/}
 
 This form lets you enter first and last name. It also has a checkbox controlling which field goes first. When you tick the checkbox, the "Last name" field will appear before the "First name" field.
 
@@ -1439,7 +1439,7 @@ label { display: block; margin: 10px 0; }
 
 </Solution>
 
-### Reset a detail form {#reset-a-detail-form}
+### Reset a detail form {/*reset-a-detail-form*/}
 
 This is an editable contact list. You can edit the selected contact's details and then either press "Save" to update it, or "Reset" to undo your changes.
 
@@ -1748,7 +1748,7 @@ button {
 
 </Solution>
 
-### Clear an image while it's loading {#clear-an-image-while-its-loading}
+### Clear an image while it's loading {/*clear-an-image-while-its-loading*/}
 
 When you press "Next", the browser starts loading the next image. However, because it's displayed in the same `<img>` tag, by default you would still see the previous image until the next one loads. This may be undesirable if it's important for the text to always match the image. Change it so that the moment you press "Next," the previous image immediately clears.
 
@@ -1892,7 +1892,7 @@ img { width: 150px; height: 150px; }
 
 </Solution>
 
-### Fix misplaced state in the list {#fix-misplaced-state-in-the-list}
+### Fix misplaced state in the list {/*fix-misplaced-state-in-the-list*/}
 
 In this list, each `Contact` has state that determines whether "Show email" has been pressed for it. Press "Show email" for Alice, and then tick the "Show in reverse order" checkbox. You will notice that it's _Taylor's_ email that is expanded now, but Alice's--which has moved to the bottom--appears collapsed.
 

--- a/beta/src/pages/learn/queueing-a-series-of-state-updates.md
+++ b/beta/src/pages/learn/queueing-a-series-of-state-updates.md
@@ -15,7 +15,7 @@ Setting a state variable will queue another render. But sometimes you might want
 
 </YouWillLearn>
 
-## React batches state updates {#react-batches-state-updates}
+## React batches state updates {/*react-batches-state-updates*/}
 
 You might expect that clicking the "+3" button will increment the counter three times because it calls `setNumber(number + 1)` three times:
 
@@ -65,7 +65,7 @@ This lets you update multiple state variables--even from multiple components--wi
 
 **React does not batch across *multiple* intentional events like clicks**--each click is handled separately. Rest assured that React only does batching when it's generally safe to do. This ensures that, for example, if the first button click disables a form, the second click would not submit it again.
 
-## Updating the same state variable multiple times before the next render {#updating-the-same-state-variable-multiple-times-before-the-next-render}
+## Updating the same state variable multiple times before the next render {/*updating-the-same-state-variable-multiple-times-before-the-next-render*/}
 
 It is an uncommon use case, but if you would like to update the same state variable multiple times before the next render, instead of passing the *next state value* like `setNumber(number + 1)`, you can pass a *function* that calculates the next state based on the previous one in the queue, like `setNumber(n => n + 1)`. It is a way to tell React to "do something with the state value" instead of just replacing it.
 
@@ -127,7 +127,7 @@ When you call `useState` during the next render, React goes through the queue. T
 React stores `3` as the final result and returns it from `useState`.
 
 This is why clicking "+3" in the above example correctly increments the value by 3.
-### What happens if you update state after replacing it {#what-happens-if-you-update-state-after-replacing-it}
+### What happens if you update state after replacing it {/*what-happens-if-you-update-state-after-replacing-it*/}
 
 What about this event handler? What do you think `number` will be in the next render?
 
@@ -181,7 +181,7 @@ React stores `6` as the final result and returns it from `useState`.
 
 > You may have noticed that `setState(x)` actually works like `setState(n => x)`, but `n` is unused!
 
-### What happens if you replace state after updating it {#what-happens-if-you-replace-state-after-updating-it}
+### What happens if you replace state after updating it {/*what-happens-if-you-replace-state-after-updating-it*/}
 
 Let's try one more example. What do you think `number` will be in the next render?
 
@@ -244,7 +244,7 @@ To summarize, here's how you can think of what you're passing to the `setNumber`
 
 After the event handler completes, React will trigger a re-render. During the re-render, React will process the queue. Updater functions run during rendering, so **updater functions must be [pure](/learn/keeping-components-pure)** and only *return* the result. Don't try to set state from inside of them or run other side effects. In Strict Mode, React will run each updater function twice (but discard the second result) to help you find mistakes.
 
-### Naming conventions {#naming-conventions}
+### Naming conventions {/*naming-conventions*/}
 
 It's common to name the updater function argument by the first letters of the corresponding state variable:
 
@@ -268,7 +268,7 @@ If you prefer more verbose code, another common convention is to repeat the full
 
 <Challenges>
 
-### Fix a request counter {#fix-a-request-counter}
+### Fix a request counter {/*fix-a-request-counter*/}
 
 You're working on an art marketplace app that lets the user submit multiple orders for an art item at the same time. Each time the user presses the "Buy" button, the "Pending" counter should increase by one. After three seconds, the "Pending" counter should decrease, and the "Completed" counter should increase.
 
@@ -364,7 +364,7 @@ This ensures that when you increment or decrement a counter, you do it in relati
 
 </Solution>
 
-### Implement the state queue yourself {#implement-the-state-queue-yourself}
+### Implement the state queue yourself {/*implement-the-state-queue-yourself*/}
 
 In this challenge, you will reimplement a tiny part of React from scratch! It's not as hard as it sounds.
 

--- a/beta/src/pages/learn/react-developer-tools.md
+++ b/beta/src/pages/learn/react-developer-tools.md
@@ -8,7 +8,7 @@ Use React Developer Tools to inspect React [components](/learn/your-first-compon
 
 </Intro>
 
-## Browser extension {#browser-extension}
+## Browser extension {/*browser-extension*/}
 
 The easiest way to debug websites built with React is to install the React Developer Tools browser extension. It is available for several popular browsers:
 
@@ -20,7 +20,7 @@ Now, if you visit a website **built with React**, you will see the _Components_ 
 
 ![React Developer Tools extension](/images/docs/react-devtools-extension.png)
 
-### Safari and other browsers {#safari-and-other-browsers}
+### Safari and other browsers {/*safari-and-other-browsers*/}
 For other browsers (for example, Safari), install the [`react-devtools`](https://www.npmjs.com/package/react-devtools) npm package:
 ```bash
 # Yarn
@@ -46,7 +46,7 @@ Reload your website in the browser now to view it in developer tools.
 
 ![React Developer Tools standalone](/images/docs/react-devtools-standalone.png)
 
-## Mobile (React Native) {#mobile-react-native}
+## Mobile (React Native) {/*mobile-react-native*/}
 React Developer Tools can be used to inspect apps built with [React Native](https://reactnative.dev/) as well.
 
 The easiest way to use React Developer Tools is to install it globally:

--- a/beta/src/pages/learn/reacting-to-input-with-state.md
+++ b/beta/src/pages/learn/reacting-to-input-with-state.md
@@ -16,7 +16,7 @@ React uses a declarative way to manipulate the UI. Instead of manipulating indiv
 
 </YouWillLearn>
 
-## How declarative UI compares to imperative {#how-declarative-ui-compares-to-imperative}
+## How declarative UI compares to imperative {/*how-declarative-ui-compares-to-imperative*/}
 
 When you design UI interactions, you probably think about how the UI *changes* in response to user actions. Consider a form that lets the user submit an answer:
 
@@ -139,7 +139,7 @@ In React, you don't directly manipulate the UI--meaning you don't enable, disabl
 
 <Illustration src="/images/docs/illustrations/i_declarative-ui-programming.png" alt="In a car driven by React, a passenger asks to be taken to a specific place on the map. React figures out how to do that." />
 
-## Thinking about UI declaratively {#thinking-about-ui-declaratively}
+## Thinking about UI declaratively {/*thinking-about-ui-declaratively*/}
 
 You've seen how to implement a form imperatively above. To better understand how to think in React, you'll walk through reimplementing this UI in React below:
 
@@ -149,7 +149,7 @@ You've seen how to implement a form imperatively above. To better understand how
 4. **Remove** any non-essential state variables
 5. **Connect** the event handlers to set the state
 
-### Step 1: Identify your component's different visual states {#step-1-identify-your-components-different-visual-states}
+### Step 1: Identify your component's different visual states {/*step-1-identify-your-components-different-visual-states*/}
 
 In computer science, you may hear about a ["state machine"](https://en.wikipedia.org/wiki/Finite-state_machine) being in one of several “states”. If you work with a designer, you may have seen mockups for different "visual states". React stands at the intersection of design and computer science, so both of these ideas are sources of inspiration.
 
@@ -309,7 +309,7 @@ Pages like this are often called "living styleguides" or "storybooks."
 
 </DeepDive>
 
-### Step 2: Determine what triggers those state changes {#step-2-determine-what-triggers-those-state-changes}
+### Step 2: Determine what triggers those state changes {/*step-2-determine-what-triggers-those-state-changes*/}
 
 <IllustrationBlock title="Types of inputs">
   <Illustration caption="Human inputs" alt="A finger." src="/images/docs/illustrations/i_inputs1.png" />
@@ -334,7 +334,7 @@ To help visualize this flow, try drawing each state on paper as a labeled circle
 
 <img alt="A flow chart showing states and transitions between them" src="/images/docs/sketches/s_flow-chart.jpg" />
 
-### Step 3: Represent the state in memory with `useState` {#step-3-represent-the-state-in-memory-with-usestate}
+### Step 3: Represent the state in memory with `useState` {/*step-3-represent-the-state-in-memory-with-usestate*/}
 
 Next you'll need to represent the visual states of your component in memory with [`useState`](/reference/usestate). Simplicity is key: each piece of state is a "moving piece", and **you want as few "moving pieces" as possible**. More complexity leads to more bugs!
 
@@ -359,7 +359,7 @@ const [isError, setIsError] = useState(false);
 
 Your first idea likely won't be the best, but that's ok--refactoring state is a part of the process!
 
-### Step 4: Remove any non-essential state variables {#step-4-remove-any-non-essential-state-variables}
+### Step 4: Remove any non-essential state variables {/*step-4-remove-any-non-essential-state-variables*/}
 
 You want to avoid duplication in the state content so you're only tracking what is essential. Spending a little time on refactoring your state structure will make your components easier to understand, reduce duplication, and avoid unintended meanings. Your goal is to **prevent the cases where the state in memory doesn't represent any valid UI that you'd want a user to see.** (For example, you never want to show an error message and disable the input at the same time, or the user won't be able to correct the error!)
 
@@ -385,7 +385,7 @@ These three variables are a good enough representation of this form's state. How
 
 </DeepDive>
 
-### Step 5: Connect the event handlers to set state {#step-5-connect-the-event-handlers-to-set-state}
+### Step 5: Connect the event handlers to set state {/*step-5-connect-the-event-handlers-to-set-state*/}
 
 Lastly, create event handlers to set the state variables. Below is the final form, with all event handlers wired up:
 
@@ -487,7 +487,7 @@ Although this code is longer than the original imperative example, it is much le
 
 <Challenges>
 
-### Add and remove a CSS class {#add-and-remove-a-css-class}
+### Add and remove a CSS class {/*add-and-remove-a-css-class*/}
 
 Make it so that clicking on the picture *removes* the `background--active` CSS class from the outer `<div>`, but *adds* the `picture--active` class to the `<img>`. Clicking the background again should restore the original CSS classes.
 
@@ -685,7 +685,7 @@ Keep in mind that if two different JSX chunks describe the same tree, their nest
 
 </Solution>
 
-### Profile editor {#profile-editor}
+### Profile editor {/*profile-editor*/}
 
 Here is a small form implemented with plain JavaScript and DOM. Play with it to understand its behavior:
 
@@ -887,7 +887,7 @@ Compare this solution to the original imperative code. How are they different?
 
 </Solution>
 
-### Refactor the imperative solution without React {#refactor-the-imperative-solution-without-react}
+### Refactor the imperative solution without React {/*refactor-the-imperative-solution-without-react*/}
 
 Here is the original sandbox from the previous challenge, written imperatively without React:
 

--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -17,7 +17,7 @@ When you want a component to "remember" some information, but you don't want tha
 
 </YouWillLearn>
 
-## Adding a ref to your component {#adding-a-ref-to-your-component}
+## Adding a ref to your component {/*adding-a-ref-to-your-component*/}
 
 You can add a ref to your component by importing the `useRef` Hook from React:
 
@@ -73,7 +73,7 @@ The ref points to a number, but, like [state](/learn/state-a-components-memory),
 
 Note that **the component doesn't re-render with every increment.** Like state, refs are retained by React between re-renders. However, setting state re-renders a component. Changing a ref does not!
 
-## Example: building a stopwatch {#example-building-a-stopwatch}
+## Example: building a stopwatch {/*example-building-a-stopwatch*/}
 
 You can combine refs and state in a single component. For example, let's make a stopwatch that the user can start or stop by pressing a button. In order to display how much time has passed since the user pressed "Start," you will need to keep track of when the Start button was pressed and what the current time is. **This information is used for rendering, so you'll keep it in state:**
 
@@ -169,7 +169,7 @@ export default function Stopwatch() {
 
 When a piece of information is used for rendering, keep it in state. When a piece of information is only needed by event handlers and changing it doesn't require a re-render, using a ref may be more efficient.
 
-## Differences between refs and state {#differences-between-refs-and-state}
+## Differences between refs and state {/*differences-between-refs-and-state*/}
 
 Perhaps you're thinking refs seem less "strict" than state—you can mutate them instead of always having to use a state setting function, for instance. But in most cases, you'll want to use state. Refs are an "escape hatch" you won't need often. Here's how state and refs compare:
 
@@ -251,7 +251,7 @@ React provides a built-in version of `useRef` because it is common enough in pra
 
 </DeepDive>
 
-## When to use refs {#when-to-use-refs}
+## When to use refs {/*when-to-use-refs*/}
 
 Typically, you will use a ref when your component needs to "step outside" React and communicate with external APIs—often a browser API that won't impact the appearance of the component. Here are a few of these rare situations:
 
@@ -261,7 +261,7 @@ Typically, you will use a ref when your component needs to "step outside" React 
 
 If your component needs to store some value, but it doesn't impact the rendering logic, choose refs.
 
-## Best practices for refs {#best-practices-for-refs}
+## Best practices for refs {/*best-practices-for-refs*/}
 
 Following these principles will make your components more predictable:
 
@@ -279,7 +279,7 @@ This is because **the ref itself is a regular JavaScript object,** and so it beh
 
 You also don't need to worry about [avoiding mutation](/learn/updating-objects-in-state) when you work with a ref. As long as the object you're mutating isn't used for rendering, React doesn't care what you do with the ref or its contents.
 
-## Refs and the DOM {#refs-and-the-dom}
+## Refs and the DOM {/*refs-and-the-dom*/}
 
 You can point a ref to any value. However, the most common use case for a ref is to access a DOM element. For example, this is handy if you want to focus an input programmatically. When you pass a ref to a `ref` attribute in JSX, like `<div ref={myRef}>`, React will put the corresponding DOM element into `myRef.current`. You can read more about this in [Manipulating the DOM with Refs](/learn/manipulating-the-dom-with-refs).
 
@@ -298,7 +298,7 @@ You can point a ref to any value. However, the most common use case for a ref is
 
 <Challenges>
 
-### Fix a broken chat input {#fix-a-broken-chat-input}
+### Fix a broken chat input {/*fix-a-broken-chat-input*/}
 
 Type a message and click "Send". You will notice there is a three second delay before you see the "Sent!" alert. During this delay, you can see an "Undo" button. Click it. This "Undo" button is supposed to stop the "Sent!" message from appearing. It does this by calling [`clearTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout) for the timeout ID saved during `handleSend`. However, even after "Undo" is clicked, the "Sent!" message still appears. Find why it doesn't work, and fix it.
 
@@ -409,7 +409,7 @@ export default function Chat() {
 </Solution>
 
 
-### Fix a component failing to re-render {#fix-a-component-failing-to-re-render}
+### Fix a component failing to re-render {/*fix-a-component-failing-to-re-render*/}
 
 This button is supposed to toggle between showing "On" and "Off". However, it always shows "Off". What is wrong with this code? Fix it.
 
@@ -459,7 +459,7 @@ export default function Toggle() {
 
 </Solution>
 
-### Fix debouncing {#fix-debouncing}
+### Fix debouncing {/*fix-debouncing*/}
 
 In this example, all button click handlers are ["debounced"](https://redd.one/blog/debounce-vs-throttle). To see what this means, press one of the buttons. Notice how the message appears a second later. If you press the button while waiting for the message, the timer will reset. So if you keep clicking the same button fast many times, the message won't appear until a second *after* you stop clicking. Debouncing lets you delay some action until the user "stops doing things".
 
@@ -576,7 +576,7 @@ button { display: block; margin: 10px; }
 
 </Solution>
 
-### Read the latest state {#read-the-latest-state}
+### Read the latest state {/*read-the-latest-state*/}
 
 In this example, after you press "Send", there is a small delay before the message is shown. Type "hello", press Send, and then quickly edit the input again. Despite your edits, the alert would still show "hello" (which was the value of state [at the time](/learn/state-as-a-snapshot#state-over-time) the button was clicked).
 

--- a/beta/src/pages/learn/render-and-commit.md
+++ b/beta/src/pages/learn/render-and-commit.md
@@ -29,14 +29,14 @@ Imagine that your components are cooks in the kitchen, assembling tasty dishes f
   <Illustration caption="Commit" alt="React delivers the Card to the user at their table." src="/images/docs/illustrations/i_render-and-commit3.png" />
 </IllustrationBlock>
 
-## Step 1: Trigger a render {#step-1-trigger-a-render}
+## Step 1: Trigger a render {/*step-1-trigger-a-render*/}
 
 There are two reasons for a component to render:
 
 1. It's the component's **initial render.**
 2. The component's **state has been updated.**
 
-### Initial render {#initial-render}
+### Initial render {/*initial-render*/}
 
 When your app starts, you need to trigger the initial render. Frameworks and sandboxes sometimes hide this code, but it's done by calling `ReactDOM.render` with your root component and the target DOM node:
 
@@ -67,7 +67,7 @@ export default function Image() {
 
 Try commenting out the `ReactDOM.render` call and see the component disappear!
 
-### Re-renders when state updates {#re-renders-when-state-updates}
+### Re-renders when state updates {/*re-renders-when-state-updates*/}
 
 Once the component has been initially rendered, you can trigger further renders by updating its state with [`setState`](reference/setstate). Updating your component's state automatically queues a render. (You can imagine these as a restaurant guest ordering tea, dessert, and all sorts of things after putting in their first order, depending on the state of their thirst or hunger.)
 
@@ -77,7 +77,7 @@ Once the component has been initially rendered, you can trigger further renders 
   <Illustration caption="...render!" alt="The Card Chef gives React the pink Card." src="/images/docs/illustrations/i_rerender3.png" />
 </IllustrationBlock>
 
-## Step 2: React renders your components {#step-2-react-renders-your-components}
+## Step 2: React renders your components {/*step-2-react-renders-your-components*/}
 
 After you trigger a render, React calls your components to figure out what to display on screen. **"Rendering" is React calling your components.**
 
@@ -148,7 +148,7 @@ The default behavior of rendering all components nested within the updated compo
 
 </DeepDive>
 
-## Step 3: React commits changes to the DOM {#step-3-react-commits-changes-to-the-dom}
+## Step 3: React commits changes to the DOM {/*step-3-react-commits-changes-to-the-dom*/}
 
 After rendering (calling) your components, React will modify the DOM. 
 
@@ -196,7 +196,7 @@ export default function App() {
 </Sandpack>
 
 This works because during this last step, React only updates the content of `<h1>` with the new `time`. It sees that the `<input>` appears in the JSX in the same place as last time, so React doesn't touch the `<input>`—or its `value`!
-## Epilogue: Browser paint {#epilogue-browser-paint}
+## Epilogue: Browser paint {/*epilogue-browser-paint*/}
 
 After rendering is done and React updated the DOM, the browser will repaint the screen. Although this process is known as "browser rendering", we'll refer to it as "painting" to avoid confusion in the rest of these docs.
 

--- a/beta/src/pages/learn/rendering-lists.md
+++ b/beta/src/pages/learn/rendering-lists.md
@@ -16,7 +16,7 @@ You will often want to display multiple similar components from a collection of 
 
 </YouWillLearn>
 
-## Rendering data from arrays {#rendering-data-from-arrays}
+## Rendering data from arrays {/*rendering-data-from-arrays*/}
 
 Say that you have a list of content.
 
@@ -85,7 +85,7 @@ li { margin-bottom: 10px; }
 
 </Sandpack>
 
-## Filtering arrays of items {#filtering-arrays-of-items}
+## Filtering arrays of items {/*filtering-arrays-of-items*/}
 
 This data can be structured even more.
 
@@ -254,7 +254,7 @@ Arrow functions containing `=> {` are said to have a ["block body"](https://deve
 
 </Gotcha>
 
-## Keeping list items in order with `key` {#keeping-list-items-in-order-with-key}
+## Keeping list items in order with `key` {/*keeping-list-items-in-order-with-key*/}
 
 If you open any of the sandboxes above in a new tab, you'll see an error in the console:
 
@@ -385,19 +385,19 @@ Fragments disappear from the DOM, so this will produce a flat list of `<h1>`, `<
 
 </DeepDive>
 
-### Where to get your `key` {#where-to-get-your-key}
+### Where to get your `key` {/*where-to-get-your-key*/}
 
 Different sources of data provide different sources of keys:
 
 * **Data from a database:** If your data is coming from a database, you can use the database keys/IDs, which are unique by nature.
 * **Locally generated data:** If your data is generated and persisted locally (e.g. notes in a note-taking app), use an incrementing counter or a package like [`uuid`](https://www.npmjs.com/package/uuid) when creating items.
 
-### Rules of keys {#rules-of-keys}
+### Rules of keys {/*rules-of-keys*/}
 
 * **Keys must be unique among siblings.** However, it’s okay to use the same keys for JSX nodes in _different_ arrays.
 * **Keys must not change** or that defeats their purpose! Don't generate them while rendering.
 
-### Why does React need keys? {#why-does-react-need-keys}
+### Why does React need keys? {/*why-does-react-need-keys*/}
 
 Imagine that files on your desktop didn't have names. Instead, you'd refer to them by their order -- the first file, the second file, and so on. You could get used to it, but once you delete a file, it would get confusing. The second file would become the first file, the third file would be the second file, and so on.
 
@@ -428,7 +428,7 @@ On this page you learned:
 
 <Challenges>
 
-### Splitting a list in two {#splitting-a-list-in-two}
+### Splitting a list in two {/*splitting-a-list-in-two*/}
 
 This example shows a list of all people.
 
@@ -870,7 +870,7 @@ img { width: 100px; height: 100px; border-radius: 50%; }
 
 </Solution>
 
-### Nested lists in one component {#nested-lists-in-one-component}
+### Nested lists in one component {/*nested-lists-in-one-component*/}
 
 Make a list of recipes from this array! For each recipe in the array, display its title as an `<h2>` and list its ingredients in a `<ul>`.
 
@@ -964,7 +964,7 @@ Each of the `recipes` already includes an `id` field, so that's what the outer l
 
 </Solution>
 
-### Extracting a list item component {#extracting-a-list-item-component}
+### Extracting a list item component {/*extracting-a-list-item-component*/}
 
 This `RecipeList` component contains two nested `map` calls. To simplify it, extract a `Recipe` component from it which will accept `id`, `name`, and `ingredients` props. Where do you place the outer `key` and why?
 
@@ -1072,7 +1072,7 @@ Here, `<Recipe {...recipe} key={recipe.id} />` is a syntax shortcut saying "pass
 
 </Solution>
 
-### List with a separator {#list-with-a-separator}
+### List with a separator {/*list-with-a-separator*/}
 
 This example renders a famous haiku by Katsushika Hokusai, with each line wrapped in a `<p>` tag. Your job is to insert an `<hr />` separator between each paragraph. Your resulting structure should look like this:
 

--- a/beta/src/pages/learn/responding-to-events.md
+++ b/beta/src/pages/learn/responding-to-events.md
@@ -16,7 +16,7 @@ React lets you add event handlers to your JSX. Event handlers are your own funct
 
 </YouWillLearn>
 
-## Adding event handlers {#adding-event-handlers}
+## Adding event handlers {/*adding-event-handlers*/}
 
 To add an event handler, you will first define a function and then [pass it as a prop](/learn/passing-props-to-a-component) to the appropriate JSX tag. For example, here is a button that doesn't do anything yet:
 
@@ -130,7 +130,7 @@ In both cases, what you want to pass is a function:
 
 </Gotcha>
 
-### Reading props in event handlers {#reading-props-in-event-handlers}
+### Reading props in event handlers {/*reading-props-in-event-handlers*/}
 
 Because event handlers are declared inside of a component, they have access to the component's props. Here is a button that, when clicked, shows an alert with its `message` prop:
 
@@ -167,7 +167,7 @@ button { margin-right: 10px; }
 
 This lets these two buttons show different messages. Try changing the messages passed to them.
 
-### Passing event handlers as props {#passing-event-handlers-as-props}
+### Passing event handlers as props {/*passing-event-handlers-as-props*/}
 
 Often you'll want the parent component to specify a child's event handler. Consider buttons: depending on where you're using a `Button` component, you might want to execute a different function—perhaps one plays a movie and another uploads an image. 
 
@@ -229,7 +229,7 @@ Finally, your `Button` component accepts a prop called `onClick`. It passes that
 
 If you use a [design system](https://uxdesign.cc/everything-you-need-to-know-about-design-systems-54b109851969), it's common for components like buttons to contain styling but not specify behavior. Instead, components like `PlayButton` and `UploadButton` will pass event handlers down.
 
-### Naming event handler props {#naming-event-handler-props}
+### Naming event handler props {/*naming-event-handler-props*/}
 
 Built-in components like `<button>` and `<div>` only support [browser event names](/reference/reactdom-api) like `onClick`. However, when you're building your own components, you can name their event handler props any way that you like.
 
@@ -314,7 +314,7 @@ button { margin-right: 10px; }
 
 Notice how the `App` component does not need to know *what* `Toolbar` will do with `onPlayMovie` or `onUploadImage`. That's an implementation detail of the `Toolbar`. Here, `Toolbar` passes them down as `onClick` handlers to its `Button`s, but it could later also trigger them on a keyboard shortcut. Naming props after app-specific interactions like `onPlayMovie` gives you the flexibility to change how they're used later.
 
-## Event propagation {#event-propagation}
+## Event propagation {/*event-propagation*/}
 
 <!--
 // TODO illo
@@ -361,7 +361,7 @@ All events propagate in React except `onScroll`, which only works on the JSX tag
 
 </Gotcha>
 
-### Stopping propagation {#stopping-propagation}
+### Stopping propagation {/*stopping-propagation*/}
 
 Event handlers receive an **event object** as their only argument. By convention, it's usually called `e`, which stands for "event." You can use this object to read information about the event.
 
@@ -443,7 +443,7 @@ Capture events are useful for code like routers or analytics, but you probably w
 
 </DeepDive>
 
-### Passing handlers as alternative to propagation {#passing-handlers-as-alternative-to-propagation}
+### Passing handlers as alternative to propagation {/*passing-handlers-as-alternative-to-propagation*/}
 
 Notice how this click handler runs a line of code _and then_ calls the `onClick` prop passed by the parent:
 
@@ -464,7 +464,7 @@ You could add more code to this handler before calling the parent `onClick` even
 
 If you rely on propagation and it's difficult to trace which handlers execute and why, try this approach instead.
 
-### Preventing default behavior {#preventing-default-behavior}
+### Preventing default behavior {/*preventing-default-behavior*/}
 
 Some browser events have default behavior associated with them. For example, a `<form>` submit event, which happens when a button inside of it is clicked, will reload the whole page by default:
 
@@ -516,7 +516,7 @@ Don't confuse `e.stopPropagation()` and `e.preventDefault()`. They are both usef
 * [`e.stopPropagation()`](https://developer.mozilla.org/docs/Web/API/Event/stopPropagation) stops the event handlers attached to the tags above from firing.
 * [`e.preventDefault()` ](https://developer.mozilla.org/docs/Web/API/Event/preventDefault) prevents the default browser behavior for the few events that have it.
 
-## Can event handlers have side effects? {#can-event-handlers-have-side-effects}
+## Can event handlers have side effects? {/*can-event-handlers-have-side-effects*/}
 
 Absolutely! Event handlers are the best place for side effects.
 
@@ -540,7 +540,7 @@ Unlike rendering functions, event handlers don't need to be [pure](/learn/keepin
 
 <Challenges>
 
-### Fix an event handler {#fix-an-event-handler}
+### Fix an event handler {/*fix-an-event-handler*/}
 
 Clicking this button is supposed to switch the page background between white and black. However, nothing happens when you click it. Fix the problem. (Don't worry about the logic inside `handleClick`—that part is fine.)
 
@@ -621,7 +621,7 @@ export default function LightSwitch() {
 
 </Solution>
 
-### Wire up the events {#wire-up-the-events}
+### Wire up the events {/*wire-up-the-events*/}
 
 This `ColorSwitch` component renders a button. It's supposed to change the page color. Wire it up to the `onChangeColor` event handler prop it receives from the parent so that clicking the button changes the color.
 

--- a/beta/src/pages/learn/scaling-up-with-reducer-and-context.md
+++ b/beta/src/pages/learn/scaling-up-with-reducer-and-context.md
@@ -16,7 +16,7 @@ Reducers let you consolidate a component's state update logic. Context lets you 
 
 </YouWillLearn>
 
-## Combining a reducer with context {#combining-a-reducer-with-context}
+## Combining a reducer with context {/*combining-a-reducer-with-context*/}
 
 In this example from [the introduction to reducers](/learn/extracting-state-logic-into-a-reducer), the state is managed by a reducer. The reducer function contains all of the state update logic and is declared at the bottom of this file:
 
@@ -243,7 +243,7 @@ Here is how you can combine a reducer with context:
 2. **Put** state and dispatch into context.
 3. **Use** context anywhere in the tree.
 
-### Step 1: Create the context {#step-1-create-the-context}
+### Step 1: Create the context {/*step-1-create-the-context*/}
 
 The `useReducer` Hook returns the current `tasks` and the `dispatch` function that lets you update them:
 
@@ -454,7 +454,7 @@ ul, li { margin: 0; padding: 0; }
 
 Here, you're passing `null` as the default value to both contexts. The actual values will be provided by the `TaskBoard` component.
 
-### Step 2: Put state and dispatch into context {#step-2-put-state-and-dispatch-into-context}
+### Step 2: Put state and dispatch into context {/*step-2-put-state-and-dispatch-into-context*/}
 
 Now you can import both contexts in your `TaskBoard` component. Take the `tasks` and `dispatch` returned by `useReducer()` and [provide them](/learn/passing-data-deeply-with-context#step-3-provide-the-context) to the entire tree below:
 
@@ -675,7 +675,7 @@ ul, li { margin: 0; padding: 0; }
 
 In the next step, you will remove prop passing.
 
-### Step 3: Use context anywhere in the tree {#step-3-use-context-anywhere-in-the-tree}
+### Step 3: Use context anywhere in the tree {/*step-3-use-context-anywhere-in-the-tree*/}
 
 Now you don't need to pass the list of tasks or the event handlers down the tree:
 
@@ -903,7 +903,7 @@ ul, li { margin: 0; padding: 0; }
 
 **The state still "lives" in the top-level `TaskBoard` component, managed with `useReducer`.** But its `tasks` and `dispatch` are now available to every component below in the tree by importing and using these contexts.
 
-## Moving all wiring into a single file {#moving-all-wiring-into-a-single-file}
+## Moving all wiring into a single file {/*moving-all-wiring-into-a-single-file*/}
 
 You don't have to do this, but you could further declutter the components by moving both reducer and context into a single file. Currently, `TasksContext.js` contains only two context declarations:
 

--- a/beta/src/pages/learn/sharing-state-between-components.md
+++ b/beta/src/pages/learn/sharing-state-between-components.md
@@ -15,7 +15,7 @@ Sometimes, you want the state of two components to always change together. To do
 
 </YouWillLearn>
 
-## Lifting state up by example {#lifting-state-up-by-example}
+## Lifting state up by example {/*lifting-state-up-by-example*/}
 
 In this example, a parent `Accordion` component renders two separate `Panel`s:
 
@@ -87,7 +87,7 @@ This will allow the `Accordion` component to coordinate both `Panel`s and only e
 
 <img alt="On the left are two components each owning their own state values. On the right, they are the children of a parent component that owns both their state values." src="/images/docs/sketches/s_lifting-state-up.png" />
 
-### Step 1: Remove state from the child components {#step-1-remove-state-from-the-child-components}
+### Step 1: Remove state from the child components {/*step-1-remove-state-from-the-child-components*/}
 
 You will give control of the `Panel`'s `isActive` to its parent component. This means that the parent component will pass `isActive` to `Panel` as a prop instead. Start by **removing this line** from the `Panel` component:
 
@@ -103,7 +103,7 @@ function Panel({ title, children, isActive }) {
 
 Now the `Panel`'s parent component can *control* `isActive` by [passing it down as a prop](/learn/passing-props-to-a-component). Conversely, the `Panel` component now has *no control* over the value of `isActive`--it's now up to the parent component!
 
-### Step 2: Pass hardcoded data from the common parent {#step-2-pass-hardcoded-data-from-the-common-parent}
+### Step 2: Pass hardcoded data from the common parent {/*step-2-pass-hardcoded-data-from-the-common-parent*/}
 
 To lift state up, you must locate the closest common parent component of *both* of the child components that you want to coordinate:
 
@@ -160,7 +160,7 @@ h3, p { margin: 5px 0px; }
 
 Try editing the hardcoded `isActive` values in the `Accordion` component and see the result on the screen.
 
-### Step 3: Add state to the common parent {#step-3-add-state-to-the-common-parent}
+### Step 3: Add state to the common parent {/*step-3-add-state-to-the-common-parent*/}
 
 Lifting state up often changes the nature of what you're storing as state.
 
@@ -270,7 +270,7 @@ When writing a component, consider which information in it should be controlled 
 
 </DeepDive>
 
-## A single source of truth for each state {#a-single-source-of-truth-for-each-state}
+## A single source of truth for each state {/*a-single-source-of-truth-for-each-state*/}
 
 In a React application, many components will have their own state. Some state may "live" close to the leaf components (components at the bottom of the tree) like inputs. Other state may "live" closer to the top of the app. For example, even client-side routing libraries are usually implemented by storing the current route in the React state, and passing it down by props!
 
@@ -291,7 +291,7 @@ To see what this feels like in practice with a few more components, read [Thinki
 
 <Challenges>
 
-### Synced inputs {#synced-inputs}
+### Synced inputs {/*synced-inputs*/}
 
 These two inputs are independent. Make them stay in sync: editing one input should update the other input with the same text, and vice versa. 
 
@@ -397,7 +397,7 @@ label { display: block; }
 
 </Solution>
 
-### Filtering a list {#filtering-a-list}
+### Filtering a list {/*filtering-a-list*/}
 
 In this example, the `SearchBar` has its own `query` state that controls the text input. Its parent `FilterableList` component displays a `List` of items, but it doesn't take the search query into account.
 

--- a/beta/src/pages/learn/start-a-new-react-project.md
+++ b/beta/src/pages/learn/start-a-new-react-project.md
@@ -8,7 +8,7 @@ If you're learning React or considering adding it to an existing project, you ca
 
 </Intro>
 
-## Choose your own adventure {#choose-your-own-adventure}
+## Choose your own adventure {/*choose-your-own-adventure*/}
 
 React is a library that lets you organize UI code by breaking it apart into pieces called components. React doesn't take care of routing or data management. For these features, you'll want to use third-party libraries or write your own solutions. This means there are several ways to start a new React project:
 
@@ -17,7 +17,7 @@ React is a library that lets you organize UI code by breaking it apart into piec
 
 Whether you're just getting started, looking to build something big, or want to set up your own toolchain, this guide will set you on the right path.
 
-## Getting started with a React toolchain {#getting-started-with-a-react-toolchain}
+## Getting started with a React toolchain {/*getting-started-with-a-react-toolchain*/}
 
 If you're just getting started with React, we recommend [Create React App](https://create-react-app.dev/), the most popular way to try out React's features and a great way to build a new single-page, client-side application. Create React App is an unopinionated toolchain configured just for React. Toolchains help with things like:
 
@@ -48,7 +48,7 @@ For more information, [check out the official guide](https://create-react-app.de
 
 > Create React App doesn't handle backend logic or databases; it just creates a frontend build pipeline. This means you can use it with any backend you want. But if you're looking for more features like routing and server-side logic, read on!
 
-### Other options {#other-options}
+### Other options {/*other-options*/}
 
 Create React App is great to get started working with React, but if you'd like an even lighter toolchain, you might try one of these other popular toolchains:
 
@@ -56,18 +56,18 @@ Create React App is great to get started working with React, but if you'd like a
 * [Parcel](https://parceljs.org/)
 * [Snowpack](https://www.snowpack.dev/tutorials/react)
 
-## Building with React and a framework {#building-with-react-and-a-framework}
+## Building with React and a framework {/*building-with-react-and-a-framework*/}
 
 If you're looking to start a bigger, production-ready project, [Next.js](https://nextjs.org/) is a great place to start. Next.js is a popular, lightweight framework for static and server‑rendered applications built with React. It comes pre-packaged with features like routing, styling, and server-side rendering, getting your project up and running quickly. 
 
 [Get started building with Next.js](https://nextjs.org/docs/getting-started) with the official guide.
 
-### Other options {#other-options-1}
+### Other options {/*other-options-1*/}
 
 * [Gatsby](https://www.gatsbyjs.org/) lets you generate static websites with React with GraphQL.
 * [Razzle](https://razzlejs.org/) is a server-rendering framework that doesn't require any configuration, but offers more flexibility than Next.js.
 
-## Custom toolchains {#custom-toolchains}
+## Custom toolchains {/*custom-toolchains*/}
 
 You may prefer to create and configure your own toolchain. A JavaScript build toolchain typically consists of:
 

--- a/beta/src/pages/learn/state-a-components-memory.md
+++ b/beta/src/pages/learn/state-a-components-memory.md
@@ -17,7 +17,7 @@ Components often need to change what's on the screen as a result of an interacti
 
 </YouWillLearn>
 
-## When a regular variable isn’t enough {#when-a-regular-variable-isnt-enough}
+## When a regular variable isn’t enough {/*when-a-regular-variable-isnt-enough*/}
 
 Here's a component that renders a sculpture image. Clicking the "Next" button should show the next sculpture by changing the `index` to `1`, then `2`, and so on. However, this **won't work** (you can try it!):
 
@@ -166,7 +166,7 @@ The [`useState`](/reference/usestate) Hook provides those two things:
 1. A **state variable** to retain the data between renders.
 2. A **state setter function** to update the variable and trigger React to render the component again.
 
-## Adding a state variable {#adding-a-state-variable}
+## Adding a state variable {/*adding-a-state-variable*/}
 
 To add a state variable, import `useState` from React at the top of the file:
 
@@ -331,7 +331,7 @@ button {
 
 </Sandpack>
 
-### Meet your first Hook {#meet-your-first-hook}
+### Meet your first Hook {/*meet-your-first-hook*/}
 
 In React, `useState`, as well as any other function starting with "`use`," is called a **Hook**.
 
@@ -345,7 +345,7 @@ State is just one of those features, but you will meet the other Hooks later.
 
 </Gotcha>
 
-### Anatomy of `useState` {#anatomy-of-usestate}
+### Anatomy of `useState` {/*anatomy-of-usestate*/}
 
 When you call [`useState`](/reference/usestate), you are telling React that you want this component to remember something:
 
@@ -375,7 +375,7 @@ const [index, setIndex] = useState(0);
 3. **Your component's second render.** React still sees `useState(0)`, but because React *remembers* that you set `index` to `1`, it returns `[1, setIndex]` instead.
 4. And so on!
 
-## Giving a component multiple state variables {#giving-a-component-multiple-state-variables}
+## Giving a component multiple state variables {/*giving-a-component-multiple-state-variables*/}
 
 You can have as many state variables of as many types as you like in one component. This component has two state variables, a number `index` and a boolean `showMore` that's toggled when you click "Show details":
 
@@ -722,7 +722,7 @@ You don't have to understand it to use React, but you might find this a helpful 
 
 </DeepDive>
 
-## State is isolated and private {#state-is-isolated-and-private}
+## State is isolated and private {/*state-is-isolated-and-private*/}
 
 State is local to a component instance on the screen. In other words, **if you render the same component twice, each copy will have completely isolated state!** Changing one of them will not affect the other.
 
@@ -907,7 +907,7 @@ What if you wanted both galleries to keep their states in sync? The right way to
 
 <Challenges>
 
-### Complete the gallery {#complete-the-gallery}
+### Complete the gallery {/*complete-the-gallery*/}
 
 When you press "Next" on the last sculpture, the code crashes. Fix the logic to prevent the crash. You may do this by adding extra logic to event handler or by disabling the button when the action is not possible.
 
@@ -1217,7 +1217,7 @@ Notice how `hasPrev` and `hasNext` are used *both* for the returned JSX and insi
 
 </Solution>
 
-### Fix stuck form inputs {#fix-stuck-form-inputs}
+### Fix stuck form inputs {/*fix-stuck-form-inputs*/}
 
 When you type into the input fields, nothing appears. It's like the input values are "stuck" with empty strings. The `value` of the first `<input>` is set to always match the `firstName` variable, and the `value` for the second `<input>` is set to always match the `lastName` variable. This is correct. Both inputs have `onChange` event handlers, which try to update the variables based on the latest user input (`e.target.value`). However, the variables don't seem to "remember" their values between re-renders. Fix this by using state variables instead.
 
@@ -1319,7 +1319,7 @@ h1 { margin-top: 10px; }
 
 </Solution>
 
-### Fix a crash {#fix-a-crash}
+### Fix a crash {/*fix-a-crash*/}
 
 Here is a small form that is supposed to let the user leave some feedback. When the feedback is submitted, it's supposed to display a thank-you message. However, it crashes with an error message saying "Rendered fewer hooks than expected". Can you spot the mistake and fix it?
 
@@ -1441,7 +1441,7 @@ In general, these types of mistakes are caught by the [`eslint-plugin-react-hook
 
 </Solution>
 
-### Remove unnecessary state {#remove-unnecessary-state}
+### Remove unnecessary state {/*remove-unnecessary-state*/}
 
 When the button is clicked, this example should ask for the user's name and then display an alert greeting them. You tried to use state to keep the name, but for some reason it always shows "Hello, !".
 

--- a/beta/src/pages/learn/state-as-a-snapshot.md
+++ b/beta/src/pages/learn/state-as-a-snapshot.md
@@ -17,7 +17,7 @@ State variables might look like regular JavaScript variables that you can read a
 
 </YouWillLearn>
 
-## Setting state triggers renders {#setting-state-triggers-renders}
+## Setting state triggers renders {/*setting-state-triggers-renders*/}
 
 You might think of your user interface as changing directly in response to the user input like a click. This may feel intuitive if you've been [storyboarding](https://wikipedia.org/wiki/Storyboard) your designs and interactions:
 
@@ -77,7 +77,7 @@ Let's take a closer look at the relationship between state and rendering.
 
 <Illustration alt="State living in React; React gets a setUpdate; in the re-render, React passes a snapshot of the state value into the component." src="/images/docs/illustrations/i_ui-snapshot.png" />
 
-## Rendering takes a snapshot in time {#rendering-takes-a-snapshot-in-time}
+## Rendering takes a snapshot in time {/*rendering-takes-a-snapshot-in-time*/}
 
 ["Rendering"](/learn/render-and-commit#step-2-react-renders-your-components) means that React is calling your component, which is a function. The JSX you return from that function is like a snapshot of the UI in time. Its props, event handlers, and local variables were all calculated **using its state at the time of the render.**
 
@@ -180,7 +180,7 @@ For the next render, `number` is `1`, so *that render's* click handler looks lik
 
 This is why clicking the button again will set the counter to `2`, then to `3` on the next click, and so on.
 
-## State over time {#state-over-time}
+## State over time {/*state-over-time*/}
 
 Well, that was fun. Try to guess what clicking this button will alert:
 
@@ -333,7 +333,7 @@ But what if you wanted to read the latest state before a re-render? You'll want 
 
 <Challenges>
 
-### Implement a traffic light {#implement-a-traffic-light}
+### Implement a traffic light {/*implement-a-traffic-light*/}
 
 Here is a crosswalk light component that toggles on when the button is pressed:
 

--- a/beta/src/pages/learn/thinking-in-react.md
+++ b/beta/src/pages/learn/thinking-in-react.md
@@ -8,7 +8,7 @@ React can change how you think about the designs you look at and the apps you bu
 
 </Intro>
 
-## Start with the mockup {#start-with-the-mockup}
+## Start with the mockup {/*start-with-the-mockup*/}
 
 Imagine that you already have a JSON API and a mockup from a designer.
 
@@ -31,7 +31,7 @@ The mockup looks like this:
 
 To implement a UI in React, you will usually follow the same five steps.
 
-## Step 1: Break the UI into a component hierarchy {#step-1-break-the-ui-into-a-component-hierarchy}
+## Step 1: Break the UI into a component hierarchy {/*step-1-break-the-ui-into-a-component-hierarchy*/}
 
 Start by drawing boxes around every component and subcomponent in the mockup and naming them. If you work with a designer, they may have already named these components in their design tool. Check in with them!
 
@@ -71,7 +71,7 @@ Now that you've identified the components in the mockup, arrange them into a hie
         * `ProductCategoryRow`
         * `ProductRow`
 
-## Step 2: Build a static version in React {#step-2-build-a-static-version-in-react}
+## Step 2: Build a static version in React {/*step-2-build-a-static-version-in-react*/}
 
 Now that you have your component hierarchy, it's time to implement your app. The most straightforward approach is to build a version that renders the UI from your data model without adding any interactivity... yet! It's often easier to build the static version first and then add interactivity separately. Building a static version requires a lot of typing and no thinking, but adding interactivity requires a lot of thinking and not a lot of typing.
 
@@ -205,7 +205,7 @@ At this point, you should not be using any state values. That’s for the next s
 
 </Gotcha>
 
-## Step 3: Find the minimal but complete representation of UI state {#step-3-find-the-minimal-but-complete-representation-of-ui-state}
+## Step 3: Find the minimal but complete representation of UI state {/*step-3-find-the-minimal-but-complete-representation-of-ui-state*/}
 
 To make the UI interactive, you need to let users change your underlying data model. You will use *state* for this.
 
@@ -246,7 +246,7 @@ Props and state are different, but they work together. A parent component will o
 
 </DeepDive>
 
-## Step 4: Identify where your state should live {#step-4-identify-where-your-state-should-live}
+## Step 4: Identify where your state should live {/*step-4-identify-where-your-state-should-live*/}
 
 After identifying your app’s minimal state data, you need to identify which component is responsible for changing this state, or *owns* the state. Remember: React uses one-way data flow, passing data down the component hierarchy from parent to child component. It may not be immediately clear which component should own what state. This can be challenging if you’re new to this concept, but you can figure it out by following these steps!
 
@@ -450,7 +450,7 @@ function SearchBar({ filterText, inStockOnly }) {
 
 Refer to the [Managing State](/learn/managing-state) to dive deeper into how React uses state and how you can organize your app with it.
 
-## Step 5: Add inverse data flow {#step-5-add-inverse-data-flow}
+## Step 5: Add inverse data flow {/*step-5-add-inverse-data-flow*/}
 
 Currently your app renders correctly with props and state flowing down the hierarchy. But to change the state according to user input, you will need to support data flowing the other way: the form components deep in the hierarchy need to update the state in `FilterableProductTable`. 
 
@@ -634,6 +634,6 @@ td {
 
 You can learn all about handling events and updating state in the [Adding Interactivity](/learn/adding-interactivity) section.
 
-## Where to go from here {#where-to-go-from-here}
+## Where to go from here {/*where-to-go-from-here*/}
 
 This was a very brief introduction to how to think about building components and applications with React. You can [start a React project](/learn/installation) right now or [dive deeper on all the syntax](/learn/describing-the-ui) used in this tutorial.

--- a/beta/src/pages/learn/updating-arrays-in-state.md
+++ b/beta/src/pages/learn/updating-arrays-in-state.md
@@ -16,7 +16,7 @@ Arrays are another type of mutable JavaScript objects you can store in state and
 
 </YouWillLearn>
 
-## Updating arrays without mutation {#updating-arrays-without-mutation}
+## Updating arrays without mutation {/*updating-arrays-without-mutation*/}
 
 In JavaScript, arrays are just another kind of object. [Like with objects](/learn/updating-objects-in-state), **you should treat arrays in React state as read-only**. This means that you shouldn't reassign items inside an array like `arr[0] = 'bird'`, and you also shouldn't use methods that mutate the array, such as `push()` and `pop()`.
 
@@ -44,7 +44,7 @@ In React, you will be using `slice` (no `p`!) a lot more often because you don't
 
 </Gotcha>
 
-### Adding to an array {#adding-to-an-array}
+### Adding to an array {/*adding-to-an-array*/}
 
 `push()` will mutate an array, which you don't want:
 
@@ -154,7 +154,7 @@ setArtists([
 
 In this way, spread can do the job of both `push()` by adding to the end of an array and `unshift()` by adding to the beginning of an array. Try it in the sandbox above!
 
-### Removing from an array {#removing-from-an-array}
+### Removing from an array {/*removing-from-an-array*/}
 
 The easiest way to remove an item from an array is to *filter it out*. In other words, you will produce a new array that will not contain that item. To do this, use the `filter` method, for example:
 
@@ -210,7 +210,7 @@ setArtists(
 
 Here, `artists.filter(s => s.id !== artist.id)` means "create an array that consists of those `artists` whose IDs are different from `artist.id`." In other words, each artist's "Delete" button will filter _that_ artist out of the array, and then request a re-render with the resulting array. Note that `filter` does not modify the original array.
 
-### Transforming an array {#transforming-an-array}
+### Transforming an array {/*transforming-an-array*/}
 
 If you want to change some or all items of the array, you can use `map()` to create a **new** array. The function you will pass to `map` can decide what to do with each item, based on its data or its index (or both).
 
@@ -278,7 +278,7 @@ body { height: 300px; }
 
 </Sandpack>
 
-### Replacing items in an array {#replacing-items-in-an-array}
+### Replacing items in an array {/*replacing-items-in-an-array*/}
 
 It is particularly common to want to replace one or more items in an array. Assignments like `arr[0] = 'bird'` are mutating the original array, so instead you'll want to use `map` for this as well.
 
@@ -332,7 +332,7 @@ button { margin: 5px; }
 
 </Sandpack>
 
-### Inserting into an array {#inserting-into-an-array}
+### Inserting into an array {/*inserting-into-an-array*/}
 
 Sometimes, you may want to insert an item at a particular position that's neither at the beginning nor at the end. To do this, you can use the `...` array spread operator together with the `slice()` method. The `slice()` method lets you cut a "slice" of the array. To insert an item, you will create an array that spreads the slice _before_ the insertion point, then the new item, and then the rest of the original array.
 
@@ -396,7 +396,7 @@ button { margin-left: 5px; }
 
 </Sandpack>
 
-### Making other changes to an array {#making-other-changes-to-an-array}
+### Making other changes to an array {/*making-other-changes-to-an-array*/}
 
 There are some things you can't do with the spread operator and non-mutating methods like `map()` and `filter()` alone. For example, you may want to reverse or sort an array. The JavaScript `reverse()` and `sort()` methods are mutating the original array, so you can't use them directly.
 
@@ -454,7 +454,7 @@ setList(nextList);
 
 Although `nextList` and `list` are two different arrays, **`nextList[0]` and `list[0]` point to the same object**. So by changing `nextList[0].seen`, you are also changing `list[0].seen`. This is a state mutation, which you should avoid! You can solve this issue in a similar way to [updating nested JavaScript objects](docs/updating-objects-in-state#updating-a-nested-object)--by copying individual items you want to change instead of mutating them. Here's how.
 
-## Updating objects inside arrays {#updating-objects-inside-arrays}
+## Updating objects inside arrays {/*updating-objects-inside-arrays*/}
 
 Objects are not _really_ located "inside" arrays. They might appear to be "inside" in code, but each object in an array is a separate value, to which the array "points". This is why you need to be careful when changing nested fields like `list[0]`. Another person's artwork list may point to the same element of the array!
 
@@ -657,7 +657,7 @@ function ItemList({ artworks, onToggle }) {
 
 In general, **you should only mutate objects that you have just created.** If you were inserting a *new* artwork, you could mutate it, but if you're dealing with something that's already in state, you need to make a copy.
 
-### Write concise update logic with Immer {#write-concise-update-logic-with-immer}
+### Write concise update logic with Immer {/*write-concise-update-logic-with-immer*/}
 
 Updating nested arrays without mutation can get a little bit repetitive. [Just as with objects](/learn/updating-objects-in-state#write-concise-update-logic-with-immer):
 
@@ -792,7 +792,7 @@ Behind the scenes, Immer always constructs the next state from scratch according
 
 <Challenges>
 
-### Update an item in the shopping cart {#update-an-item-in-the-shopping-cart}
+### Update an item in the shopping cart {/*update-an-item-in-the-shopping-cart*/}
 
 Fill in the `handleIncreaseClick` logic so that pressing "+" increases the corresponding number:
 
@@ -919,7 +919,7 @@ button { margin: 5px; }
 
 </Solution>
 
-### Remove an item from the shopping cart {#remove-an-item-from-the-shopping-cart}
+### Remove an item from the shopping cart {/*remove-an-item-from-the-shopping-cart*/}
 
 This shopping cart has a working "+" button, but the "–" button doesn't do anything. You need to add an event handler to it so that pressing it decreases the `count` of the corresponding product. If you press "–" when the count is 1, the product should automatically get removed from the cart. Make sure it never shows 0.
 
@@ -1080,7 +1080,7 @@ button { margin: 5px; }
 
 </Solution>
 
-### Fix the mutations using non-mutative methods {#fix-the-mutations-using-non-mutative-methods}
+### Fix the mutations using non-mutative methods {/*fix-the-mutations-using-non-mutative-methods*/}
 
 In this example, all of the event handlers in `App.js` use mutation. As a result, editing and deleting todos doesn't work. Rewrite `handleAddTodo`, `handleChangeTodo`, and `handleDeleteTodo` to use the non-mutative methods:
 
@@ -1413,7 +1413,7 @@ ul, li { margin: 0; padding: 0; }
 </Solution>
 
 
-### Fix the mutations using Immer {#fix-the-mutations-using-immer}
+### Fix the mutations using Immer {/*fix-the-mutations-using-immer*/}
 
 This is the same example as in the previous challenge. This time, fix the mutations by using Immer. For your convenience, `useImmer` is already imported, so you need to change the `todos` state variable to use it.
 

--- a/beta/src/pages/learn/updating-objects-in-state.md
+++ b/beta/src/pages/learn/updating-objects-in-state.md
@@ -17,7 +17,7 @@ State can hold any kind of JavaScript value, including objects. But you shouldn'
 
 </YouWillLearn>
 
-## What's a mutation? {#whats-a-mutation}
+## What's a mutation? {/*whats-a-mutation*/}
 
 You can store any kind of JavaScript value in state.
 
@@ -47,7 +47,7 @@ position.x = 5;
 
 However, although objects in React state are technically mutable, you should treat them **as if** they were immutable--like numbers, booleans, and strings. Instead of mutating them, you should always replace them.
 
-## Treat state as read-only {#treat-state-as-read-only}
+## Treat state as read-only {/*treat-state-as-read-only*/}
 
 In other words, you should **treat any JavaScript object that you put into state as read-only.**
 
@@ -197,7 +197,7 @@ Mutation is only a problem when you change *existing* objects that are already i
 
 </DeepDive>  
 
-## Copying objects with the spread syntax {#copying-objects-with-the-spread-syntax}
+## Copying objects with the spread syntax {/*copying-objects-with-the-spread-syntax*/}
 
 In the previous example, the `position` object is always created fresh from the current cursor position. But often, you will want to include *existing* data as a part of the new object you're creating. For example, you may want to update *only one* field in a form, but keep the previous values for all other fields.
 
@@ -441,7 +441,7 @@ Here, `e.target.name` refers to the `name` property given to the `<input>` DOM e
 
 </DeepDive>
 
-## Updating a nested object {#updating-a-nested-object}
+## Updating a nested object {/*updating-a-nested-object*/}
 
 Consider a nested object structure like this:
 
@@ -644,7 +644,7 @@ If you were to mutate `obj3.artwork.city`, it would affect both `obj2.artwork.ci
 
 </DeepDive>  
 
-### Write concise update logic with Immer {#write-concise-update-logic-with-immer}
+### Write concise update logic with Immer {/*write-concise-update-logic-with-immer*/}
 
 If your state is deeply nested, you might want to consider [flattening it](/learn/choosing-the-state-structure#avoid-deeply-nested-state). But, if you don't want to change your state structure, you might prefer a shortcut to nested spreads. [Immer](https://github.com/immerjs/use-immer) is a popular library that lets you write using the convenient but mutating syntax and takes care of producing the copies for you. With Immer, the code you write looks like you are "breaking the rules" and mutating an object:
 
@@ -813,7 +813,7 @@ In practice, you can often "get away" with mutating state in React, but we stron
 
 <Challenges>
 
-### Fix incorrect state updates {#fix-incorrect-state-updates}
+### Fix incorrect state updates {/*fix-incorrect-state-updates*/}
 
 This form has a few bugs. Click the button that increases the score a few times. Notice that it does not increase. Then edit the first name, and notice that the score has suddenly "caught up" with your changes. Finally, edit the last name, and notice that the score has disappeared completely.
 
@@ -961,7 +961,7 @@ The problem with `handleLastNameChange` was that it did not copy the existing `.
 
 </Solution>
 
-### Find and fix the mutation {#find-and-fix-the-mutation}
+### Find and fix the mutation {/*find-and-fix-the-mutation*/}
 
 There is a draggable box on a static background. You can change the box's color using the select input.
 
@@ -1276,7 +1276,7 @@ select { margin-bottom: 10px; }
 
 </Solution>
 
-### Update an object with Immer {#update-an-object-with-immer}
+### Update an object with Immer {/*update-an-object-with-immer*/}
 
 This is the same buggy example as in the previous challenge. This time, fix the mutation by using Immer. For your convenience, `useImmer` is already imported, so you need to change the `shape` state variable to use it.
 

--- a/beta/src/pages/learn/writing-markup-with-jsx.md
+++ b/beta/src/pages/learn/writing-markup-with-jsx.md
@@ -16,7 +16,7 @@ JSX is a syntax extension for JavaScript that lets you write HTML-like markup in
 
 </YouWillLearn>
 
-## JSX: Putting markup into JavaScript {#jsx-putting-markup-into-javascript}
+## JSX: Putting markup into JavaScript {/*jsx-putting-markup-into-javascript*/}
 
 The Web has been built on HTML, CSS, and JavaScript. For many years, web developers kept content in HTML, design in CSS, and logic in JavaScript—often in separate files! Content was marked up inside HTML while the page's logic lived separately in JavaScript:
 
@@ -36,7 +36,7 @@ Each React component is a JavaScript function that may contain some markup that 
 
 </Note>
 
-## Converting HTML to JSX {#converting-html-to-jsx}
+## Converting HTML to JSX {/*converting-html-to-jsx*/}
 
 Suppose that you have some (perfectly valid) HTML:
 
@@ -102,9 +102,9 @@ Most of the times, React's on-screen error messages will help you find where the
 
 </Note>
 
-## The Rules of JSX {#the-rules-of-jsx}
+## The Rules of JSX {/*the-rules-of-jsx*/}
 
-### 1. Return a single root element {#1-return-a-single-root-element}
+### 1. Return a single root element {/*1-return-a-single-root-element*/}
 
 To return multiple elements from a component, **wrap them with a single parent tag**.
 
@@ -149,7 +149,7 @@ JSX looks like HTML, but under the hood it is transformed into plain JavaScript 
 
 </DeepDive>
 
-### 2. Close all the tags {#2-close-all-the-tags}
+### 2. Close all the tags {/*2-close-all-the-tags*/}
 
 JSX requires tags to be explicitly closed: self-closing tags like `<img>` must become `<img />`, and wrapping tags like `<li>oranges` must be written as `<li>oranges</li>`.
 
@@ -170,7 +170,7 @@ This is how Hedy Lamarr's image and list items look closed:
 </>
 ```
 
-### 3. camelCase <s>all</s> most of the things! {#3-camelcase-salls-most-of-the-things}
+### 3. camelCase <s>all</s> most of the things! {/*3-camelcase-salls-most-of-the-things*/}
 
 JSX turns into JavaScript and attributes written in JSX become keys of JavaScript objects. In your own components, you will often want to read those attributes into variables. But JavaScript has limitations on variable names. For example, their names can't contain dashes or be reserved words like `class`.
 
@@ -192,7 +192,7 @@ For historical reasons, [`aria-*`](https://developer.mozilla.org/docs/Web/Access
 
 </Gotcha>
 
-### Pro-tip: Use a JSX Converter {#pro-tip-use-a-jsx-converter}
+### Pro-tip: Use a JSX Converter {/*pro-tip-use-a-jsx-converter*/}
 
 Converting all these attributes in existing markup can be tedious! We recommend using a [converter](https://transform.tools/html-to-jsx) to translate your existing HTML and SVG to JSX. Converters are very useful in practice, but it's still worth understanding what is going on so that you can comfortably write JSX on your own.
 
@@ -240,7 +240,7 @@ Now you know why JSX exists and how to use it in components:
 
 <Challenges>
 
-### Convert some HTML to JSX {#convert-some-html-to-jsx}
+### Convert some HTML to JSX {/*convert-some-html-to-jsx*/}
 
 This HTML was pasted into a component, but it's not valid JSX. Fix it:
 

--- a/beta/src/pages/learn/your-first-component.md
+++ b/beta/src/pages/learn/your-first-component.md
@@ -16,7 +16,7 @@ Components are one of the core concepts of React. They are the foundation upon w
 
 </YouWillLearn>
 
-## Components: UI building blocks {#components-ui-building-blocks}
+## Components: UI building blocks {/*components-ui-building-blocks*/}
 
 On the Web, HTML lets us create rich structured documents with its built-in set of tags like `<h1>` and `<li>`:
 
@@ -53,7 +53,7 @@ Just like with HTML tags, you can compose, order and nest components to design w
 
 As your project grows, you will notice that many of your designs can be composed by reusing components you already wrote, speeding up your development. Our table of contents above could be added to any screen with `<TableOfContents />`! You can even jumpstart your project with the thousands of components shared by the React open source community like [Chakra UI](https://chakra-ui.com/) and [Material UI](https://material-ui.com/).
 
-## Defining a component {#defining-a-component}
+## Defining a component {/*defining-a-component*/}
 
 Traditionally when creating web pages, web developers marked up their content and then added interaction by sprinkling on some JavaScript. This worked great when interaction was a nice-to-have on the web. Now it is expected for many sites and all apps. React puts interactivity first while still using the same technology: **a React component is a JavaScript function that you can _sprinkle with markup_**. Here's what that looks like (you can edit the example below):
 
@@ -78,11 +78,11 @@ img { height: 200px; }
 
 And here's how to build a component:
 
-### Step 1: Export the component {#step-1-export-the-component}
+### Step 1: Export the component {/*step-1-export-the-component*/}
 
 The `export default` prefix is a [standard JavaScript syntax](https://developer.mozilla.org/docs/web/javascript/reference/statements/export) (not specific to React). It lets you mark the main function in a file so that you can later import it from other files. (More on importing in [Importing and Exporting Components](/learn/importing-and-exporting-components)!)
 
-### Step 2: Define the function {#step-2-define-the-function}
+### Step 2: Define the function {/*step-2-define-the-function*/}
 
 With `function Profile() { }` you define a JavaScript function with the name `Profile`.
 
@@ -92,7 +92,7 @@ React components are regular JavaScript functions, but **their names must start 
 
 </Gotcha>
 
-### Step 3: Add markup {#step-3-add-markup}
+### Step 3: Add markup {/*step-3-add-markup*/}
 
 The component returns an `<img />` tag with `src` and `alt` attributes. `<img />` is written like HTML, but it is actually JavaScript under the hood! This syntax is called [JSX](/learn/writing-markup-with-jsx), and it lets you embed markup inside JavaScript.
 
@@ -118,7 +118,7 @@ Without parentheses, any code on the lines after `return` [will be ignored](http
 
 </Gotcha>
 
-## Using a component {#using-a-component}
+## Using a component {/*using-a-component*/}
 
 Now that you've defined your `Profile` component, you can nest it inside other components. For example, you can export a `Gallery` component that uses multiple `Profile` components:
 
@@ -152,7 +152,7 @@ img { margin: 0 10px 10px 0; height: 90px; }
 
 </Sandpack>
 
-### What the browser sees {#what-the-browser-sees}
+### What the browser sees {/*what-the-browser-sees*/}
 
 Notice the difference in casing:
 
@@ -170,7 +170,7 @@ And `Profile` contains even more HTML: `<img />`. In the end, this is what the b
 </section>
 ```
 
-### Nesting and organizing components {#nesting-and-organizing-components}
+### Nesting and organizing components {/*nesting-and-organizing-components*/}
 
 Components are regular JavaScript functions, so you can keep multiple components in the same file. This is convenient when components are relatively small or tightly related to each other. If this file gets crowded, you can always move `Profile` to a separate file. You will learn how to do this shortly on the [page about imports](/learn/importing-and-exporting-components).
 
@@ -205,7 +205,7 @@ You've just gotten your first taste of React! Let's recap some key points.
 
 <Challenges>
 
-### Export the component {#export-the-component}
+### Export the component {/*export-the-component*/}
 
 This sandbox doesn't work because the root component is not exported:
 
@@ -257,7 +257,7 @@ You might be wondering why writing `export` alone is not enough to fix this exam
 
 </Solution>
 
-### Fix the return statement {#fix-the-return-statement}
+### Fix the return statement {/*fix-the-return-statement*/}
 
 Something isn't right about this `return` statement. Can you fix it?
 
@@ -324,7 +324,7 @@ img { height: 180px; }
 
 </Solution>
 
-### Spot the mistake {#spot-the-mistake}
+### Spot the mistake {/*spot-the-mistake*/}
 
 Something's wrong with how the `Profile` component is declared and used. Can you spot the mistake? (Try to remember how React distinguishes components from the regular HTML tags!)
 
@@ -396,7 +396,7 @@ img { margin: 0 10px 10px 0; }
 
 </Solution>
 
-### Your own component {#your-own-component}
+### Your own component {/*your-own-component*/}
 
 Write a component from scratch. You can give it any valid name and return any markup. If you're out of ideas, you can write a `Congratulations` component thats shows `<h1>Good job!</h1>`. Don't forget to export it!
 

--- a/beta/src/pages/reference/index.md
+++ b/beta/src/pages/reference/index.md
@@ -8,7 +8,7 @@ The React package contains all the APIs necessary to define and use [components]
 
 </Intro>
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 It is available as [`react`](https://www.npmjs.com/package/react) on npm. You can also [add React to the page as a `<script>` tag](/learn/add-react-to-a-website).
 
@@ -32,7 +32,7 @@ import * as React from 'react';
 
 If you use React on the web, you'll also need the same version of [ReactDOM](/api/reactdom).
 
-## Exports {#exports}
+## Exports {/*exports*/}
 
 <YouWillLearnCard title="useState" path="/reference/usestate">
 

--- a/beta/src/pages/reference/reactdom.md
+++ b/beta/src/pages/reference/reactdom.md
@@ -10,7 +10,7 @@ The ReactDOM package lets you render React components on a webpage.
 
 Typically, you will use ReactDOM at the top level of your app to display your components. You will either use it directly or a [framework](/learn/start-a-new-react-project#building-with-react-and-a-framework) may do it for you. Most of your components should *not* need to import this module.
 
-## Installation {#installation}
+## Installation {/*installation*/}
 
 <PackageImport>
 
@@ -32,11 +32,11 @@ import * as ReactDOM from 'react';
 
 You'll also need to install the same version of [React](/api/).
 
-## Browser Support {#browser-support}
+## Browser Support {/*browser-support*/}
 
 ReactDOM supports all popular browsers, including Internet Explorer 9 and above. [Some polyfills are required](http://todo%20link%20to%20js%20environment%20requirements/) for older browsers such as IE 9 and IE 10.
 
-## Exports {#exports}
+## Exports {/*exports*/}
 
 <YouWillLearnCard title="render" path="/reference/render">
 

--- a/beta/src/pages/reference/render.md
+++ b/beta/src/pages/reference/render.md
@@ -13,7 +13,7 @@ render(<App />, container, callback);
 
 </Intro>
 
-## Rendering the root component {#rendering-the-root-component}
+## Rendering the root component {/*rendering-the-root-component*/}
 
 To call `render`, you need a piece of JSX and a DOM container:
 
@@ -60,7 +60,7 @@ export default function App() {
 
 <br />
 
-## Rendering multiple roots {#rendering-multiple-roots}
+## Rendering multiple roots {/*rendering-multiple-roots*/}
 
 If you use ["sprinkles"](/learn/add-react-to-a-website) of React here and there, call `render` for each top-level piece of UI managed by React.
 
@@ -134,7 +134,7 @@ nav ul li { display: inline-block; margin-right: 20px; }
 
 <br />
 
-## Updating the rendered tree {#updating-the-rendered-tree}
+## Updating the rendered tree {/*updating-the-rendered-tree*/}
 
 You can call `render` more than once on the same DOM node. As long as the component tree structure matches up with what was previously rendered, React will [preserve the state](/learn/preserving-and-resetting-state). Notice how you can type in the input:
 
@@ -171,7 +171,7 @@ You can destroy the rendered tree with [`unmountComponentAtNode()`](TODO).
 
 <br />
 
-## When not to use it {#when-not-to-use-it}
+## When not to use it {/*when-not-to-use-it*/}
 
 * If your app uses server rendering and generates HTML on the server, use [`hydrate`](TODO) instead of `render`.
 * If your app is fully built with React, you shouldn't need to use `render` more than once. If you want to render something in a different part of the DOM tree (for example, a modal or a tooltip), use [`createPortal`](TODO) instead.
@@ -179,7 +179,7 @@ You can destroy the rendered tree with [`unmountComponentAtNode()`](TODO).
 <br />
 
 
-## Behavior in detail {#behavior-in-detail}
+## Behavior in detail {/*behavior-in-detail*/}
 
 The first time you call `render`, any existing DOM elements inside `container` are replaced. If you call `render` again, React will update the DOM as necessary to reflect the latest JSX. React will decide which parts of the DOM can be reused and which need to be recreated by ["matching it up"](/learn/preserving-and-resetting-state) with the previously rendered tree. Calling `render` repeatedly is similar to calling `setState`--in both cases, React avoids unnecessary DOM updates.
 

--- a/beta/src/pages/reference/usestate.md
+++ b/beta/src/pages/reference/usestate.md
@@ -12,7 +12,7 @@ const [state, setState] = useState(initialState);
 
 </Intro>
 
-## Using state {#using-state}
+## Using state {/*using-state*/}
 
 You can add state to your component in three steps:
 
@@ -82,7 +82,7 @@ export default function Counter() {
 
 <br />
 
-## Declaring a state variable {#declaring-a-state-variable}
+## Declaring a state variable {/*declaring-a-state-variable*/}
 
 You can declare multiple state variables in a component. You must declare them **at the top level of your component,** outside of any conditions or loops. This component declares state variables called `name` and `age`:
 
@@ -165,14 +165,14 @@ function handleClick() {
 
 <br />
 
-## When not to use it {#when-not-to-use-it}
+## When not to use it {/*when-not-to-use-it*/}
 
 * Don't use state when a regular variable works. State is only used to [persist information between re-renders](/learn/state-a-components-memory).
 * Don't add [redundant state](/learn/choosing-the-state-structure#avoid-redundant-state). If you can calculate something during render, you don't need state for it.
 
 <br />
 
-## Updating objects and arrays in state {#updating-objects-and-arrays-in-state}
+## Updating objects and arrays in state {/*updating-objects-and-arrays-in-state*/}
 
 You can hold objects and arrays in state, too. However, you should always *replace* objects in state rather than modify the existing ones. [Updating objects](/learn/updating-objects-in-state) and [updating arrays](/learn/updating-arrays-in-state) describe common patterns that help avoid bugs.
 
@@ -223,7 +223,7 @@ body { margin: 0; padding: 0; height: 250px; }
 
 <Recipes>
 
-### Image gallery {#image-gallery}
+### Image gallery {/*image-gallery*/}
 
 <Sandpack>
 
@@ -385,7 +385,7 @@ img { width: 120px; height: 120px; }
 
 <Solution />
 
-### Form with multiple fields {#form-with-multiple-fields}
+### Form with multiple fields {/*form-with-multiple-fields*/}
 
 <Sandpack>
 
@@ -451,7 +451,7 @@ input { margin-left: 5px; }
 
 <Solution />
 
-### Todo list {#todo-list}
+### Todo list {/*todo-list*/}
 
 <Sandpack>
 
@@ -618,7 +618,7 @@ ul, li { margin: 0; padding: 0; }
 
 <Solution />
 
-### Multiple selection {#multiple-selection}
+### Multiple selection {/*multiple-selection*/}
 
 <Sandpack>
 
@@ -723,9 +723,9 @@ label { width: 100%; padding: 5px; display: inline-block; }
 
 </Recipes>
 
-## Special cases {#special-cases}
+## Special cases {/*special-cases*/}
 
-### Passing the same value to `setState` {#passing-the-same-value-to-setstate}
+### Passing the same value to `setState` {/*passing-the-same-value-to-setstate*/}
 
 If you pass the current state to `setState`, React **will skip re-rendering the component**:
 
@@ -737,7 +737,7 @@ This is a performance optimization. React uses the [`Object.is()`](https://devel
 
 <br />
 
-### Passing an updater function to `setState` {#passing-an-updater-function-to-setstate}
+### Passing an updater function to `setState` {/*passing-an-updater-function-to-setstate*/}
 
 Instead of passing the next state itself, **you may pass a function to `setState`.** Such a function, like `c => c + 1` in this example, is called an "updater". React will call your updater during the next render to calculate the final state.
 
@@ -884,7 +884,7 @@ setState(() => myFunction);
 
 <br />
 
-### Passing an initializer function to `useState` {#passing-an-initializer-function-to-usestate}
+### Passing an initializer function to `useState` {/*passing-an-initializer-function-to-usestate*/}
 
 The initial state that you pass to `useState` as an argument is only used for the initial render. For next renders, this argument is ignored. If creating the initial state is expensive, it is wasteful to create and throw it away many times. **You can pass a function to `useState` to calculate the initial state.** React will only run it during the initialization.
 

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -881,7 +881,7 @@
   resolved "https://registry.yarnpkg.com/@types/github-slugger/-/github-slugger-1.3.0.tgz#16ab393b30d8ae2a111ac748a015ac05a1fc5524"
   integrity sha512-J/rMZa7RqiH/rT29TEVZO4nBoDP9XJOjnbbIofg7GQKs4JIduEO3WLpte+6WeUz/TcrXKlY+bM7FYrp8yFB+3g==
 
-"@types/hast@^2.0.0":
+"@types/hast@^2.0.0", "@types/hast@^2.3.2":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
   integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
@@ -1303,6 +1303,11 @@ bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2598,7 +2603,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-github-slugger@^1.3.0:
+github-slugger@^1.0.0, github-slugger@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
   integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
@@ -3203,6 +3208,11 @@ is-plain-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-plain-obj@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.0.0.tgz#06c0999fd7574edf5a906ba5644ad0feb3a84d22"
+  integrity sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -3600,6 +3610,11 @@ mdast-util-to-string@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
+mdast-util-to-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz#56c506d065fbf769515235e577b5a261552d56e9"
+  integrity sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==
 
 mdurl@^1.0.0:
   version "1.0.1"
@@ -4894,6 +4909,18 @@ remark-parse@8.0.3, remark-parse@^8.0.0:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
+remark-slug@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-7.0.1.tgz#9827ce6d6ee81ca82b79891b0e5931a8123ce63b"
+  integrity sha512-NRvYePr69LdeCkEGwL4KYAmq7kdWG5rEavCXMzUR4qndLoXHJAOLSUmPY6Qm4NJfKix7/EmgObyVaYivONAFhg==
+  dependencies:
+    "@types/hast" "^2.3.2"
+    "@types/mdast" "^3.0.0"
+    github-slugger "^1.0.0"
+    mdast-util-to-string "^3.0.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-4.0.0.tgz#76eb0e085295131c84748c8e43810159c5653ead"
@@ -5621,6 +5648,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+trough@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.0.2.tgz#94a3aa9d5ce379fc561f6244905b3f36b7458d96"
+  integrity sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==
+
 tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
@@ -5705,6 +5737,19 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
+unified@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.0.tgz#4e65eb38fc2448b1c5ee573a472340f52b9346fe"
+  integrity sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
+
 unified@^8.0.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.2.tgz#13ad58b4a437faa2751a4a4c6a16f680c500fff1"
@@ -5748,6 +5793,11 @@ unist-util-is@^4.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
   integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
 
+unist-util-is@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
+  integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
+
 unist-util-modify-children@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-2.0.0.tgz#9c9c30d4e32502aabb3fde10d7872a17c86801e2"
@@ -5781,6 +5831,13 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
+unist-util-stringify-position@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz#d517d2883d74d0daa0b565adc3d10a02b4a8cde9"
+  integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 unist-util-visit-children@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz#e8a087e58a33a2815f76ea1901c15dec2cb4b432"
@@ -5794,6 +5851,14 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
+unist-util-visit-parents@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz#44bbc5d25f2411e7dfc5cecff12de43296aa8521"
+  integrity sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
@@ -5802,6 +5867,15 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+unist-util-visit@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
+  integrity sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -5875,6 +5949,14 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
+vfile-message@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.0.2.tgz#db7eaebe7fecb853010f2ef1664427f52baf8f74"
+  integrity sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
 vfile@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
@@ -5884,6 +5966,16 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vfile@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.2.0.tgz#a32a646ff9251c274dbe8675644a39031025b369"
+  integrity sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 vm-browserify@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This website currently uses a custom (non-standard) syntax extension to markdown to add custom IDs to headings.
“Custom” is not really a correct term: almost all of them (except 3) match exactly what GitHub would slug for them.
The reason for their existence is i18n.

The syntax extension to add IDs to heading like so:

```
## Some heading {#some-heading}
```

Does not interfere with markdown, so it works pretty nicely there (though it’s not supported in many places).
But in MDX 2, support for expressions was added similar to how expressions work in JSX:

```
# Hello, {props.name}
```

…so you can probably see the problem there. Braces signal (JavaScript) expressions.
To solve that problem, this PR switches to using MDX/JSX comments as the last “child” in headings instead:

```
## Some heading {/*some-heading*/}
```

This PR is part of GH-4081. Externalized as this might be able to go faster than the other PR, in which case that PR would become much easier to review.

For reviewers:

* PR is giant. Almost all of it is automated from two scripts, so you don’t have to look through every file
* See the first commit, which fixes two unicode whitespace cases which do not match how proper markdown works
* review `beta/scripts/generateHeadingIds.js` and `beta/plugins/remark-header-custom-ids`. The rest is docs automated by them.

/cc @lex111


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
