### PR TITLE
Update CDN links for React 18

### DIFF
--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -9,18 +9,18 @@ next: release-channels.html
 Both React and ReactDOM are available over a CDN.
 
 ```html
-<script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 ```
 
 The versions above are only meant for development, and are not suitable for production. Minified and optimized production versions of React are available at:
 
 ```html
-<script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 ```
 
-To load a specific version of `react` and `react-dom`, replace `17` with the version number.
+To load a specific version of `react` and `react-dom`, replace `18` with the version number.
 
 ### Why the `crossorigin` Attribute? {#why-the-crossorigin-attribute}
 


### PR DESCRIPTION
The CDN links referred to React v17.x, so I updated them to v18.x.
