### PR TITLE
Fix markdown comment breakage in community page

### DIFF
--- a/beta/src/pages/community/index.md
+++ b/beta/src/pages/community/index.md
@@ -18,9 +18,9 @@ Stack Overflow is a popular forum to ask code-level questions or if you're stuck
 
 <!--
 
-TODO: decide on the criteria for inclusion before uncommenting.
+TODO: decide on the criteria for inclusion before uncommenting. (Change Popular Discussion Forums into heading while un-commenting)
 
-## Popular Discussion Forums {/*popular-discussion-forums*/}
+Popular Discussion Forums
 
 There are many online forums which are a great place for discussion about best practices and application architecture as well as the future of React. If you have an answerable code-level question, Stack Overflow is usually a better fit.
 


### PR DESCRIPTION
<img width="917" alt="Screenshot 2021-11-26 at 10 13 37 AM" src="https://user-images.githubusercontent.com/32865581/143527949-cc552cb2-bf6f-47af-a3f3-aab93f98d857.png">

The text in the community page in the beta site seems to be broken since there was a heading inside the comment block.

Issue link: https://github.com/reactjs/reactjs.org/issues/4125

Fix: 
Converting the heading to normal text (Added note to convert to heading in todo).