### PR TITLE
Update useTransition documentation to remove references to timeoutMS

### DIFF
--- a/content/docs/concurrent-mode-reference.md
+++ b/content/docs/concurrent-mode-reference.md
@@ -102,8 +102,6 @@ Note that `SuspenseList` only operates on the closest `Suspense` and `SuspenseLi
 ### `useTransition` {#usetransition}
 
 ```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-
 const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
 ```
 
@@ -116,11 +114,9 @@ The `useTransition` hook returns two values in an array.
 **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
 
 ```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-
 function App() {
   const [resource, setResource] = useState(initialResource);
-  const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
+  const [startTransition, isPending] = useTransition();
   return (
     <>
       <button
@@ -143,21 +139,11 @@ function App() {
 }
 ```
 
-In this code, we've wrapped our data fetching with `startTransition`. This allows us to start fetching the profile data right away, while deferring the render of the next profile page and its associated `Spinner` for 2 seconds (the time shown in `timeoutMs`).
+In this code, we've wrapped our data fetching with `startTransition`. This allows us to start fetching the profile data right away, while deferring the render of the next profile page and its associated `Spinner`.
 
 The `isPending` boolean lets React know that our component is transitioning, so we are able to let the user know this by showing some loading text on the previous profile page.
 
 **For an in-depth look at transitions, you can read [Concurrent UI Patterns](/docs/concurrent-mode-patterns.html#transitions).**
-
-#### useTransition Config {#usetransition-config}
-
-```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-```
-
-`useTransition` accepts an **optional Suspense Config** with a `timeoutMs`. This timeout (in milliseconds) tells React how long to wait before showing the next state (the new Profile Page in the above example).
-
-**Note: We recommend that you share Suspense Config between different modules.**
 
 
 ### `useDeferredValue` {#usedeferredvalue}

--- a/content/docs/concurrent-mode-reference.md
+++ b/content/docs/concurrent-mode-reference.md
@@ -102,21 +102,21 @@ Note that `SuspenseList` only operates on the closest `Suspense` and `SuspenseLi
 ### `useTransition` {#usetransition}
 
 ```js
-const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
+const [isPending, startTransition] = useTransition(SUSPENSE_CONFIG);
 ```
 
 `useTransition` allows components to avoid undesirable loading states by waiting for content to load before **transitioning to the next screen**. It also allows components to defer slower, data fetching updates until subsequent renders so that more crucial updates can be rendered immediately.
 
 The `useTransition` hook returns two values in an array.
-* `startTransition` is a function that takes a callback. We can use it to tell React which state we want to defer.
 * `isPending` is a boolean. It's React's way of informing us whether we're waiting for the transition to finish.
+* `startTransition` is a function that takes a callback. We can use it to tell React which state we want to defer.
 
 **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
 
 ```js
 function App() {
   const [resource, setResource] = useState(initialResource);
-  const [startTransition, isPending] = useTransition();
+  const [isPending, startTransition] = useTransition();
   return (
     <>
       <button


### PR DESCRIPTION
This PR deletes references to `timeoutMS` in the documentation about `useTransition`. For users starting to adopt React 18, it's very confusing that the official documentation still references a deleted config option. Here's the PR that disables `timeoutMS`: https://github.com/facebook/react/pull/19703