### PR TITLE
Revert "Sandpack error icon overlapping issue fix"

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -93,8 +93,9 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
 }
 
 .sp-code-editor .cm-errorLine:after {
-  position: relative;
-  top: 1px;
+  position: absolute;
+  right: 8px;
+  top: 0;
   content: '\26A0';
   font-size: 22px;
   line-height: 16px;


### PR DESCRIPTION
Reverts reactjs/reactjs.org#4302

This fix broke the most common case.

Before reactjs/reactjs.org#4302:

<img width="586" alt="Screenshot 2022-02-12 at 00 23 46" src="https://user-images.githubusercontent.com/810438/153687814-60e78977-fe8a-47be-97c3-e5a8d0403ba6.png">

After reactjs/reactjs.org#4302:

<img width="562" alt="Screenshot 2022-02-12 at 00 23 48" src="https://user-images.githubusercontent.com/810438/153687824-58b600ba-6a3c-4d51-993b-b8ad58f5ffc9.png">

I'm undoing this. A correct fix needs to fix https://github.com/reactjs/reactjs.org/issues/4287 **and** not regress on the common case.