### PR TITLE
[Beta] Make line highlight full width

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -114,7 +114,7 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
  */
 .sp-stack {
   height: initial !important;
-  width: fit-content !important;
+  width: 100% !important;
 }
 .sp-cm {
   -webkit-text-size-adjust: none !important;
@@ -145,6 +145,9 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
 .sp-cm .cm-gutters {
   background-color: var(--sp-colors-bg-default);
   z-index: 1;
+}
+.sp-wrapper {
+  width: 100% !important;
 }
 .sp-wrapper .sp-custom-layout {
   overflow: initial;


### PR DESCRIPTION
Addresses issue from https://github.com/reactjs/reactjs.org/pull/4245#issuecomment-1022814023.

Now it appears full width.

<img width="496" alt="Screenshot 2022-01-28 at 00 37 38" src="https://user-images.githubusercontent.com/810438/151466672-07c7ea48-8c06-4632-a348-9df4c2c6411c.png">


<img width="989" alt="Screenshot 2022-01-28 at 00 37 23" src="https://user-images.githubusercontent.com/810438/151466667-f2c0cd06-96b9-47f9-ad50-dd385d65763e.png">

I still think there was some reason we didn't do this before, but I can't recall it. So if something breaks, I guess we'll find out.