### PR TITLE
Updated typo of createRoot and hydrateRoot syntax

### DIFF
--- a/content/docs/reference-react-dom-client.md
+++ b/content/docs/reference-react-dom-client.md
@@ -38,7 +38,7 @@ React supports all modern browsers, although [some polyfills are required](/docs
 ### `createRoot()` {#createroot}
 
 ```javascript
-createRoot(container[, options]);
+createRoot(container, [ options ]);
 ```
 
 Create a React root for the supplied `container` and return the root. The root can be used to render a React element into the DOM with `render`:
@@ -71,7 +71,7 @@ root.unmount();
 ### `hydrateRoot()` {#hydrateroot}
 
 ```javascript
-hydrateRoot(element, container[, options])
+hydrateRoot(element, container, [ options ])
 ```
 
 Same as [`createRoot()`](#createroot), but is used to hydrate a container whose HTML contents were rendered by [`ReactDOMServer`](/docs/react-dom-server.html). React will attempt to attach event listeners to the existing markup.


### PR DESCRIPTION
According to their implementations :

export function createRoot(container: Element | DocumentFragment, options?: RootOptions): Root;

export function hydrateRoot(
    container: Element | Document,
    initialChildren: React.ReactChild | Iterable<React.ReactNode>,
    options?: HydrationOptions,
): Root;

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
