### PR TITLE
Remove unnecessary Tailwind CSS classes

### DIFF
--- a/beta/src/components/Icon/IconArrow.tsx
+++ b/beta/src/components/Icon/IconArrow.tsx
@@ -19,7 +19,7 @@ export const IconArrow = React.memo<
       fill="currentColor"
       {...rest}
       className={cn(className, {
-        'transform rotate-180': displayDirection === 'right',
+        'rotate-180': displayDirection === 'right',
       })}>
       <path fill="none" d="M0 0h24v24H0z" />
       <path d="M7.828 11H20v2H7.828l5.364 5.364-1.414 1.414L4 12l7.778-7.778 1.414 1.414z" />

--- a/beta/src/components/Icon/IconArrowSmall.tsx
+++ b/beta/src/components/Icon/IconArrowSmall.tsx
@@ -11,8 +11,8 @@ export const IconArrowSmall = React.memo<
   }
 >(function IconArrowSmall({displayDirection, className, ...rest}) {
   const classes = cn(className, {
-    'transform rotate-180': displayDirection === 'left',
-    'transform rotate-90': displayDirection === 'down',
+    'rotate-180': displayDirection === 'left',
+    'rotate-90': displayDirection === 'down',
   });
   return (
     <svg

--- a/beta/src/components/Icon/IconChevron.tsx
+++ b/beta/src/components/Icon/IconChevron.tsx
@@ -12,10 +12,10 @@ export const IconChevron = React.memo<
 >(function IconChevron({className, displayDirection, ...rest}) {
   const classes = cn(
     {
-      'transform rotate-0': displayDirection === 'down',
-      'transform rotate-90': displayDirection === 'left',
-      'transform rotate-180': displayDirection === 'up',
-      'transform -rotate-90': displayDirection === 'right',
+      'rotate-0': displayDirection === 'down',
+      'rotate-90': displayDirection === 'left',
+      'rotate-180': displayDirection === 'up',
+      '-rotate-90': displayDirection === 'right',
     },
     className
   );

--- a/beta/src/components/Icon/IconNavArrow.tsx
+++ b/beta/src/components/Icon/IconNavArrow.tsx
@@ -13,9 +13,9 @@ export const IconNavArrow = React.memo<
   const classes = cn(
     'duration-100 ease-in transition',
     {
-      'transform rotate-0': displayDirection === 'down',
-      'transform -rotate-90': displayDirection === 'right',
-      'transform rotate-90': displayDirection === 'left',
+      'rotate-0': displayDirection === 'down',
+      '-rotate-90': displayDirection === 'right',
+      'rotate-90': displayDirection === 'left',
     },
     className
   );


### PR DESCRIPTION
Removed `transform` Tailwind classes because they're no longer unnecessary in Tailwind CSS version 3+. (https://tailwindcss.com/docs/upgrade-guide#automatic-transforms-and-filters) I also checked for `filter` and  `backdrop-filter` but there were none.