### PR TITLE
Add Strict Effects to Strict Mode

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -132,36 +132,21 @@ Read the [new context API documentation](/docs/context.html) to help migrate to 
 
 ### Detecting unsafe effects {#detecting-unsafe-effects}
 
-Conceptually, React effects include three phases:
-* The **create** phase is called for all effects when the effect is created.
-* The **update** phase is called when the dependencies change, if applicable.
-* The **destroy** phase is called for all effects when the effect is destroyed.
+In the future, we’d like to add a feature that allows React to add and remove sections of the UI while preserving state. For example, when a user tabs away from a screen and back, React should be able to immediately show the previous screen. To do this, React support remounting trees using the same component state used before unmounting.
 
-In the past, React has only called the create phase once when a component mounts:
+This feature will give React better performance out-of-the-box, but requires components to be resilient to effects being mounted and destroyed multiple times. Most effects will work without any changes, but some effects do not properly clean up subscriptions in the destroy callback, or implicitly assume they are only mounted or destroyed once.
+
+To help surface these issues, React 18 introduces a new development-only check to Strict Mode. This new check will automatically unmount and remount every component, whenever a component mounts for the first time, restoring the previous state on the second mount.
+
+To demonstrate the development behavior you'll see in Strict Mode with this feature, consider what happens when React mounts a new component. Without this change, when a component mounts, React creates the effects:
 
 ```
 * React mounts the component.
   * Layout effects are created.
-  * Effect effects are created.
+  * Effects are created.
 ```
 
-and the destroy phase once when a component unmounts:
-
-```
-* React unmounts the component.
-  * Layout effects are destroyed.
-  * Effect effects are destroyed.
-```
-
-> Note:
->
-> It's common to hear effects being "mounted" and "unmounted". This is because effects have historically been created when a component was mounted, and destroyed when a component was unmounted. This can cause confusion, so we refer to them as "created" and "destroyed" here instead.
-
-In the future, we'd like to add features to React which would allow a component to mount without immediately creating effects (such as pre-rendering), or to destroy effects in already-mounted components (such as when a component isn't visible). These features will add better performance and resource management out-of-the-box to React, but require effects to be decoupled from the component lifecycle and resilient to being created and destroyed multiple times in a component.
-
-To help surface these issues, React 18 introduced Strict Effects to Strict Mode.
-
-With Strict Effects, React will automatically destroy and re-create every effect in development, whenever a component mounts:
+With Strict Mode starting in React 18, whenever a component mounts in development, React will simulate immediately unmounting and remounting the component:
 
 ```
 * React mounts the component.
@@ -171,11 +156,13 @@ With Strict Effects, React will automatically destroy and re-create every effect
     * Layout effects are destroyed.
     * Effects are destroyed.
 * React simulates effects being re-created on a mounted component.
-    * Layout effect setup code runs
+    * Layout effects are created
     * Effect setup code runs
 ```
 
-when the component unmounts, effects are destroyed as normal:
+On the second mount, React will restore the state from the first mount. This feature simulates user behavior such as a user tabbing away from a screen and back, ensuring that code will properly handle state restoration.
+
+When the component unmounts, effects are destroyed as normal:
 
 ```
 * React unmounts the component.
@@ -185,8 +172,7 @@ when the component unmounts, effects are destroyed as normal:
 
 > Note:
 >
-> This only applies to development mode. _Strict Effects will not run in production mode._
+> This only applies to development mode, _production behavior is unchanged_.
 
-For more information, see:
-  - [Adding Strict Effects to Strict Mode](https://github.com/reactwg/react-18/discussions/19)
+For help supporting common issues, see:
   - [How to Support Strict Effects](https://github.com/reactwg/react-18/discussions/18)


### PR DESCRIPTION
## Overview

Adds a sorta brief overview of Strict Effects to the Strict Mode docs for React 18. I tried to match the level of depth that Detecting Side Effects for double rendering above. Feedback appreciated!

## [Preview](https://reactjs-org-fqccjvzmq-fbopensource.vercel.app/docs/strict-mode.html#detecting-unsafe-effects)