### PR TITLE
Fixes initial jump in sandpack 

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -249,7 +249,7 @@ html.dark .sp-devtools > div {
   }
 }
 
-.sp-cm.sp-pristine {
+.sp-cm {
   padding-left: 8px !important;
 }
 .sp-layout {


### PR DESCRIPTION
`sp-pristine` class is changed to `sp-dirty` during code change so this CSS is not applied. 