### PR TITLE
Switch eslint-plugin-prettier link to eslint-config-prettier

### DIFF
--- a/beta/src/pages/learn/editor-setup.md
+++ b/beta/src/pages/learn/editor-setup.md
@@ -50,4 +50,4 @@ Ideally, you should format your code on every save. VS Code has settings for thi
 4. In the search bar, type "format on save"
 5. Be sure the "format on save" option is ticked!
 
-> Prettier can sometimes conflict with other linters. But there's usually a way to get them to run nicely together. For instance, if you're using Prettier with ESLint, you can use [eslint-prettier](https://github.com/prettier/eslint-plugin-prettier) plugin to run prettier as an ESLint rule.
+> Prettier can sometimes conflict with other linters. But there's usually a way to get them to run nicely together. For instance, if you're using Prettier with ESLint, you can use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) plugin to disable ESLint rules that conflict with Prettier.


### PR DESCRIPTION
Switch from eslint-plugin-prettier to eslint-config-prettier as a way to make ESLint and Prettier coexist.

According to the [Prettier documentation](https://prettier.io/docs/en/integrating-with-linters.html), the use of eslint-plugin-prettier is generally not recommended.

It should be fine to use eslint-config-prettier as a way to resolve the conflict between ESLint and Pretter.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
