### PR TITLE
Fix typo in Automatic Batching example

### DIFF
--- a/content/blog/2022-03-29-react-v18.md
+++ b/content/blog/2022-03-29-react-v18.md
@@ -87,7 +87,7 @@ setTimeout(() => {
 }, 1000);
 
 // After: updates inside of timeouts, promises,
-// native event handlers or any other event are batched.`
+// native event handlers or any other event are batched.
 setTimeout(() => {
   setCount(c => c + 1);
   setFlag(f => !f);


### PR DESCRIPTION
Fix small typo in [Automatic Batching](https://reactjs.org/blog/2022/03/29/react-v18.html#new-feature-automatic-batching) example.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/23019698/160971902-720b7005-f99c-40e2-aec7-1251b7f9956e.png">

