### PR TITLE
Update react-router examples to use v6 version

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -178,7 +178,7 @@ Here's an example of how to setup route-based code splitting into your app using
 
 ```js
 import React, { Suspense, lazy } from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 const Home = lazy(() => import('./routes/Home'));
 const About = lazy(() => import('./routes/About'));
@@ -186,10 +186,11 @@ const About = lazy(() => import('./routes/About'));
 const App = () => (
   <Router>
     <Suspense fallback={<div>Loading...</div>}>
-      <Switch>
-        <Route exact path="/" component={Home}/>
-        <Route path="/about" component={About}/>
-      </Switch>
+      <Routes>
+        <Route path="/" index element={<Home />}>
+          <Route path="/about" element={<About />} />
+        </Route>
+      </Routes>
     </Suspense>
   </Router>
 );

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -187,9 +187,8 @@ const App = () => (
   <Router>
     <Suspense fallback={<div>Loading...</div>}>
       <Routes>
-        <Route path="/" index element={<Home />}>
-          <Route path="/about" element={<About />} />
-        </Route>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
       </Routes>
     </Suspense>
   </Router>


### PR DESCRIPTION
The exemple used to demonstrate Code-Splitting using react-router-dom is outdated. My suggestion is to use the new way of calling routes that was introduced in React Router v6

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
