### PR TITLE
fix(sandpack): improve memory usage

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "0.13.9-experimental.0",
+    "@codesandbox/sandpack-react": "0.13.9-experimental.5",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "0.13.9-experimental.5",
+    "@codesandbox/sandpack-react": "0.13.9-experimental.6",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "0.13.6-experimental.0",
+    "@codesandbox/sandpack-react": "0.13.9-experimental.0",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -79,22 +79,22 @@ export function Preview({
 
   React.useEffect(
     function bundlerListener() {
-      const unsubscribeListen = listen((message: any) => {
+      const unsubscribe = listen((message: any) => {
         if (message.type === 'resize') {
           setComputedAutoHeight(message.height);
         } else if (message.type === 'start') {
           if (message.firstLoad) {
             setIsReady(false);
           }
-        } else if (message.type === 'test') {
-          // Does it make sense that we're listening to "test" event?
-          // Not really. Does it cause less flicker than "done"? Yes.
+        } else if (message.type === 'done') {
           setIsReady(true);
         }
       }, clientId.current);
 
       return () => {
-        unsubscribeListen();
+        setIsReady(false);
+        setComputedAutoHeight(null);
+        unsubscribe();
       };
     },
     [status === 'idle']
@@ -184,7 +184,7 @@ export function Preview({
             <Error error={error} />
           </div>
         )}
-        <LoadingOverlay clientId={clientId.current} />
+        <LoadingOverlay clientId={clientId.current} loading={!isReady && iframeComputedHeight === null} />
       </div>
     </div>
   );

--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -46,6 +46,7 @@ export function Preview({
     errorScreenRegisteredRef,
     openInCSBRegisteredRef,
     loadingScreenRegisteredRef,
+    status,
   } = sandpack;
 
   if (
@@ -67,29 +68,37 @@ export function Preview({
   errorScreenRegisteredRef.current = true;
   loadingScreenRegisteredRef.current = true;
 
-  React.useEffect(() => {
+  React.useEffect(function createBundler() {
     const iframeElement = iframeRef.current!;
     registerBundler(iframeElement, clientId.current);
 
-    const unsub = listen((message: any) => {
-      if (message.type === 'resize') {
-        setComputedAutoHeight(message.height);
-      } else if (message.type === 'start') {
-        if (message.firstLoad) {
-          setIsReady(false);
-        }
-      } else if (message.type === 'test') {
-        // Does it make sense that we're listening to "test" event?
-        // Not really. Does it cause less flicker than "done"? Yes.
-        setIsReady(true);
-      }
-    }, clientId.current);
-
     return () => {
-      unsub();
       unregisterBundler(clientId.current);
     };
   }, []);
+
+  React.useEffect(
+    function bundlerListener() {
+      const unsubscribeListen = listen((message: any) => {
+        if (message.type === 'resize') {
+          setComputedAutoHeight(message.height);
+        } else if (message.type === 'start') {
+          if (message.firstLoad) {
+            setIsReady(false);
+          }
+        } else if (message.type === 'test') {
+          // Does it make sense that we're listening to "test" event?
+          // Not really. Does it cause less flicker than "done"? Yes.
+          setIsReady(true);
+        }
+      }, clientId.current);
+
+      return () => {
+        unsubscribeListen();
+      };
+    },
+    [status === 'idle']
+  );
 
   const viewportStyle = computeViewportSize('auto', 'portrait');
   const overrideStyle = error

--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -184,7 +184,10 @@ export function Preview({
             <Error error={error} />
           </div>
         )}
-        <LoadingOverlay clientId={clientId.current} loading={!isReady && iframeComputedHeight === null} />
+        <LoadingOverlay
+          clientId={clientId.current}
+          loading={!isReady && iframeComputedHeight === null}
+        />
       </div>
     </div>
   );

--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -128,7 +128,8 @@ function Sandpack(props: SandpackProps) {
         template="react"
         customSetup={{...setup, files: files}}
         autorun={autorun}
-        initMode="user-visible">
+        initMode="user-visible"
+        initModeObserverOptions={{rootMargin: '1400px 0px'}}>
         <CustomPreset
           isSingleFile={isSingleFile}
           showDevTools={showDevTools}

--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -127,7 +127,8 @@ function Sandpack(props: SandpackProps) {
       <SandpackProvider
         template="react"
         customSetup={{...setup, files: files}}
-        autorun={autorun}>
+        autorun={autorun}
+        initMode="user-visible">
         <CustomPreset
           isSingleFile={isSingleFile}
           showDevTools={showDevTools}

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -570,10 +570,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@0.13.9-experimental.0":
-  version "0.13.9-experimental.0"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.0.tgz#f595d252189a27a4a356f9721a9a500d6d44633c"
-  integrity sha512-RGp49NZ5M0Tik/YQRejlhvjRDD6kmg4V+b4AtVm7KiAclO1DYC5Hu0G/F7lKXkrduz/qbaZHN9lI1vpwPpvSrA==
+"@codesandbox/sandpack-react@0.13.9-experimental.5":
+  version "0.13.9-experimental.5"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.5.tgz#5466dcea355f446b7bb209ff2ad561ebc771fc49"
+  integrity sha512-Hxu3t9AlJfk6AuSxB7QmDAHYJu5obzaerB5lwbdgLvT9G9i9x6rgP+rhq8kcVaKhxEAu56KncYWQY9WEEWKDtQ==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -570,10 +570,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@0.13.9-experimental.5":
-  version "0.13.9-experimental.5"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.5.tgz#5466dcea355f446b7bb209ff2ad561ebc771fc49"
-  integrity sha512-Hxu3t9AlJfk6AuSxB7QmDAHYJu5obzaerB5lwbdgLvT9G9i9x6rgP+rhq8kcVaKhxEAu56KncYWQY9WEEWKDtQ==
+"@codesandbox/sandpack-react@0.13.9-experimental.6":
+  version "0.13.9-experimental.6"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.6.tgz#81ee72ad96b8dadf3626271a0ec9ae0694a421de"
+  integrity sha512-IOjuSPg28B/YkRGvbYCjDA45SHIBL2oF/1LBDkUisBHz1fbMTROYLLqdzNDP4yWgA9Ya9OgOgJe904i3pcE4YQ==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -562,18 +562,18 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
-"@codesandbox/sandpack-client@^0.13.6-experimental.0":
-  version "0.13.6-experimental.0"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.13.6-experimental.0.tgz#6688663f74f3f526f11691fb23cc3d1dea6d1f80"
-  integrity sha512-xEwGRg3ETgsmcGFYAcWSyYDRRxy5uwxQ2Zu0G82GXySZunLYwc5gQy+NOfgjnn6O+Tp7BW4ao6j3OGTZYqZOUg==
+"@codesandbox/sandpack-client@^0.13.9-experimental.0":
+  version "0.13.9-experimental.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.13.9-experimental.0.tgz#10eccbd0a3b35d3f46f9484405580c13a4693127"
+  integrity sha512-ktd6HWeQyErO91Sm5DxcLAc4BouUyUUNM1mKwWKzRkw6uUyt9IPbJNttnU0FH88gQxIwduEYVi7wEx/qn0AtMQ==
   dependencies:
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@0.13.6-experimental.0":
-  version "0.13.6-experimental.0"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.6-experimental.0.tgz#3070cd0e5b741284133b65e32d313b2aca0c5d50"
-  integrity sha512-QLP6wusM8COpFpmizUh1HGtNmKXDo8KNk5NSYSsCojeQyr9YFC1ye65MM6bMp5kXeF7c6kJFs9MulxpIckEbUQ==
+"@codesandbox/sandpack-react@0.13.9-experimental.0":
+  version "0.13.9-experimental.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.0.tgz#f595d252189a27a4a356f9721a9a500d6d44633c"
+  integrity sha512-RGp49NZ5M0Tik/YQRejlhvjRDD6kmg4V+b4AtVm7KiAclO1DYC5Hu0G/F7lKXkrduz/qbaZHN9lI1vpwPpvSrA==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"
@@ -589,10 +589,11 @@
     "@codemirror/matchbrackets" "^0.19.3"
     "@codemirror/state" "^0.19.6"
     "@codemirror/view" "^0.19.32"
-    "@codesandbox/sandpack-client" "^0.13.6-experimental.0"
+    "@codesandbox/sandpack-client" "^0.13.9-experimental.0"
     "@react-hook/intersection-observer" "^3.1.1"
     codesandbox-import-util-types "^2.2.3"
     codesandbox-import-utils "^2.2.3"
+    lodash.isequal "^4.5.0"
     react-devtools-inline "4.22.1"
     react-is "^17.0.2"
 


### PR DESCRIPTION
@gaearon This introduces a new prop to define the initialization strategy for the code editor and the preview components.

Current, there is no way to control how the code-editor and the preview components, which are the most expensive operations, are going to be initialized. As a result, this can be a problem for pages that contain multiple instances of Sandpack (eg: https://beta.reactjs.org/learn/describing-the-ui), which might lag the initialization of the page and even block the navigation between pages.

**Solution**
From now on, Sandpack supports a new prop called `initMode`, which expecting to receive one of the following values:

- `immediate`: it immediately mounts all components, such as the code-editor and the preview - this option might overload the memory usage and resource from the browser on a page with multiple instances;
- `lazy`: only initialize the components when the user is about to scroll them to the viewport and keep these components mounted until the user leaves the page - this is the default value;
- `user-visible`: only initialize the components when the user is about to scroll them to the viewport, but differently from `lazy`, this option unmounts those components once it's no longer in the viewport - destroying most of the Workers from the CodeSandbox bundler.

In this PR I set the Sandpack component to use the `user-visible` strategy, then we can measure the performance improvements (or not). 

**More improvements**
The code-editor should have been initialized in a more efficient way. Ideally, it could use the new `postTask scheduler` API, which unfortunately it's still not available. So, for while it uses a `setTimeout` to wrap the code-editor init, in order to postpone the most expensive operations.