### PR TITLE
Fix params order for hydrateRoot reference

### DIFF
--- a/content/docs/reference-react-dom-client.md
+++ b/content/docs/reference-react-dom-client.md
@@ -71,7 +71,7 @@ root.unmount();
 ### `hydrateRoot()` {#hydrateroot}
 
 ```javascript
-hydrateRoot(element, container[, options])
+hydrateRoot(container, element[, options])
 ```
 
 Same as [`createRoot()`](#createroot), but is used to hydrate a container whose HTML contents were rendered by [`ReactDOMServer`](/docs/react-dom-server.html). React will attempt to attach event listeners to the existing markup.


### PR DESCRIPTION
After double-checking the types for the createRoot and hydrateRoot methods, I found a discrepancy in how the arguments were named in those methods.
In my understanding, the hydrateRoot() method gets as the first argument the DOM container, and the second one would be the initial React element we want to hydrate.

I just switch the order of those two arguments to make it consistent with its definition in the createRoot method.