### PR TITLE
Fix broken link in render-and-commit.md

### DIFF
--- a/beta/src/pages/learn/render-and-commit.md
+++ b/beta/src/pages/learn/render-and-commit.md
@@ -69,7 +69,7 @@ Try commenting out the `ReactDOM.render` call and see the component disappear!
 
 ### Re-renders when state updates {/*re-renders-when-state-updates*/}
 
-Once the component has been initially rendered, you can trigger further renders by updating its state with [`setState`](reference/setstate). Updating your component's state automatically queues a render. (You can imagine these as a restaurant guest ordering tea, dessert, and all sorts of things after putting in their first order, depending on the state of their thirst or hunger.)
+Once the component has been initially rendered, you can trigger further renders by updating its state with the [`set` function](/apis/usestate#setstate). Updating your component's state automatically queues a render. (You can imagine these as a restaurant guest ordering tea, dessert, and all sorts of things after putting in their first order, depending on the state of their thirst or hunger.)
 
 <IllustrationBlock sequential>
   <Illustration caption="State update..." alt="React as a server in a restaurant, serving a Card UI to the user, represented as a patron with a cursor for their head. They patron expresses they want a pink card, not a black one!" src="/images/docs/illustrations/i_rerender1.png" />


### PR DESCRIPTION
`/reference/setState` -> `/apis/usestate#setstate`

For the actual text, I also considered being more verbose (e.g. "the `set` function from `useState`") but decided to go with the shorter version.