### PR TITLE
sandpack: bring back init mode

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "0.13.11-experimental.0",
+    "@codesandbox/sandpack-react": "0.13.16-experimental.0",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.3.0",

--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -127,7 +127,9 @@ function Sandpack(props: SandpackProps) {
       <SandpackProvider
         template="react"
         customSetup={{...setup, files: files}}
-        autorun={autorun}>
+        autorun={autorun}
+        initMode="user-visible"
+        initModeObserverOptions={{rootMargin: '1400px 0px'}}>
         <CustomPreset
           isSingleFile={isSingleFile}
           showDevTools={showDevTools}

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -547,18 +547,18 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
-"@codesandbox/sandpack-client@^0.13.9-experimental.0":
-  version "0.13.9-experimental.0"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.13.9-experimental.0.tgz#10eccbd0a3b35d3f46f9484405580c13a4693127"
-  integrity sha512-ktd6HWeQyErO91Sm5DxcLAc4BouUyUUNM1mKwWKzRkw6uUyt9IPbJNttnU0FH88gQxIwduEYVi7wEx/qn0AtMQ==
+"@codesandbox/sandpack-client@^0.13.16-experimental.0":
+  version "0.13.16-experimental.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-0.13.16-experimental.0.tgz#c8ef9e56e0cc2c264412f0e79cbc14f2e04c4479"
+  integrity sha512-n32sFGug1OksZR/4O7I9YYRs/p4JuVvjGPjf4xnDImKfs+butW9sLT8QzCfhad8QLfSGdzBHIyXPWrFe/zilvQ==
   dependencies:
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@0.13.11-experimental.0":
-  version "0.13.11-experimental.0"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.11-experimental.0.tgz#3d24a3258e2d94d30415c49e97d8b1f02ef4af8d"
-  integrity sha512-rIqChiYcuEbNEG/G7gShu8NBHO6bBrnfWQv4QTLbZMWvTh3MqRVKgFm3ah184Ara49L0AHnnBmrk/6yeojqxRA==
+"@codesandbox/sandpack-react@0.13.16-experimental.0":
+  version "0.13.16-experimental.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-0.13.16-experimental.0.tgz#e8982aabc4a584e1ee261cd19606b9531be471f8"
+  integrity sha512-nXxwTwAA42b3AG2Lx6Mqi+yncG8BIACpXjau619KJQFqeoAkc6e2n0D5oYO/qrIean1CntB95xWfvSNbFX8K1Q==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"
@@ -574,7 +574,7 @@
     "@codemirror/matchbrackets" "^0.19.3"
     "@codemirror/state" "^0.19.6"
     "@codemirror/view" "^0.19.32"
-    "@codesandbox/sandpack-client" "^0.13.9-experimental.0"
+    "@codesandbox/sandpack-client" "^0.13.16-experimental.0"
     "@react-hook/intersection-observer" "^3.1.1"
     codesandbox-import-util-types "^2.2.3"
     codesandbox-import-utils "^2.2.3"


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
This adds back the `init-mode` configuration on Sandpack that aims to make better usage of the memory, by destroying the iframe that is not close to the viewport. It was previously removed on #4278 due to the following reasons:

- Layout shift on mobile devices: fixed https://github.com/reactjs/reactjs.org/pull/4322
- Transpiled error (which is very rare, we couldn't even reproduce it): possibly fixed on https://github.com/codesandbox/sandpack/pull/370 ([evidence](https://user-images.githubusercontent.com/4838076/154051407-8f6adb97-0ccd-4a90-bf51-c0de90060d01.png));

Plus, the latest Sandpack version includes the following fix https://github.com/codesandbox/sandpack/pull/357, by @sophiebits.

---

**Sandpack checklist**
- [x]  Decorations are still rendering (`/apis/usestate`);
- [x]  It’s possible to run multiple DevTools on the same page;
- [x]  Edit content on markdown file;
- [x]  Reset: all context and refresh the preview;
- [x]  The line-height of the CodeEditor component is correctly `24px`;
- [x]  Navigate in the codebase (command + arrow keys);
- [x]  Scroll tests: jump to the very end of the page, go back to a Sandpack;
- [x]  On loading state: no layout shift between placeholder and editor;
- [x]  Mobile version: no layout shift on the scroll;
- [x] Syntax inline error;
- [x]  No extra console logs;

So, let's give it another try! 