### PR TITLE
[Beta] Add aria-label and title to permalinks

### DIFF
--- a/beta/src/components/MDX/Heading.tsx
+++ b/beta/src/components/MDX/Heading.tsx
@@ -20,6 +20,11 @@ const Heading = forwardRefWithAs<HeadingProps, 'div'>(function Heading(
   {as: Comp = 'div', className, children, id, isPageAnchor = true, ...props},
   ref
 ) {
+  let label = 'Link for this heading';
+  if (typeof children === 'string') {
+    label = 'Link for ' + children;
+  }
+
   return (
     <>
       <Comp id={id} {...props} ref={ref} className={cn('heading', className)}>
@@ -27,12 +32,12 @@ const Heading = forwardRefWithAs<HeadingProps, 'div'>(function Heading(
         {isPageAnchor && (
           <a
             href={`#${id}`}
+            aria-label={label}
+            title={label}
             className={cn(
               anchorClassName,
               Comp === 'h1' ? 'hidden' : 'inline-block'
-            )}
-            aria-hidden="true"
-            tabIndex={-1}>
+            )}>
             <svg
               width="1em"
               height="1em"

--- a/beta/src/components/MDX/Heading.tsx
+++ b/beta/src/components/MDX/Heading.tsx
@@ -31,7 +31,8 @@ const Heading = forwardRefWithAs<HeadingProps, 'div'>(function Heading(
               anchorClassName,
               Comp === 'h1' ? 'hidden' : 'inline-block'
             )}
-            aria-hidden="true">
+            aria-hidden="true"
+            tabIndex={-1}>
             <svg
               width="1em"
               height="1em"


### PR DESCRIPTION
<s>The heading anchors shouldn't be focusable. So, I added `tabIndex={-1}`. This improves accessibility.</s>

Adds `aria-label` and `title` to permalinks