### PR TITLE
Made it explicit that encompasing `tick()` function must be removed

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -59,7 +59,7 @@ setInterval(tick, 1000);
 
 However, it misses a crucial requirement: the fact that the `Clock` sets up a timer and updates the UI every second should be an implementation detail of the `Clock`.
 
-Ideally we want to write this once and have the `Clock` update itself:
+Ideally we want to write this once and have the `Clock` update itself. This means the encompassing `tick()` function will no longer be needed:
 
 ```js{2}
 ReactDOM.render(
@@ -68,7 +68,7 @@ ReactDOM.render(
 );
 ```
 
-To implement this, we need to add "state" to the `Clock` component.
+To implement a self-updating `Clock`, we need to add "state" to the `Clock` component.
 
 State is similar to props, but it is private and fully controlled by the component.
 


### PR DESCRIPTION
Made it explicit that encompassing `tick()` function had to be removed. When I followed this tutorial, this completely passed me by, and I left the encompassing `tick()` function in my code until a much later stage, when I realized it was no longer needed.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
