### PR TITLE
Add the  current LTS Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "unist-util-visit": "^1.1.3"
   },
   "engines": {
-    "node": "12.x.x || 14.x.x || 15.x.x",
+    "node": "12.x.x || 14.x.x || 15.x.x || 16.x.x",
     "yarn": "^1.3.2"
   },
   "homepage": "https://reactjs.org/",


### PR DESCRIPTION
I added 16.x.x for the "node" under "engines" in package.json to support the current LTS version of NodeJS.

