### PR TITLE
Fix: fixed out of bound of array

### DIFF
--- a/beta/src/pages/learn/index.md
+++ b/beta/src/pages/learn/index.md
@@ -280,9 +280,9 @@ import { sculptureList } from './data.js';
 export default function Gallery() {
   const [index, setIndex] = useState(0);
   const [showMore, setShowMore] = useState(false);
-
+  const {length: len} = sculptureList
   function handleNextClick() {
-    setIndex(index + 1);
+    setIndex((index + len + 1) % len);
   }
 
   function handleMoreClick() {


### PR DESCRIPTION
🐛 In the "Chapter 2 overview: Adding interactivity", If you press "next"13 times, the index is out of bounds of "sculptureList".