### PR TITLE
Fix useTransition document link

### DIFF
--- a/content/blog/2022-03-29-react-v18.md
+++ b/content/blog/2022-03-29-react-v18.md
@@ -222,7 +222,7 @@ With Strict Mode in React 18, React will simulate unmounting and remounting the 
 
 #### useTransition {#usetransition}
 
-`useTransition` and `startTransition` let you mark some state updates as not urgent. Other state updates are considered urgent by default. React will allow urgent state updates (for example, updating a text input) to interrupt non-urgent state updates (for example, rendering a list of search results). [See docs here](/docs/react-reference.html#transitions)
+`useTransition` and `startTransition` let you mark some state updates as not urgent. Other state updates are considered urgent by default. React will allow urgent state updates (for example, updating a text input) to interrupt non-urgent state updates (for example, rendering a list of search results). [See docs here](/docs/react-reference.html#usetransition)
 
 #### useDeferredValue {#usedeferredvalue}
 


### PR DESCRIPTION
Fixes the "See docs here" link. Currently routes to Not Found page