### PR TITLE
Removing the generate ids scripts for now since it affects translation

### DIFF
--- a/beta/.husky/pre-commit
+++ b/beta/.husky/pre-commit
@@ -2,7 +2,7 @@
 . "$(dirname "$0")/_/husky.sh"
 
 cd beta
-yarn generate-ids
-git add -u src/pages/**/*.md
+# yarn generate-ids
+# git add -u src/pages/**/*.md
 yarn prettier
 yarn lint:fix


### PR DESCRIPTION
https://github.com/reactjs/reactjs.org/issues/4135#issuecomment-983729301

To address automatic generation and auto addition of markdown files during commit removing the generate ids script for now.

Todo:
- [ ] Add a pre commit hook that throws error when the markdown does not have ids
