### PR TITLE
Update historical Concurrent Mode pages

### DIFF
--- a/content/docs/concurrent-mode-adoption.md
+++ b/content/docs/concurrent-mode-adoption.md
@@ -17,12 +17,22 @@ next: concurrent-mode-reference.html
 
 >Caution:
 >
->This page was about experimental features that aren't yet available in a stable release. It was aimed at early adopters and people who are curious.
+>This page is **severely outdated** and only exists for historical purposes.
 >
->Much of the information on this page is now outdated and exists only for archival purposes. **Please refer to the [React 18 Alpha announcement post](/blog/2021/06/08/the-plan-for-react-18.html
-) for the up-to-date information.**
+>React 18 was released with support for concurrency. However, **there is no "mode" anymore,** and the new behavior is fully opt-in and only enabled [when you use the new features](https://reactjs.org/blog/2022/03/29/react-v18.html#gradually-adopting-concurrent-features).
 >
->Before React 18 is released, we will replace this page with stable documentation.
+>**For up-to-date high-level information, refer to:**
+>* [React 18 Announcement](https://reactjs.org/blog/2022/03/29/react-v18.html)
+>* [Upgrading to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html)
+>* [React Conf 2021 Videos](http://localhost:8000/blog/2021/12/17/react-conf-2021-recap.html)
+>
+>**For details about concurrent APIs in React 18, refer to:**
+>* [`React.Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) reference
+>* [`React.startTransition`](https://reactjs.org/docs/react-api.html#starttransition) reference
+>* [`React.useTransition`](https://reactjs.org/docs/hooks-reference.html#usetransition) reference
+>* [`React.useDeferredValue`](https://reactjs.org/docs/hooks-reference.html#usedeferredvalue) reference
+>
+>The rest of this page includes content that's stale, broken, or incorrect.
 
 </div>
 
@@ -57,6 +67,14 @@ We're using this code in production (and it works for us) but there are still so
 
 ### Enabling Concurrent Mode {#enabling-concurrent-mode}
 
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
+
 Normally, when we add features to React, you can start using them immediately. Fragments, Context, and even Hooks are examples of such features. You can use them in new code without making any changes to the existing code.
 
 Concurrent Mode is different. It introduces semantic changes to how React works. Otherwise, the [new features](/docs/concurrent-mode-patterns.html) enabled by it *wouldn't be possible*. This is why they're grouped into a new "mode" rather than released one by one in isolation.
@@ -87,11 +105,28 @@ In Concurrent Mode, the lifecycle methods [previously marked](/blog/2018/03/27/u
 
 ## What to Expect {#what-to-expect}
 
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
+
+
 If you have a large existing app, or if your app depends on a lot of third-party packages, please don't expect that you can use the Concurrent Mode immediately. **For example, at Facebook we are using Concurrent Mode for the new website, but we're not planning to enable it on the old website.** This is because our old website still uses unsafe lifecycle methods in the product code, incompatible third-party libraries, and patterns that don't work well with the Concurrent Mode.
 
 In our experience, code that uses idiomatic React patterns and doesn't rely on external state management solutions is the easiest to get running in the Concurrent Mode. We will describe common problems we've seen and the solutions to them separately in the coming weeks.
 
 ### Migration Step: Blocking Mode {#migration-step-blocking-mode}
+
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
 
 For older codebases, Concurrent Mode might be a step too far. This is why we also provide a new "Blocking Mode" in the experimental React builds. You can try it by substituting `createRoot` with `createBlockingRoot`. It only offers a *small subset* of the Concurrent Mode features, but it is closer to how React works today and can serve as a migration step.
 
@@ -103,6 +138,14 @@ To recap:
 
 ### Why So Many Modes? {#why-so-many-modes}
 
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
+
 We think it is better to offer a [gradual migration strategy](/docs/faq-versioning.html#commitment-to-stability) than to make huge breaking changes — or to let React stagnate into irrelevance.
 
 In practice, we expect that most apps using Legacy Mode today should be able to migrate at least to the Blocking Mode (if not Concurrent Mode). This fragmentation can be annoying for libraries that aim to support all Modes in the short term. However, gradually moving the ecosystem away from the Legacy Mode will also *solve* problems that affect major libraries in the React ecosystem, such as [confusing Suspense behavior when reading layout](https://github.com/facebook/react/issues/14536) and [lack of consistent batching guarantees](https://github.com/facebook/react/issues/15080). There's a number of bugs that can't be fixed in Legacy Mode without changing semantics, but don't exist in Blocking and Concurrent Modes.
@@ -110,6 +153,14 @@ In practice, we expect that most apps using Legacy Mode today should be able to 
 You can think of the Blocking Mode as a "gracefully degraded" version of the Concurrent Mode. **As a result, in longer term we should be able to converge and stop thinking about different Modes altogether.** But for now, Modes are an important migration strategy. They let everyone decide when a migration is worth it, and upgrade at their own pace.
 
 ### Feature Comparison {#feature-comparison}
+
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
 
 <style>
   #feature-table table { border-collapse: collapse; }

--- a/content/docs/concurrent-mode-intro.md
+++ b/content/docs/concurrent-mode-intro.md
@@ -16,12 +16,22 @@ next: concurrent-mode-suspense.html
 
 >Caution:
 >
->This page was about experimental features that aren't yet available in a stable release. It was aimed at early adopters and people who are curious.
+>This page is **somewhat outdated** and only exists for historical purposes.
 >
->Much of the information on this page is now outdated and exists only for archival purposes. **Please refer to the [React 18 Alpha announcement post](/blog/2021/06/08/the-plan-for-react-18.html
-) for the up-to-date information.**
+>React 18 was released with support for concurrency. However, **there is no "mode" anymore,** and the new behavior is fully opt-in and only enabled [when you use the new features](https://reactjs.org/blog/2022/03/29/react-v18.html#gradually-adopting-concurrent-features).
 >
->Before React 18 is released, we will replace this page with stable documentation.
+>**For up-to-date high-level information, refer to:**
+>* [React 18 Announcement](https://reactjs.org/blog/2022/03/29/react-v18.html)
+>* [Upgrading to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html)
+>* [React Conf 2021 Videos](http://localhost:8000/blog/2021/12/17/react-conf-2021-recap.html)
+>
+>**For details about concurrent APIs in React 18, refer to:**
+>* [`React.Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) reference
+>* [`React.startTransition`](https://reactjs.org/docs/react-api.html#starttransition) reference
+>* [`React.useTransition`](https://reactjs.org/docs/hooks-reference.html#usetransition) reference
+>* [`React.useDeferredValue`](https://reactjs.org/docs/hooks-reference.html#usedeferredvalue) reference
+>
+>The rest of this page includes content that's stale, broken, or incorrect.
 
 </div>
 
@@ -33,6 +43,14 @@ This page provides a theoretical overview of Concurrent Mode. **For a more pract
 * [Concurrent Mode API Reference](/docs/concurrent-mode-reference.html) documents the new APIs available in experimental builds.
 
 ## What Is Concurrent Mode? {#what-is-concurrent-mode}
+
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
+
+</div>
 
 Concurrent Mode is a set of new features that help React apps stay responsive and gracefully adjust to the user's device capabilities and network speed.
 

--- a/content/docs/concurrent-mode-reference.md
+++ b/content/docs/concurrent-mode-reference.md
@@ -55,6 +55,8 @@ This page is an API reference for the React [Concurrent Mode](/docs/concurrent-m
 >
 >This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
 
+</div>
+
 ### `createRoot` {#createroot}
 
 ```js

--- a/content/docs/concurrent-mode-reference.md
+++ b/content/docs/concurrent-mode-reference.md
@@ -134,7 +134,7 @@ The `useTransition` hook returns two values in an array.
 ```js
 function App() {
   const [resource, setResource] = useState(initialResource);
-  const [startTransition, isPending] = useTransition();
+  const [isPending, startTransition] = useTransition();
   return (
     <>
       <button

--- a/content/docs/concurrent-mode-reference.md
+++ b/content/docs/concurrent-mode-reference.md
@@ -16,12 +16,22 @@ prev: concurrent-mode-adoption.html
 
 >Caution:
 >
->This page was about experimental features that aren't yet available in a stable release. It was aimed at early adopters and people who are curious.
+>This page is **somewhat outdated** and only exists for historical purposes.
 >
->Much of the information on this page is now outdated and exists only for archival purposes. **Please refer to the [React 18 Alpha announcement post](/blog/2021/06/08/the-plan-for-react-18.html
-) for the up-to-date information.**
+>React 18 was released with support for concurrency. However, **there is no "mode" anymore,** and the new behavior is fully opt-in and only enabled [when you use the new features](https://reactjs.org/blog/2022/03/29/react-v18.html#gradually-adopting-concurrent-features).
 >
->Before React 18 is released, we will replace this page with stable documentation.
+>**For up-to-date high-level information, refer to:**
+>* [React 18 Announcement](https://reactjs.org/blog/2022/03/29/react-v18.html)
+>* [Upgrading to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html)
+>* [React Conf 2021 Videos](http://localhost:8000/blog/2021/12/17/react-conf-2021-recap.html)
+>
+>**For details about concurrent APIs in React 18, refer to:**
+>* [`React.Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) reference
+>* [`React.startTransition`](https://reactjs.org/docs/react-api.html#starttransition) reference
+>* [`React.useTransition`](https://reactjs.org/docs/hooks-reference.html#usetransition) reference
+>* [`React.useDeferredValue`](https://reactjs.org/docs/hooks-reference.html#usedeferredvalue) reference
+>
+>The rest of this page may include content that's stale, broken, or incorrect.
 
 </div>
 
@@ -38,6 +48,12 @@ This page is an API reference for the React [Concurrent Mode](/docs/concurrent-m
     - [`useDeferredValue`](#usedeferredvalue)
 
 ## Enabling Concurrent Mode {#concurrent-mode}
+
+<div class="scary">
+
+>Caution:
+>
+>This explanation is outdated. The strategy of a separate "mode" was abandoned in React 18. Instead, concurrent rendering is only enabled when you use concurrent features.
 
 ### `createRoot` {#createroot}
 
@@ -102,25 +118,21 @@ Note that `SuspenseList` only operates on the closest `Suspense` and `SuspenseLi
 ### `useTransition` {#usetransition}
 
 ```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-
-const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
+const [isPending, startTransition] = useTransition();
 ```
 
 `useTransition` allows components to avoid undesirable loading states by waiting for content to load before **transitioning to the next screen**. It also allows components to defer slower, data fetching updates until subsequent renders so that more crucial updates can be rendered immediately.
 
+* `isPending` is a boolean. It's React's way of informing us whether we're waiting for the transition to finish.
 The `useTransition` hook returns two values in an array.
 * `startTransition` is a function that takes a callback. We can use it to tell React which state we want to defer.
-* `isPending` is a boolean. It's React's way of informing us whether we're waiting for the transition to finish.
 
 **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
 
 ```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-
 function App() {
   const [resource, setResource] = useState(initialResource);
-  const [startTransition, isPending] = useTransition(SUSPENSE_CONFIG);
+  const [startTransition, isPending] = useTransition();
   return (
     <>
       <button
@@ -143,30 +155,19 @@ function App() {
 }
 ```
 
-In this code, we've wrapped our data fetching with `startTransition`. This allows us to start fetching the profile data right away, while deferring the render of the next profile page and its associated `Spinner` for 2 seconds (the time shown in `timeoutMs`).
+In this code, we've wrapped our data fetching with `startTransition`. This allows us to start fetching the profile data right away, while deferring the render of the next profile page and its associated `Spinner`.
 
 The `isPending` boolean lets React know that our component is transitioning, so we are able to let the user know this by showing some loading text on the previous profile page.
 
 **For an in-depth look at transitions, you can read [Concurrent UI Patterns](/docs/concurrent-mode-patterns.html#transitions).**
 
-#### useTransition Config {#usetransition-config}
-
-```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-```
-
-`useTransition` accepts an **optional Suspense Config** with a `timeoutMs`. This timeout (in milliseconds) tells React how long to wait before showing the next state (the new Profile Page in the above example).
-
-**Note: We recommend that you share Suspense Config between different modules.**
-
-
 ### `useDeferredValue` {#usedeferredvalue}
 
 ```js
-const deferredValue = useDeferredValue(value, { timeoutMs: 2000 });
+const deferredValue = useDeferredValue(value);
 ```
 
-Returns a deferred version of the value that may "lag behind" it for at most `timeoutMs`.
+Returns a deferred version of the value that may "lag behind" it.
 
 This is commonly used to keep the interface responsive when you have something that renders immediately based on user input and something that needs to wait for a data fetch.
 
@@ -175,7 +176,7 @@ A good example of this is a text input.
 ```js
 function App() {
   const [text, setText] = useState("hello");
-  const deferredText = useDeferredValue(text, { timeoutMs: 2000 }); 
+  const deferredText = useDeferredValue(text); 
 
   return (
     <div className="App">
@@ -189,16 +190,6 @@ function App() {
  }
 ```
 
-This allows us to start showing the new text for the `input` immediately, which allows the webpage to feel responsive. Meanwhile, `MySlowList` "lags behind" for up to 2 seconds according to the `timeoutMs` before updating, allowing it to render with the current text in the background.
+This allows us to start showing the new text for the `input` immediately, which allows the webpage to feel responsive. Meanwhile, `MySlowList` "lags behind", allowing it to render with the current text in the background.
 
 **For an in-depth look at deferring values, you can read [Concurrent UI Patterns](/docs/concurrent-mode-patterns.html#deferring-a-value).**
-
-#### useDeferredValue Config {#usedeferredvalue-config}
-
-```js
-const SUSPENSE_CONFIG = { timeoutMs: 2000 };
-```
-
-`useDeferredValue` accepts an **optional Suspense Config** with a `timeoutMs`. This timeout (in milliseconds) tells React how long the deferred value is allowed to lag behind.
-
-React will always try to use a shorter lag when network and device allows it.

--- a/content/docs/concurrent-mode-suspense.md
+++ b/content/docs/concurrent-mode-suspense.md
@@ -17,12 +17,22 @@ next: concurrent-mode-patterns.html
 
 >Caution:
 >
->This page was about experimental features that aren't yet available in a stable release. It was aimed at early adopters and people who are curious.
+>This page is **somewhat outdated** and only exists for historical purposes.
 >
->Much of the information on this page is now outdated and exists only for archival purposes. **Please refer to the [React 18 Alpha announcement post](/blog/2021/06/08/the-plan-for-react-18.html
-) for the up-to-date information.**
+>React 18 was released with support for concurrency. However, **there is no "mode" anymore,** and the new behavior is fully opt-in and only enabled [when you use the new features](https://reactjs.org/blog/2022/03/29/react-v18.html#gradually-adopting-concurrent-features).
 >
->Before React 18 is released, we will replace this page with stable documentation.
+>**For up-to-date high-level information, refer to:**
+>* [React 18 Announcement](https://reactjs.org/blog/2022/03/29/react-v18.html)
+>* [Upgrading to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html)
+>* [React Conf 2021 Videos](http://localhost:8000/blog/2021/12/17/react-conf-2021-recap.html)
+>
+>**For details about concurrent APIs in React 18, refer to:**
+>* [`React.Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) reference
+>* [`React.startTransition`](https://reactjs.org/docs/react-api.html#starttransition) reference
+>* [`React.useTransition`](https://reactjs.org/docs/hooks-reference.html#usetransition) reference
+>* [`React.useDeferredValue`](https://reactjs.org/docs/hooks-reference.html#usedeferredvalue) reference
+>
+>The rest of this page includes content that's stale, broken, or incorrect.
 
 </div>
 
@@ -734,6 +744,5 @@ Suspense answers some questions, but it also poses new questions of its own:
 * What if we want to show a spinner in a different place than "above" the component in a tree?
 * If we intentionally *want* to show an inconsistent UI for a small period of time, can we do that?
 * Instead of showing a spinner, can we add a visual effect like "greying out" the current screen?
-* Why does our [last Suspense example](https://codesandbox.io/s/sparkling-field-41z4r3) log a warning when clicking the "Next" button?
 
 To answer these questions, we will refer to the next section on [Concurrent UI Patterns](/docs/concurrent-mode-patterns.html).


### PR DESCRIPTION
We've removed them from the main site so they're only on the `17.` subdomain now. This updates their content to more-or-less match what came out in 18, with disclaimers that you should really look elsewhere for stable docs.

If there's something salvageable in these guides, we'll need to port those parts to the stable docs.