### PR TITLE
[18] Add stubs for new API references

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -24,6 +24,12 @@ If you're new to Hooks, you might want to check out [the overview](/docs/hooks-o
   - [`useImperativeHandle`](#useimperativehandle)
   - [`useLayoutEffect`](#uselayouteffect)
   - [`useDebugValue`](#usedebugvalue)
+  - [`useDeferredValue`](#usedeferredvalue)
+  - [`useTransition`](#usetransition)
+- [Library Hooks](#library-hooks)
+  - [`useId`](#useid)
+  - [`useInsertionEffect`](#useinsertioneffect)
+  - [`useSyncExternalStore`](#usesyncexternalstore)
 
 ## Basic Hooks {#basic-hooks}
 
@@ -508,3 +514,59 @@ For example a custom Hook that returned a `Date` value could avoid calling the `
 ```js
 useDebugValue(date, date => date.toDateString());
 ```
+
+### `useDeferredValue` {#usedeferredvalue}
+
+```js
+const [deferredValue] = useDeferredValue(value);
+```
+
+TODO: description
+
+### `useTransition` {#usetransition}
+
+```js
+const [isPending, startTransition] = useTransition();
+```
+
+TODO: description
+
+## Library Hooks {#library-hooks}
+
+The following Hooks are provided for library authors to integrate libraries deeply into the React model, and are not typically used in application code.
+
+### `useId` {#useid}
+
+```js
+const id = useId(value);
+```
+
+TODO: description
+
+> Note:
+> 
+> TODO: identifierPrefix
+
+### `useInsertionEffect` {#useinsertioneffect}
+
+```js
+useInsertionEffect(didUpdate);
+```
+
+TODO: description
+
+> Note:
+> 
+> TODO: no refs
+
+### `useSyncExternalStore` {#usesyncexternalstore}
+
+```js
+const state = useSyncExternalStore(subscribe, snapshot);
+```
+
+TODO: description
+
+> Note:
+> 
+> TODO: use-sync-external-store/shim

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -26,10 +26,10 @@ If you're new to Hooks, you might want to check out [the overview](/docs/hooks-o
   - [`useDebugValue`](#usedebugvalue)
   - [`useDeferredValue`](#usedeferredvalue)
   - [`useTransition`](#usetransition)
-- [Library Hooks](#library-hooks)
   - [`useId`](#useid)
-  - [`useInsertionEffect`](#useinsertioneffect)
+- [Library Hooks](#library-hooks)
   - [`useSyncExternalStore`](#usesyncexternalstore)
+  - [`useInsertionEffect`](#useinsertioneffect)
 
 ## Basic Hooks {#basic-hooks}
 
@@ -531,10 +531,6 @@ const [isPending, startTransition] = useTransition();
 
 TODO: description
 
-## Library Hooks {#library-hooks}
-
-The following Hooks are provided for library authors to integrate libraries deeply into the React model, and are not typically used in application code.
-
 ### `useId` {#useid}
 
 ```js
@@ -547,6 +543,22 @@ TODO: description
 > 
 > TODO: identifierPrefix
 
+## Library Hooks {#library-hooks}
+
+The following Hooks are provided for library authors to integrate libraries deeply into the React model, and are not typically used in application code.
+
+### `useSyncExternalStore` {#usesyncexternalstore}
+
+```js
+const state = useSyncExternalStore(subscribe, snapshot);
+```
+
+TODO: description
+
+> Note:
+>
+> TODO: use-sync-external-store/shim
+
 ### `useInsertionEffect` {#useinsertioneffect}
 
 ```js
@@ -558,15 +570,3 @@ TODO: description
 > Note:
 > 
 > TODO: no refs
-
-### `useSyncExternalStore` {#usesyncexternalstore}
-
-```js
-const state = useSyncExternalStore(subscribe, snapshot);
-```
-
-TODO: description
-
-> Note:
-> 
-> TODO: use-sync-external-store/shim

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -90,10 +90,10 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
   - [`useDebugValue`](/docs/hooks-reference.html#usedebugvalue)
   - [`useDeferredValue`](/docs/hooks-reference.html#usedeferredvalue)
   - [`useTransition`](/docs/hooks-reference.html#usetransition)
-- [Library Hooks](/docs/hooks-reference.html#library-hooks)
   - [`useId`](/docs/hooks-reference.html#useid)
-  - [`useInsertionEffect`](/docs/hooks-reference.html#useinsertioneffect)
+- [Library Hooks](/docs/hooks-reference.html#library-hooks)
   - [`useSyncExternalStore`](/docs/hooks-reference.html#usesyncexternalstore)
+  - [`useInsertionEffect`](/docs/hooks-reference.html#useinsertioneffect)
 
 * * *
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -65,6 +65,13 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
 - [`React.lazy`](#reactlazy)
 - [`React.Suspense`](#reactsuspense)
 
+### Transitions
+
+*Transitions* are a new concurrent feature introduced in React 18. They allow you to mark updates as transitions, which tells React that they can be interrupted and avoid going back to Suspense fallbacks for already visible content.
+
+- [`React.startTransition`](#starttransition)
+- [`React.useTransition`](/docs/hooks-reference.html#usetransition)
+
 ### Hooks {#hooks}
 
 *Hooks* are a new addition in React 16.8. They let you use state and other React features without writing a class. Hooks have a [dedicated docs section](/docs/hooks-intro.html) and a separate API reference:
@@ -81,6 +88,12 @@ Suspense lets components "wait" for something before rendering. Today, Suspense 
   - [`useImperativeHandle`](/docs/hooks-reference.html#useimperativehandle)
   - [`useLayoutEffect`](/docs/hooks-reference.html#uselayouteffect)
   - [`useDebugValue`](/docs/hooks-reference.html#usedebugvalue)
+  - [`useDeferredValue`](/docs/hooks-reference.html#usedeferredvalue)
+  - [`useTransition`](/docs/hooks-reference.html#usetransition)
+- [Library Hooks](/docs/hooks-reference.html#library-hooks)
+  - [`useId`](/docs/hooks-reference.html#useid)
+  - [`useInsertionEffect`](/docs/hooks-reference.html#useinsertioneffect)
+  - [`useSyncExternalStore`](/docs/hooks-reference.html#usesyncexternalstore)
 
 * * *
 
@@ -360,3 +373,15 @@ While this is not supported today, in the future we plan to let `Suspense` handl
 >Note:
 >
 >`React.lazy()` and `<React.Suspense>` are not yet supported by `ReactDOMServer`. This is a known limitation that will be resolved in the future.
+
+### `React.startTransition` {#starttransition}
+
+```js
+React.startTransition(callback)
+```
+
+TODO: description
+
+> Note:
+> 
+> TODO: useTransition


### PR DESCRIPTION
## Overview

Add stubs to fill in for the new APIs in React 18.