### PR TITLE
minor fix for a title in Introducing Hooks

### DIFF
--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -60,7 +60,7 @@ Before we continue, note that Hooks are:
 
 Hooks solve a wide variety of seemingly unconnected problems in React that we've encountered over five years of writing and maintaining tens of thousands of components. Whether you're learning React, use it daily, or even prefer a different library with a similar component model, you might recognize some of these problems.
 
-### It's hard to reuse stateful logic between components {#its-hard-to-reuse-stateful-logic-between-components}
+### It leads to a "wrapper hell" to reuse stateful logic between components {#it-leads-to-a-wrapper-hell-to-reuse-stateful-logic-between-components}
 
 React doesn't offer a way to "attach" reusable behavior to a component (for example, connecting it to a store). If you've worked with React for a while, you may be familiar with patterns like [render props](/docs/render-props.html) and [higher-order components](/docs/higher-order-components.html) that try to solve this. But these patterns require you to restructure your components when you use them, which can be cumbersome and make code harder to follow. If you look at a typical React application in React DevTools, you will likely find a "wrapper hell" of components surrounded by layers of providers, consumers, higher-order components, render props, and other abstractions. While we could [filter them out in DevTools](https://github.com/facebook/react-devtools/pull/503), this points to a deeper underlying problem: React needs a better primitive for sharing stateful logic.
 


### PR DESCRIPTION
I don't see how hard in the title, and we can certainly reuse stateful logic between components using HOC / render props.
The section is more about readability. So I changed the title.