### PR TITLE
Change "return statement" to "return keyword"

### DIFF
--- a/beta/src/pages/learn/your-first-component.md
+++ b/beta/src/pages/learn/your-first-component.md
@@ -102,7 +102,7 @@ Return statements can be written all on one line, as in this component:
 return <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />;
 ```
 
-But if your markup isn't all on the same line as the return statement, you must wrap it in a pair of parentheses like this:
+But if your markup isn't all on the same line as the `return` keyword, you must wrap it in a pair of parentheses like this:
 
 ```js
 return (


### PR DESCRIPTION
If I understand correctly, a return *statement* would refer to everything between `return` and `;` even if it spans multiple lines.

**EDIT:** And parentheses are not strictly necessary if you write the return statement like the following, so saying "you must wrap" may be too strong.

```jsx
return <div>
  <img />
</div>;
```