### PR TITLE
Fix - Sandpack error icon overlapping issue 

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -90,10 +90,7 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
 .sp-code-editor .cm-errorLine {
   background-color: rgba(255, 107, 99, 0.1);
   position: relative;
-}
-
-.sp-code-editor .cm-content .cm-errorLine {
-  padding-right: 26px;
+  padding-right: 26px !important;
 }
 
 .sp-code-editor .cm-errorLine:after {

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -92,6 +92,10 @@ html.dark .sp-tabs .sp-tab-button[data-active='true'] {
   position: relative;
 }
 
+.sp-code-editor .cm-content .cm-errorLine {
+  padding-right: 26px;
+}
+
 .sp-code-editor .cm-errorLine:after {
   position: absolute;
   right: 8px;


### PR DESCRIPTION
Issue: Sandpack error icon overlapping code #4287

### Before 
![Screenshot 2022-02-13 at 12 00 11 PM](https://user-images.githubusercontent.com/49276301/153741702-8c09bbd1-bda3-429f-85b9-c2c6e44197d5.png)


### After
![Screenshot 2022-02-13 at 11 58 30 AM](https://user-images.githubusercontent.com/49276301/153741657-84644415-b6b5-4d73-9452-518798129fd3.png)
 