### PR TITLE
Sandpack error icon overlapping issue fix

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -93,6 +93,8 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
 }
 
 .sp-code-editor .cm-errorLine:after {
+  position: relative;
+  top: 1px;
   content: '\26A0';
   font-size: 22px;
   line-height: 16px;

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -93,9 +93,6 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
 }
 
 .sp-code-editor .cm-errorLine:after {
-  position: absolute;
-  right: 8px;
-  top: 0;
   content: '\26A0';
   font-size: 22px;
   line-height: 16px;


### PR DESCRIPTION
Issue: Sandpack error icon overlapping code #4287 


Before: (Error icon was overlapping with code content)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/152655290-4dc06a66-b0eb-4ed2-be24-2296a6baa6a8.png">


After: (Error icon appears after code content)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/152680726-70b81b03-09d0-41d4-8560-af2f265e6d8c.png">




<img width="500" alt="image" src="https://user-images.githubusercontent.com/30730124/152680707-94d48bd6-528f-421c-8bc1-67df004cf8e9.png">







<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
