### PR TITLE
Minor fixes in API page

### DIFF
--- a/beta/src/components/MDX/YouWillLearnCard.tsx
+++ b/beta/src/components/MDX/YouWillLearnCard.tsx
@@ -14,7 +14,7 @@ interface YouWillLearnCardProps {
 
 function YouWillLearnCard({title, path, children}: YouWillLearnCardProps) {
   return (
-    <div className="flex flex-col h-full bg-card dark:bg-card-dark shadow-inner justify-between rounded-lg pb-8 p-6 xl:p-8">
+    <div className="flex flex-col h-full bg-card dark:bg-card-dark shadow-inner justify-between rounded-lg pb-8 p-6 xl:p-8 mt-3">
       <div>
         <h4 className="text-primary dark:text-primary-dark font-bold text-2xl leading-tight">
           {title}

--- a/beta/src/pages/apis/index.md
+++ b/beta/src/pages/apis/index.md
@@ -52,7 +52,7 @@ Declares a ref.
 
 ```js
 function MyComponent() {
-  const inputRef = useState(null);
+  const inputRef = useRef(null);
   // ...
 ```
 


### PR DESCRIPTION
| Before | After | 
| ------ | ------ |
<img width="907" alt="Screenshot 2022-02-18 at 10 15 27 AM" src="https://user-images.githubusercontent.com/32865581/154619292-302d3a07-0234-48f9-80e1-ba5f5e919e2a.png"> |  <img width="914" alt="Screenshot 2022-02-18 at 10 15 03 AM" src="https://user-images.githubusercontent.com/32865581/154619288-e0807dc0-03c3-4fd7-9375-be1f0bbdeaf0.png"> 


Adds some margin between `useState` and `useRef`. Changes `useState` to `useRef` in `useRef` example