### PR TITLE
[18] Update versions page

### DIFF
--- a/content/versions.yml
+++ b/content/versions.yml
@@ -2,6 +2,7 @@
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md
 - title: '17.0.2'
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1702-march-22-2021
+  url: https://17.reactjs.org
 - title: '17.0.1'
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1701-october-22-2020
 - title: '17.0.0'
@@ -25,42 +26,22 @@
 - title: '16.9'
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1690-august-8-2019
 - title: '16.8'
-  path: /version/16.8
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1680-february-6-2019
-  url: https://5d4b5feba32acd0008d0df98--reactjs.netlify.com/
 - title: '16.7'
-  path: /version/16.7
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1670-december-19-2018
-  url: https://5c54aa429e16c80007af3cd2--reactjs.netlify.com/
 - title: '16.6'
-  path: /version/16.6
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1660-october-23-2018
-  url: https://5c11762d4be4d10008916ab1--reactjs.netlify.com/
 - title: '16.5'
-  path: /version/16.5
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1650-september-5-2018
-  url: https://5bcf5863c6aed64970d6de5b--reactjs.netlify.com/
 - title: '16.4'
-  path: /version/16.4
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1640-may-23-2018
-  url: https://5b90c17ac9659241e7f4c938--reactjs.netlify.com
 - title: '16.3'
-  path: /version/16.3
-  url: https://5b05c94e0733d530fd1fafe0--reactjs.netlify.com
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1632-april-16-2018
 - title: '16.2'
-  path: /version/16.2
-  url: https://5abc31d8be40f1556f06c4be--reactjs.netlify.com
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1620-november-28-2017
 - title: '16.1'
-  path: /version/16.1
-  url: https://5a1dbcf14c4b93299e65b9a9--reactjs.netlify.com
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1611-november-13-2017
 - title: '16.0'
-  path: /version/16.0
-  url: https://5a046bf5a6188f4b8fa4938a--reactjs.netlify.com
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1600-september-26-2017
 - title: '15.6'
-  path: /version/15.6
-  url: https://react-legacy.netlify.com
   changelog: https://github.com/facebook/react/blob/main/CHANGELOG.md#1562-september-25-2017

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -44,7 +44,10 @@ const Versions = ({location}: Props) => (
             </p>
             <blockquote>
               <p>Note</p>
-              <p>The current docs are for React 18. For React 17, see <a href="https://17.reactjs.org">https://17.reactjs.org.</a></p>
+              <p>
+                The current docs are for React 18. For React 17, see{' '}
+                <a href="https://17.reactjs.org">https://17.reactjs.org.</a>
+              </p>
             </blockquote>
             <p>
               See our FAQ for information about{' '}

--- a/src/pages/versions.js
+++ b/src/pages/versions.js
@@ -40,8 +40,12 @@ const Versions = ({location}: Props) => (
                 on GitHub
               </a>
               .<br />
-              Documentation for recent releases can also be found below.
+              Changelogs for recent releases can also be found below.
             </p>
+            <blockquote>
+              <p>Note</p>
+              <p>The current docs are for React 18. For React 17, see <a href="https://17.reactjs.org">https://17.reactjs.org.</a></p>
+            </blockquote>
             <p>
               See our FAQ for information about{' '}
               <a href="/docs/faq-versioning.html">


### PR DESCRIPTION
## Overview

Updates the versions page to call out the link to React 17.

Also removes the old broken documentation links until we figure out what to do with them.

## Screen
<img width="1012" alt="Screen Shot 2022-03-22 at 1 57 43 PM" src="https://user-images.githubusercontent.com/2440089/159545459-82e282f5-4d38-445e-967e-dc8e3481436f.png">

