### PR TITLE
Fix jsx example for string attributes

### DIFF
--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -92,7 +92,7 @@ function getGreeting(user) {
 You may use quotes to specify string literals as attributes:
 
 ```js
-const element = <div tabIndex="0"></div>;
+const element = <a href=""></a>;
 ```
 
 You may also use curly braces to embed a JavaScript expression in an attribute:

--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -92,7 +92,7 @@ function getGreeting(user) {
 You may use quotes to specify string literals as attributes:
 
 ```js
-const element = <a href=""></a>;
+const element = <a href="https://www.reactjs.org"> link </a>;
 ```
 
 You may also use curly braces to embed a JavaScript expression in an attribute:


### PR DESCRIPTION
https://reactjs.org/docs/introducing-jsx.html#specifying-attributes-with-jsx

tabIndex as string value is pretty misleading so replacing it with anchor tag (https://github.com/reactjs/reactjs.org/pull/3424#pullrequestreview-542695863)

Before:
```js
const element = <div tabIndex="0"></div>;
```

After:
```js
const element = <a href="https://www.reactjs.org"> link </a>;
```