### PR TITLE
Fix usage of useDeferredValue

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -524,7 +524,7 @@ useDebugValue(date, date => date.toDateString());
 ### `useDeferredValue` {#usedeferredvalue}
 
 ```js
-const [deferredValue] = useDeferredValue(value);
+const deferredValue = useDeferredValue(value);
 ```
 
 `useDeferredValue` accepts a value and returns a new copy of the value that will defer to more urgent updates. If the current render is the result of an urgent update, like user input, React will return the previous value and then render the new value after the urgent render has completed.


### PR DESCRIPTION
Since the very beginning of the `useDeferredValue` being introduced from Facebook into react back in https://github.com/facebook/react/pull/17058, the usage of `useDeferredValue` is always `const deferredValue = useDeferredValue(...args);`, not `const [deferredValue] = useDeferredValue(...args);`.

The typo is introduced by @rickhanlonii in https://github.com/reactjs/reactjs.org/pull/4499