### PR TITLE
[Beta] Fix the post layout dynamically

### DIFF
--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -67,7 +67,7 @@ function LayoutPost({meta, children}: LayoutPostProps) {
   return (
     <>
       <div className="w-full px-12">
-        <div className="h-full mx-auto max-w-4xl relative pt-16 w-full overflow-x-hidden">
+        <div className="lg:pt-0 pt-20 pl-0 lg:pl-80 2xl:px-80">
           <Seo title={meta.title} />
           <h1 className="mb-6 pt-8 text-4xl md:text-5xl font-bold leading-snug tracking-tight text-primary dark:text-primary-dark">
             {meta.title}


### PR DESCRIPTION
Fix the path: [ official React blog](https://beta.reactjs.org/blog)
We will see the page layout is wrong when the window width is not enough. 
![image](https://user-images.githubusercontent.com/24556310/145561232-2f817f2e-3ca2-4cb9-a143-b02a14538464.png)
Because the width is fixed by the container. 
So I change the style to something similar to the other page(LayoutLearn).