### PR TITLE
Add App.js Conf 2022 to the conferences page

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -41,6 +41,11 @@ June 2-4, 2022. Atlanta, GA, USA
 
 [Website](https://renderatl.com) - [Twitter](https://twitter.com/renderATL) - [Instagram](https://www.instagram.com/renderatl/) - [Facebook](https://www.facebook.com/renderatl/) - [LinkedIn](https://www.linkedin.com/company/renderatl)
 
+### App.js Conf 2022 {#appjs-conf-2022}
+June 8-10, 2022. In-person in Kraków, Poland + remote
+
+[Website](https://appjs.co) - [Twitter](https://twitter.com/appjsconf)
+
 ### React Summit 2022 {#react-summit-2022}
 June 17 & 21, 2022. In-person in Amsterdam, Netherlands + remote first interactivity (hybrid event)
 


### PR DESCRIPTION
[App.js Conf 2022](https://appjs.co) (Expo + React Native) is missing on the conferences page 🥳 