### PR TITLE
update reducers deep dive title for clarity

### DIFF
--- a/beta/src/pages/learn/extracting-state-logic-into-a-reducer.md
+++ b/beta/src/pages/learn/extracting-state-logic-into-a-reducer.md
@@ -366,7 +366,7 @@ If you're not yet comfortable with switch statements, using if/else is completel
 </Convention>
 
 
-<DeepDive title="Why are reducers called this way?">
+<DeepDive title="Why are they called reducers?">
 
 Although reducers can "reduce" the amount of code inside your component, they are actually named after the [`reduce()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) operation that you can perform on arrays.
 


### PR DESCRIPTION
Assuming I'm reading this section correctly, it's about where the name "reducer" comes from. This change makes that slightly clearer, as opposed to potentially referring to how a reducer function is called/invoked.

Before:
![Screen Shot 2021-12-07 at 10 17 36 AM](https://user-images.githubusercontent.com/10479615/145066392-3b25aa9b-bc5f-49fe-9068-163b487ee617.png)

After:
![Screen Shot 2021-12-07 at 10 17 44 AM](https://user-images.githubusercontent.com/10479615/145066413-a4384fae-f1cc-4537-b83b-1f30d10de043.png)


