### PR TITLE
Improve ESLint

### DIFF
--- a/beta/.eslintrc
+++ b/beta/.eslintrc
@@ -1,6 +1,9 @@
 {
   "root": true,
-  "extends": "next",
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-unused-vars": "warn"
+  },
   "env": {
     "node": true,
     "commonjs": true,


### PR DESCRIPTION
I replaced `next` with `next/core-web-vitals` because it's stricter and better in my opinion. (https://nextjs.org/docs/basic-features/eslint)
I also added a rule that warns about unused variables. I think this is essential. When I ran `yarn lint`, I saw many unused variables. I'll fix them later.