### PR TITLE
fix(sandpack): disable init-mode

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "0.13.9-experimental.6",
+    "@codesandbox/sandpack-react": "0.13.11-experimental.0",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -127,9 +127,7 @@ function Sandpack(props: SandpackProps) {
       <SandpackProvider
         template="react"
         customSetup={{...setup, files: files}}
-        autorun={autorun}
-        initMode="user-visible"
-        initModeObserverOptions={{rootMargin: '1400px 0px'}}>
+        autorun={autorun}>
         <CustomPreset
           isSingleFile={isSingleFile}
           showDevTools={showDevTools}

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -555,10 +555,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@0.13.9-experimental.6":
-  version "0.13.9-experimental.6"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.9-experimental.6.tgz#81ee72ad96b8dadf3626271a0ec9ae0694a421de"
-  integrity sha512-IOjuSPg28B/YkRGvbYCjDA45SHIBL2oF/1LBDkUisBHz1fbMTROYLLqdzNDP4yWgA9Ya9OgOgJe904i3pcE4YQ==
+"@codesandbox/sandpack-react@0.13.11-experimental.0":
+  version "0.13.11-experimental.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.11-experimental.0.tgz#3d24a3258e2d94d30415c49e97d8b1f02ef4af8d"
+  integrity sha512-rIqChiYcuEbNEG/G7gShu8NBHO6bBrnfWQv4QTLbZMWvTh3MqRVKgFm3ah184Ara49L0AHnnBmrk/6yeojqxRA==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The current Sandpack `initMode` implementation is leading to a race conditional in the sandpack-client, as a result, some sandpacks might break during the transpile step. So this PR removes temporarily the `initMode` configuration, while we investigate a way to fix it.
