### PR TITLE
small fixes to stopwatch codesandbox

### DIFF
--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -99,9 +99,9 @@ export default function Stopwatch() {
     setNow(Date.now());
 
     setInterval(() => {
-      // Update the current time every 100ms.
+      // Update the current time every 10ms.
       setNow(Date.now());
-    }, 100);
+    }, 10);
   }
 
   let secondsPassed = 0;
@@ -135,6 +135,10 @@ export default function Stopwatch() {
   const intervalRef = useRef(null);
 
   function handleStart() {
+    // Start counting, if not already.
+    if (intervalRef.current) {
+      return;
+    }
     setStartTime(Date.now());
     setNow(Date.now());
     intervalRef.current = setInterval(() => {
@@ -144,6 +148,7 @@ export default function Stopwatch() {
 
   function handleStop() {
     clearInterval(intervalRef.current);
+    intervalRef.current = null;
   }
 
   let secondsPassed = 0;

--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -99,9 +99,9 @@ export default function Stopwatch() {
     setNow(Date.now());
 
     setInterval(() => {
-      // Update the current time every 100ms.
+      // Update the current time every 10ms.
       setNow(Date.now());
-    }, 100);
+    }, 10);
   }
 
   let secondsPassed = 0;

--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -99,9 +99,9 @@ export default function Stopwatch() {
     setNow(Date.now());
 
     setInterval(() => {
-      // Update the current time every 10ms.
+      // Update the current time every 100ms.
       setNow(Date.now());
-    }, 10);
+    }, 100);
   }
 
   let secondsPassed = 0;
@@ -135,12 +135,10 @@ export default function Stopwatch() {
   const intervalRef = useRef(null);
 
   function handleStart() {
-    // Start counting, if not already.
-    if (intervalRef.current) {
-      return;
-    }
     setStartTime(Date.now());
     setNow(Date.now());
+
+    clearInterval(intervalRef.current);
     intervalRef.current = setInterval(() => {
       setNow(Date.now());
     }, 10);

--- a/beta/src/pages/learn/referencing-values-with-refs.md
+++ b/beta/src/pages/learn/referencing-values-with-refs.md
@@ -146,7 +146,6 @@ export default function Stopwatch() {
 
   function handleStop() {
     clearInterval(intervalRef.current);
-    intervalRef.current = null;
   }
 
   let secondsPassed = 0;


### PR DESCRIPTION
noticed that the explanation for the first stopwatch codesandbox mentions "update the time every 10 milliseconds" so just updated the codesandbox to reflect that

also there's a small bug (#4096 ) in the stopwatch codesandboxes where each call to `handleStart()` sets a new interval without checking if there's already one ongoing. 

ie: If the user accidentally double clicks the start button, they set two intervals for updating `now` every 10ms and then intervalRef only retains the second interval ID. Thus, it's impossible to actually stop the timer because `handleStop()` will only clear the latest set interval while the original one will keep executing.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
