### PR TITLE
Use MDXContext directly

### DIFF
--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
+// @ts-ignore
 import {MDXContext} from '@mdx-js/react';
 import recentPostsRouteTree from 'blogIndexRecent.json';
 import {DocsPageFooter} from 'components/DocsFooter';

--- a/beta/src/components/Layout/LayoutPost.tsx
+++ b/beta/src/components/Layout/LayoutPost.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {MDXProvider} from '@mdx-js/react';
+import {MDXContext} from '@mdx-js/react';
 import recentPostsRouteTree from 'blogIndexRecent.json';
 import {DocsPageFooter} from 'components/DocsFooter';
 import {ExternalLink} from 'components/ExternalLink';
@@ -87,7 +87,9 @@ function LayoutPost({meta, children}: LayoutPostProps) {
             </span>
           </p>
 
-          <MDXProvider components={MDXComponents}>{children}</MDXProvider>
+          <MDXContext.Provider value={MDXComponents}>
+            {children}
+          </MDXContext.Provider>
           <DocsPageFooter
             route={route}
             nextRoute={nextRoute}

--- a/beta/src/components/Layout/MarkdownPage.tsx
+++ b/beta/src/components/Layout/MarkdownPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react';
-import {MDXProvider} from '@mdx-js/react';
+import {MDXContext} from '@mdx-js/react';
 import {DocsPageFooter} from 'components/DocsFooter';
 import {MDXComponents} from 'components/MDX/MDXComponents';
 import {Seo} from 'components/Seo';
@@ -135,9 +135,9 @@ export function MarkdownPage<
         )}
         <div className="px-5 sm:px-12">
           <div className="max-w-7xl mx-auto">
-            <MDXProvider components={MDXComponents}>
+            <MDXContext.Provider value={MDXComponents}>
               {finalChildren}
-            </MDXProvider>
+            </MDXContext.Provider>
           </div>
           <DocsPageFooter
             route={route}

--- a/beta/src/components/Layout/MarkdownPage.tsx
+++ b/beta/src/components/Layout/MarkdownPage.tsx
@@ -3,6 +3,7 @@
  */
 
 import * as React from 'react';
+// @ts-ignore
 import {MDXContext} from '@mdx-js/react';
 import {DocsPageFooter} from 'components/DocsFooter';
 import {MDXComponents} from 'components/MDX/MDXComponents';


### PR DESCRIPTION
We need https://github.com/mdx-js/mdx/pull/1924 for https://github.com/reactjs/reactjs.org/pull/4256. That only lands in MDX 2.0, and our attempt to migrate has stalled. For now, we can work around it by using the context provider directly.