### PR TITLE
fix feedback component partially hidden

### DIFF
--- a/beta/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/beta/src/components/Layout/Sidebar/Sidebar.tsx
@@ -45,7 +45,7 @@ export function Sidebar() {
           <SidebarRouteTree routeTree={routeTree} />
         )}
       </nav>
-      <div className="sticky bottom-0 hidden lg:block">
+      <div className="sticky bottom-[35px] hidden lg:block">
         <Feedback />
       </div>
     </aside>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
### Fix feedback component partially hidden

add `bottom: 35px` to the feedback component wrapper

---

fixes #4447