### PR TITLE
[Beta] Change "You will learn" for chapters

### DIFF
--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -135,8 +135,15 @@ function MathI({children}: {children: any}) {
   );
 }
 
-function YouWillLearn({children}: {children: any}) {
-  return <SimpleCallout title="You will learn">{children}</SimpleCallout>;
+function YouWillLearn({
+  children,
+  isChapter,
+}: {
+  children: any;
+  isChapter?: boolean;
+}) {
+  let title = isChapter ? 'In this chapter' : 'You will learn';
+  return <SimpleCallout title={title}>{children}</SimpleCallout>;
 }
 
 // TODO: typing.

--- a/beta/src/pages/learn/adding-interactivity.md
+++ b/beta/src/pages/learn/adding-interactivity.md
@@ -8,7 +8,7 @@ Some things on the screen update in response to user input. For example, clickin
 
 </Intro>
 
-<YouWillLearn>
+<YouWillLearn isChapter={true}>
 
 * [How to handle user-initiated events](/learn/responding-to-events)
 * [How to make components "remember" information with state](/learn/state-a-components-memory)

--- a/beta/src/pages/learn/describing-the-ui.md
+++ b/beta/src/pages/learn/describing-the-ui.md
@@ -8,7 +8,7 @@ React is a JavaScript library for rendering user interfaces (UI). UI is built fr
 
 </Intro>
 
-<YouWillLearn>
+<YouWillLearn isChapter={true}>
 
 * [How to write your first React component](/learn/your-first-component)
 * [When and how to create multi-component files](/learn/importing-and-exporting-components)

--- a/beta/src/pages/learn/installation.md
+++ b/beta/src/pages/learn/installation.md
@@ -8,7 +8,7 @@ React has been designed from the start for gradual adoption, and you can use as 
 
 </Intro>
 
-<YouWillLearn>
+<YouWillLearn isChapter={true}>
 
 * [How to add React to an HTML page](/learn/add-react-to-a-website)
 * [How to start a standalone React project](/learn/start-a-new-react-project)

--- a/beta/src/pages/learn/managing-state.md
+++ b/beta/src/pages/learn/managing-state.md
@@ -8,7 +8,7 @@ As your application grows, it helps to be more intentional about how your state 
 
 </Intro>
 
-<YouWillLearn>
+<YouWillLearn isChapter={true}>
 
 * [How to think about UI changes as state changes](/learn/reacting-to-input-with-state)
 * [How to structure state well](/learn/choosing-the-state-structure)


### PR DESCRIPTION
I find it a bit confusing that we currently have two different type of "you will learn" blocks.

On chapter index pages, we use them to point to _specific pages_ within the chapter.

But on individual pages, we use them to specify the contents of the _current page_.

This change tweaks the label so that chapter index pages say "In this chapter" instead:

<img width="990" alt="Screenshot 2022-01-25 at 19 46 44" src="https://user-images.githubusercontent.com/810438/151048500-e86a060d-0f48-4435-a17b-8a57a1884a11.png">

We keep using "You will learn" in individual pages:

<img width="1013" alt="Screenshot 2022-01-25 at 19 46 49" src="https://user-images.githubusercontent.com/810438/151048520-fb5d0037-0b9b-4e81-ba6b-319dca817861.png">

I'm open to other wordings and suggestions as well. For example:

- We could remove "you will learn" from chapter indexes altogether
- We could give them a different visual treatment
- Maybe some other label (ideas?)

This isn't super important but it's been bugging me so I'm putting this for discussion.