### PR TITLE
docs: fix typo in useState Adjusting derived state section

### DIFF
--- a/beta/src/pages/apis/usestate.md
+++ b/beta/src/pages/apis/usestate.md
@@ -853,6 +853,6 @@ button { margin-bottom: 10px; }
 
 </Sandpack>
 
-Note that derived state must set be inside a condition like `prevCount !== count`, and there must be a call like `setPrevCount(count)` inside of it. Otherwise, your component would re-render in a loop until it crashes.
+Note that derived state must be set inside a condition like `prevCount !== count`, and there must be a call like `setPrevCount(count)` inside of it. Otherwise, your component would re-render in a loop until it crashes.
 
 If you can, try to avoid derived state. However, derived state is better than updating state in an effect. When you call the `set` function during render, React will re-render that component immediately after your component exits with a `return` statement, and before rendering the children. This way, children don't need to render twice.


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixed minor typo. It should say "must be set" but the words were flipped around.