### PR TITLE
[Beta] Change highlight styles

### DIFF
--- a/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
+++ b/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
@@ -49,14 +49,15 @@ const CodeBlock = function CodeBlock({
       (line: InlineHiglight) => ({
         ...line,
         elementAttributes: {'data-step': `${line.step}`},
-        className: cn('code-step bg-opacity-10 relative rounded-md p-1 ml-2', {
-          'pl-3 before:content-[attr(data-step)] before:block before:w-4 before:h-4 before:absolute before:top-1 before:-left-2 before:rounded-full before:text-white before:text-center before:text-xs before:leading-4':
-            !noMarkers,
-          'bg-blue-40 before:bg-blue-40': line.step === 1,
-          'bg-yellow-40 before:bg-yellow-40': line.step === 2,
-          'bg-green-40 before:bg-green-40': line.step === 3,
-          'bg-purple-40 before:bg-purple-40': line.step === 4,
-        }),
+        className: cn(
+          'code-step bg-opacity-10 dark:bg-opacity-20 relative rounded px-1 py-[1.5px] border-b-[2px] border-opacity-60',
+          {
+            'bg-blue-40 border-blue-40': line.step === 1,
+            'bg-yellow-40 border-yellow-40': line.step === 2,
+            'bg-green-40 border-green-40': line.step === 3,
+            'bg-purple-40 border-purple-40': line.step === 4,
+          }
+        ),
       })
     );
 

--- a/beta/src/components/MDX/ConsoleBlock.tsx
+++ b/beta/src/components/MDX/ConsoleBlock.tsx
@@ -61,7 +61,7 @@ function ConsoleBlock({level = 'info', children}: ConsoleBlockProps) {
         className={cn(
           'flex px-4 pt-4 pb-6 items-center content-center font-mono text-code rounded-b-md',
           {
-            'bg-red-30 text-red-40 bg-opacity-25': level === 'error',
+            'bg-red-30 text-red-40 bg-opacity-10': level === 'error',
             'bg-yellow-5 text-yellow-50': level === 'warning',
             'bg-gray-5 text-secondary dark:text-secondary-dark':
               level === 'info',

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -32,12 +32,12 @@ function CodeStep({children, step}: {children: any; step: number}) {
     <span
       data-step={step}
       className={cn(
-        'code-step bg-opacity-10 relative rounded-md p-1 ml-2 pl-3 before:content-[attr(data-step)] before:block before:w-4 before:h-4 before:absolute before:top-1 before:-left-2 before:rounded-full before:text-white before:text-center before:text-xs before:leading-4',
+        'code-step bg-opacity-10 dark:bg-opacity-20 relative rounded px-[6px] py-[1.5px] border-b-[2px] border-opacity-60',
         {
-          'bg-blue-40 before:bg-blue-40': step === 1,
-          'bg-yellow-40 before:bg-yellow-40': step === 2,
-          'bg-green-40 before:bg-green-40': step === 3,
-          'bg-purple-40 before:bg-purple-40': step === 4,
+          'bg-blue-40 border-blue-40': step === 1,
+          'bg-yellow-40 border-yellow-40': step === 2,
+          'bg-green-40 border-green-40': step === 3,
+          'bg-purple-40 border-purple-40': step === 4,
         }
       )}>
       {children}

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -174,3 +174,14 @@
   --hjFeedbackAccentColor: rgb(230, 247, 255) !important;
   --hjFeedbackAccentTextColor: rgb(73, 119, 171) !important;
 }
+
+.code-step * {
+  color: black !important;
+}
+.code-step code {
+  background: none !important;
+  padding: 2px !important;
+}
+html.dark .code-step * {
+  color: white !important;
+}


### PR DESCRIPTION
# [Preview](https://beta-reactjs-org-nivx9koik-fbopensource.vercel.app/apis/usestate#adding-state-to-a-component)

---

In https://github.com/reactjs/reactjs.org/pull/4328 we have restructured 1-2-3 sections into highlight in the inline text. However, the 1-2-3 labels no longer reflect any semantic ordering that we want to convey.

<img width="500" alt="Screenshot 2022-02-17 at 02 31 30" src="https://user-images.githubusercontent.com/810438/154393361-4fbc3d86-aeb7-434c-8138-eb73c77e3841.png">

This becomes more obvious if we try to use it with even slightly less structured examples:

<img width="500" alt="Screenshot 2022-02-17 at 02 32 22" src="https://user-images.githubusercontent.com/810438/154393480-7600f20d-e5b1-4c32-ba2d-2a6e569d9d50.png">

In code, `useRef([3] 0)` looks strange and distracting. There was anecdotal feedback from quite a few people that labels interfere with the flow of text.

While we could minimize their usage, it feels like maybe there's an opportunity to refine this.

----

This PR changes it to boxes like this:

<img width="977" alt="Screenshot 2022-02-17 at 02 35 15" src="https://user-images.githubusercontent.com/810438/154393790-b6f3dc94-7dde-44c9-aefa-d15a304409ee.png">

<img width="967" alt="Screenshot 2022-02-17 at 02 38 18" src="https://user-images.githubusercontent.com/810438/154394104-59e61bf3-d9a2-41dd-b373-6f0687dfb824.png">

It is not ideal that they appear a bit like links, but I couldn't find a clearer pattern that feels as legible without sacrificing the feature itself. Maybe if somebody has a clever idea, we can try that. But this feels like a step forward to me. It's possible we could actually add some kind of click/tap action if we wanted to.

One concern with dropping numbers may be that this decreases legibility for colorblind users. I'm not sure how helpful the numbers were in the last iteration. I ran a few tests with a simulator, and colors alone appeared distinguishable enough in all cases except Tritanomaly, where the green and blue we use appeared similar. This is inessential information so I don't think it's blocking but it would be nice if we could swap out the green color for something that isn't ambiguous with blue. I've tried a few other options but they were worse for people with more common forms.

Potential follow-ups could be

- Play more with a palette like https://davidmathlogic.com/colorblind/ and see if we can find a better color
- Reconsider underlines and/or actually add some tap action like highlight