### PR TITLE
fix(useMediaQuery): adds fallback to matchMedia

### DIFF
--- a/beta/src/components/Layout/useMediaQuery.tsx
+++ b/beta/src/components/Layout/useMediaQuery.tsx
@@ -17,14 +17,29 @@ const useMediaQuery = (width: number) => {
 
   useEffect(() => {
     const media = window.matchMedia(`(max-width: ${width}px)`);
-    media.addEventListener('change', updateTarget);
+
+    try {
+      // Chrome & Firefox
+      media.addEventListener('change', updateTarget);
+    } catch {
+      // @deprecated method - Safari <= iOS12
+      media.addListener(updateTarget);
+    }
 
     // Check on mount (callback is not called until a change occurs)
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeEventListener('change', updateTarget);
+    return () => {
+      try {
+        // Chrome & Firefox
+        media.removeEventListener('change', updateTarget);
+      } catch {
+        // @deprecated method - Safari <= iOS12
+        media.removeListener(updateTarget);
+      }
+    };
   }, [updateTarget, width]);
 
   return targetReached;


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

It addresses a bug reported on iOS12, which breaks the entire page due to an incompatible API. So, I added a fallback (deprecated API) for those devices that are still supporting the previous API. 

<img src="https://user-images.githubusercontent.com/4838076/152516560-1282c7d1-f17f-4b6c-af7a-bdbaf1ba59a1.png" width="300px" alt="Bug report" />
