### PR TITLE
Update conditional-rendering.md to fix formatting

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -159,7 +159,7 @@ render() {
   const count = 0;
   return (
     <div>
-      { count && <h1>Messages: {count}</h1>}
+      {count && <h1>Messages: {count}</h1>}
     </div>
   );
 }


### PR DESCRIPTION
A slight inconsistency in the formatting used throughout for `{` `}`.