### PR TITLE
ci: Fix wrong workflow file name

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -54,7 +54,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         if: success() && github.event.number
         with:
-          workflow: bundle_analysis_upload.yml
+          workflow: analyze.yml
           branch: ${{ github.event.pull_request.base.ref }}
           name: bundle_analysis.json
           path: beta/.next/analyze/base/bundle


### PR DESCRIPTION
<s>(This may be broken because I have no means to test this locally)</s>

I believe the current CI setup for the beta site is broken because the workflow file refers to an old file name when it tries to download `bundle_analysis.json` from its base branch (normally `main`). This PR fixes this.

The base file currently used by the CI comes from the same old artifact (RunID: 1429732265, Artifact: 111304536) that happens to exist only in the main repository.

<img width="582" alt="image" src="https://user-images.githubusercontent.com/7779406/146706143-bc5038b8-d5bb-417a-b0dd-cd74827ab71b.png">

Currently, all CI runs are failing on translation forks because there is no previous run associated with `bundle_analysis_upload.yml`. I suspect the same problem will surface soon also in the main repository when the avobe-mentioned artifact expires after 90 days.

CC @gaearon 