### PR TITLE
fix useTransition link

### DIFF
--- a/content/blog/2022-03-29-react-v18.md
+++ b/content/blog/2022-03-29-react-v18.md
@@ -222,7 +222,7 @@ With Strict Mode in React 18, React will simulate unmounting and remounting the 
 
 #### useTransition {#usetransition}
 
-`useTransition` and `startTransition` let you mark some state updates as not urgent. Other state updates are considered urgent by default. React will allow urgent state updates (for example, updating a text input) to interrupt non-urgent state updates (for example, rendering a list of search results). [See docs here](/docs/react-reference.html#transitions)
+`useTransition` and `startTransition` let you mark some state updates as not urgent. Other state updates are considered urgent by default. React will allow urgent state updates (for example, updating a text input) to interrupt non-urgent state updates (for example, rendering a list of search results). [See docs here](/docs/hooks-reference.html#usetransition)
 
 #### useDeferredValue {#usedeferredvalue}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Congrats on the release of React 18🎉

Corrected the "See docs here" link in "useTransition".

![image](https://user-images.githubusercontent.com/96938948/160726007-de8d4a5c-4a5a-4eb2-afdd-ff5a1cb0dda2.png)
