### PR TITLE
Generated missing ids

### DIFF
--- a/content/blog/2021-06-08-the-plan-for-react-18.md
+++ b/content/blog/2021-06-08-the-plan-for-react-18.md
@@ -15,7 +15,7 @@ The React team is excited to share a few updates:
 
 These updates are primarily aimed at maintainers of third-party libraries. If you’re learning, teaching, or using React to build user-facing applications, you can safely ignore this post. But you are welcome to follow the discussions in the React 18 Working Group if you're curious!
 
-## What’s coming in React 18
+## What’s coming in React 18 {#whats-coming-in-react-18}
 
 When it’s released, React 18 will include out-of-the-box improvements (like [automatic batching](https://github.com/reactwg/react-18/discussions/21)), new APIs (like [`startTransition`](https://github.com/reactwg/react-18/discussions/41)), and a [new streaming server renderer](https://github.com/reactwg/react-18/discussions/37) with built-in support for `React.lazy`.
 
@@ -23,13 +23,13 @@ These features are possible thanks to a new opt-in mechanism we’re adding in R
 
 If you've been following our research into the future of React (we don't expect you to!), you might have heard of something called “concurrent mode” or that it might break your app. In response to this feedback from the community, we’ve redesigned the upgrade strategy for gradual adoption. Instead of an all-or-nothing “mode”, concurrent rendering will only be enabled for updates triggered by one of the new features. In practice, this means **you will be able to adopt React 18 without rewrites and try the new features at your own pace.**
 
-## A gradual adoption strategy
+## A gradual adoption strategy {#a-gradual-adoption-strategy}
 
 Since concurrency in React 18 is opt-in, there are no significant out-of-the-box breaking changes to component behavior. **You can upgrade to React 18 with minimal or no changes to your application code, with a level of effort comparable to a typical major React release**. Based on our experience converting several apps to React 18, we expect that many users will be able to upgrade within a single afternoon.
 
 We successfully shipped concurrent features to tens of thousands of components at Facebook, and in our experience, we've found that most React components “just work” without additional changes. We're committed to making sure this is a smooth upgrade for the entire community, so today we're announcing the React 18 Working Group.
 
-## Working with the community
+## Working with the community {#working-with-the-community}
 
 We’re trying something new for this release: We've invited a panel of experts, developers, library authors, and educators from across the React community to participate in our [React 18 Working Group](https://github.com/reactwg/react-18) to provide feedback, ask questions, and collaborate on the release. We couldn't invite everyone we wanted to this initial, small group, but if this experiment works out, we hope there will be more in the future!
 
@@ -37,7 +37,7 @@ We’re trying something new for this release: We've invited a panel of experts,
 
 For more information on upgrading to React 18, or additional resources about the release, see the [React 18 announcement post](https://github.com/reactwg/react-18/discussions/4).
 
-## Accessing the React 18 Working Group
+## Accessing the React 18 Working Group {#accessing-the-react-18-working-group}
 
 Everyone can read the discussions in the [React 18 Working Group repo](https://github.com/reactwg/react-18).
 
@@ -45,13 +45,13 @@ Because we expect an initial surge of interest in the Working Group, only invite
 
 As always, you can submit bug reports, questions, and general feedback to our [issue tracker](https://github.com/facebook/react/issues).
 
-## How to try React 18 Alpha today
+## How to try React 18 Alpha today {#how-to-try-react-18-alpha-today}
 
 New alphas are [regularly published to npm using the `@alpha` tag](https://github.com/reactwg/react-18/discussions/9). These releases are built using the most recent commit to our main repo. When a feature or bugfix is merged, it will appear in an alpha the following weekday.
 
 There may be significant behavioral or API changes between alpha releases. Please remember that **alpha releases are not recommended for user-facing, production applications**.
 
-## Projected React 18 release timeline
+## Projected React 18 release timeline {#projected-react-18-release-timeline}
 
 We don't have a specific release date scheduled, but we expect it will take several months of feedback and iteration before React 18 is ready for most production applications.
 


### PR DESCRIPTION
Seems like there were no heading ids for the https://reactjs.org/blog/2021/06/08/the-plan-for-react-18.html page.

So ran `generate-ids`