### PR TITLE
[beta] add missing ending list tags

### DIFF
--- a/beta/src/pages/learn/describing-the-ui.md
+++ b/beta/src/pages/learn/describing-the-ui.md
@@ -135,9 +135,9 @@ export default function TodoList() {
       class="photo"
     >
     <ul>
-      <li>Invent new traffic lights
-      <li>Rehearse a movie scene
-      <li>Improve spectrum technology
+      <li>Invent new traffic lights</li>
+      <li>Rehearse a movie scene</li>
+      <li>Improve spectrum technology</li>
     </ul>
   );
 }

--- a/beta/src/pages/learn/writing-markup-with-jsx.md
+++ b/beta/src/pages/learn/writing-markup-with-jsx.md
@@ -48,9 +48,9 @@ Suppose that you have some (perfectly valid) HTML:
   class="photo"
 >
 <ul>
-    <li>Invent new traffic lights
-    <li>Rehearse a movie scene
-    <li>Improve the spectrum technology
+    <li>Invent new traffic lights</li>
+    <li>Rehearse a movie scene</li>
+    <li>Improve the spectrum technology</li>
 </ul>
 ```
 
@@ -80,9 +80,9 @@ export default function TodoList() {
       class="photo"
     >
     <ul>
-      <li>Invent new traffic lights
-      <li>Rehearse a movie scene
-      <li>Improve the spectrum technology
+      <li>Invent new traffic lights</li>
+      <li>Rehearse a movie scene</li>
+      <li>Improve the spectrum technology</li>
     </ul>
   );
 }


### PR DESCRIPTION
While reading the beta website's section "Writing Markup with JSX" I came across this: An example that states "Suppose that you have some (perfectly valid) HTML:" to have invalid HTML instead.

This request changes the following:
```
<h1>Hedy Lamarr's Todos</h1>
<img 
  src="https://i.imgur.com/yXOvdOSs.jpg" 
  alt="Hedy Lamarr" 
  class="photo"
>
<ul>
    <li>Invent new traffic lights
    <li>Rehearse a movie scene
    <li>Improve the spectrum technology
</ul>
```

into

```
<h1>Hedy Lamarr's Todos</h1>
<img 
  src="https://i.imgur.com/yXOvdOSs.jpg" 
  alt="Hedy Lamarr" 
  class="photo"
>
<ul>
    <li>Invent new traffic lights</li>
    <li>Rehearse a movie scene</li>
    <li>Improve the spectrum technology</li>
</ul>