### PR TITLE
fix: use `globalThis` over `global`

### DIFF
--- a/content/blog/2022-03-08-react-18-upgrade-guide.md
+++ b/content/blog/2022-03-08-react-18-upgrade-guide.md
@@ -227,11 +227,11 @@ When you first update your tests to use `createRoot`, you may see this warning i
 
 > The current testing environment is not configured to support act(...)
 
-To fix this, set `global.IS_REACT_ACT_ENVIRONMENT` to `true` before running your test:
+To fix this, set `globalThis.IS_REACT_ACT_ENVIRONMENT` to `true` before running your test:
 
 ```js
 // In your test setup file
-global.IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 ```
 
 The purpose of the flag is to tell React that it's running in a unit test-like environment. React will log helpful warnings if you forget to wrap an update with `act`.


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

`global` only exists in node (and `jest-environment-jsdom` [fakes it](https://github.com/facebook/jest/blob/54420eb51baecaba7dff293770f8cb2579825731/packages/jest-environment-jsdom/src/index.ts#L71-L72) for backwards compat). The specified name is `globalThis`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis.

This works in Node 12 and up (current lowest supported version of Node), and not IE (which you're dropping anyways), so should be fine.

---

As an aside, happy to see you removing `typeof jest` check - that does not exist in native ESM, so would have been broken for those use cases anyways 🙂 