### PR TITLE
Fix bug in keyed fragment example

### DIFF
--- a/content/docs/fragments.md
+++ b/content/docs/fragments.md
@@ -123,10 +123,12 @@ function Glossary(props) {
     <dl>
       {props.items.map(item => (
         // Without the `key`, React will fire a key warning
-        <React.Fragment key={item.id}>
-          <dt>{item.term}</dt>
-          <dd>{item.description}</dd>
-        </React.Fragment>
+        return (
+          <React.Fragment key={item.id}>
+            <dt>{item.term}</dt>
+            <dd>{item.description}</dd>
+          </React.Fragment>
+         )
       ))}
     </dl>
   );


### PR DESCRIPTION
I tried this out in my editor and without wrapping the Fragment in a return statement, the Fragment never renders in the DOM

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
