### PR TITLE
removed old "early time for hooks" note

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -97,8 +97,6 @@ You can't use Hooks *inside* a class component, but you can definitely mix class
 
 Our goal is for Hooks to cover all use cases for classes as soon as possible. There are no Hook equivalents to the uncommon `getSnapshotBeforeUpdate`, `getDerivedStateFromError` and `componentDidCatch` lifecycles yet, but we plan to add them soon.
 
-It is an early time for Hooks, and some third-party libraries might not be compatible with Hooks at the moment.
-
 ### Do Hooks replace render props and higher-order components? {#do-hooks-replace-render-props-and-higher-order-components}
 
 Often, render props and higher-order components render only a single child. We think Hooks are a simpler way to serve this use case. There is still a place for both patterns (for example, a virtual scroller component might have a `renderItem` prop, or a visual container component might have its own DOM structure). But in most cases, Hooks will be sufficient and can help reduce nesting in your tree.


### PR DESCRIPTION
This note was added in 2019 and it was really confusing to see it in 2022. My friend, who just started learning react, texted me with a question "is it ok to use hooks?" referring to this note. It might be really confusing for beginners, because hooks already became a standard