### PR TITLE
chore: remove unused dep to fix lint warning

### DIFF
--- a/plugins/gatsby-transformer-home-example-code/gatsby-node.js
+++ b/plugins/gatsby-transformer-home-example-code/gatsby-node.js
@@ -3,7 +3,6 @@
  */
 
 const crypto = require('crypto');
-const path = require('path');
 
 const createContentDigest = obj =>
   crypto


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixes lint warning shown below

![path_unused](https://user-images.githubusercontent.com/68196762/142731604-1f66185b-588e-40bf-a013-eecfe51523df.JPG)

