### PR TITLE
Updated code-splitting.md to import BrowserRouter as Router

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -178,7 +178,7 @@ Here's an example of how to setup route-based code splitting into your app using
 
 ```js
 import React, { Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 const Home = lazy(() => import('./routes/Home'));
 const About = lazy(() => import('./routes/About'));


### PR DESCRIPTION
Updated the imported `react-router-dom` Component `BrowserRouter` to read as `BrowserRouter as Router` since the code example has it as `Router` instead of `BrowserRouter`

Alternatively, can change the `<Router></Router>` component to be `<BrowserRouter>...</BrowserRouter>`

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
