### PR TITLE
Add check-all script for beta site

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -48,7 +48,7 @@ The documentation is divided into several sections with a different tone and pur
 ### Test the change
 
 1. If possible, test any visual changes in all latest versions of common browsers, on both desktop and mobile.
-2. Run `yarn check-all` from the `beta` folder. (This will run Prettier and ESLint)
+2. Run `yarn check-all` from the `beta` folder. (This will run Prettier, ESLint and validate Types.)
 
 ### Push it
 

--- a/beta/README.md
+++ b/beta/README.md
@@ -48,7 +48,7 @@ The documentation is divided into several sections with a different tone and pur
 ### Test the change
 
 1. If possible, test any visual changes in all latest versions of common browsers, on both desktop and mobile.
-1. Run `yarn check-all` from the `beta` folder. (This will run Prettier, ESLint, and Flow.)
+2. Run `yarn check-all` from the `beta` folder. (This will run Prettier and ESLint)
 
 ### Push it
 

--- a/beta/README.md
+++ b/beta/README.md
@@ -48,7 +48,7 @@ The documentation is divided into several sections with a different tone and pur
 ### Test the change
 
 1. If possible, test any visual changes in all latest versions of common browsers, on both desktop and mobile.
-2. Run `yarn check-all` from the `beta` folder. (This will run Prettier, ESLint and validate Types.)
+2. Run `yarn check-all` from the `beta` folder. (This will run Prettier, ESLint and validate types.)
 
 ### Push it
 

--- a/beta/package.json
+++ b/beta/package.json
@@ -17,7 +17,8 @@
     "ci-check": "npm-run-all prettier:diff --parallel lint tsc",
     "tsc": "tsc --noEmit",
     "start": "next start",
-    "postinstall": "is-ci || (cd .. && husky install beta/.husky)"
+    "postinstall": "is-ci || (cd .. && husky install beta/.husky)",
+    "check-all": "npm-run-all prettier lint"
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "^0.1.20",

--- a/beta/package.json
+++ b/beta/package.json
@@ -18,7 +18,7 @@
     "tsc": "tsc --noEmit",
     "start": "next start",
     "postinstall": "is-ci || (cd .. && husky install beta/.husky)",
-    "check-all": "npm-run-all prettier lint"
+    "check-all": "npm-run-all prettier lint:fix"
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "^0.1.20",

--- a/beta/package.json
+++ b/beta/package.json
@@ -18,7 +18,7 @@
     "tsc": "tsc --noEmit",
     "start": "next start",
     "postinstall": "is-ci || (cd .. && husky install beta/.husky)",
-    "check-all": "npm-run-all prettier lint:fix"
+    "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "^0.1.20",


### PR DESCRIPTION

We did not have a check-all script in the beta package.json so added that. also removed flow since we dont use it in beta.

`Run yarn check-all from the beta folder. (This will run Prettier, ESLint and flow)`
