### PR TITLE
Beta: Fix Feedback being shifted down to invisible

### DIFF
--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -21,7 +21,7 @@ export function Page({routeTree, children}: PageProps) {
       <MenuProvider>
         <SidebarContext.Provider value={routeTree}>
           <div className="h-auto lg:h-screen flex flex-row">
-            <div className="no-bg-scrollbar h-auto lg:h-full lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-16 sm:top-10 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
+            <div className="no-bg-scrollbar h-auto lg:h-[calc(100%-40px)] lg:overflow-y-scroll fixed flex flex-row lg:flex-col py-0 top-16 sm:top-10 left-0 right-0 lg:max-w-xs w-full shadow lg:shadow-none z-50">
               <Nav />
               <Sidebar />
             </div>


### PR DESCRIPTION
`<SocialBanner/>` shifted `<Feedback />` down to 40px on `>lg` screen.

<img width="325" alt="Screen Shot 2022-03-11 at 6 01 56 PM" src="https://user-images.githubusercontent.com/5563315/157999498-2dfc55b7-9b2a-4eb8-8f6e-91a01791a7b2.png">
 
This diff fixed it by using `calc`. Not sure if there is a better way but it works
<img width="310" alt="Screen Shot 2022-03-11 at 6 03 41 PM" src="https://user-images.githubusercontent.com/5563315/157999562-ec3d688f-19db-4b0b-9d9a-6664f3fa9b4b.png">
: