### PR TITLE
Edits for ReactDOMServer API

### DIFF
--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -205,5 +205,3 @@ ReactDOMServer.renderToStaticMarkup(element)
 Similar to [`renderToString`](#rendertostring), except this doesn't create extra DOM attributes that React uses internally, such as `data-reactroot`. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save some bytes.
 
 If you plan to use React on the client to make the markup interactive, do not use this method. Instead, use [`renderToString`](#rendertostring) on the server and [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on the client.
-
-* * *

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -10,7 +10,7 @@ The `ReactDOMServer` object enables you to render components to static markup. T
 
 ```js
 // ES modules
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 // CommonJS
 var ReactDOMServer = require('react-dom/server');
 ```
@@ -27,7 +27,7 @@ These methods are only available in the **environments with [Web Streams](https:
 
 - [`renderToReadableStream()`](#rendertoreadablestream)
 
-The following methods can be used in both the server and browser environments:
+The following methods can be used in both the server and Web API environments:
 
 - [`renderToString()`](#rendertostring)
 - [`renderToStaticMarkup()`](#rendertostaticmarkup)

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -72,9 +72,9 @@ const stream = renderToPipeableStream(
       // res.setHeader('Content-type', 'text/html');
       // stream.pipe(res);
     },
-    onError(x) {
+    onError(err) {
       didError = true;
-      console.error(x);
+      console.error(err);
     },
   }
 );
@@ -101,6 +101,7 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 
 ```javascript
 let controller = new AbortController();
+let didError = false;
 try {
   let stream = await renderToReadableStream(
     <html>
@@ -108,6 +109,10 @@ try {
     </html>,
     {
       signal: controller.signal,
+      onError(e) {
+        didError = true;
+        console.error(err);
+      }
     }
   );
   
@@ -118,6 +123,7 @@ try {
   // await stream.allReady;
 
   return new Response(stream, {
+    status: didError ? 500 : 200,
     headers: {'Content-Type': 'text/html'},
   });
 } catch (error) {

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -66,7 +66,7 @@ const stream = renderToPipeableStream(
     onAllReady() {
       // If you don't want streaming, use this instead of onShellReady.
       // This will fire after the entire page content is ready.
-      // You can use this for crawlers (SEO) or static generation.
+      // You can use this for crawlers or static generation.
 
       // res.statusCode = didError ? 500 : 200;
       // res.setHeader('Content-type', 'text/html');
@@ -118,7 +118,7 @@ try {
   
   // This is to wait for all Suspense boundaries to be ready. You can uncomment
   // this line if you want to buffer the entire HTML instead of streaming it.
-  // You can use this for crawlers (SEO) or static generation:
+  // You can use this for crawlers or static generation:
 
   // await stream.allReady;
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -17,45 +17,22 @@ var ReactDOMServer = require('react-dom/server');
 
 ## Overview {#overview}
 
+These methods are only available in the **environments with [Node.js Streams](https://nodejs.dev/learn/nodejs-streams):**
+
+- [`renderToPipeableStream()`](#rendertopipeablestream)
+- [`renderToNodeStream()`](#rendertonodestream) (Deprecated)
+- [`renderToStaticNodeStream()`](#rendertostaticnodestream)
+
+These methods are only available in the **environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API)** (this includes browsers, Deno, and some modern edge runtimes):
+
+- [`renderToReadableStream()`](#rendertoreadablestream)
+
 The following methods can be used in both the server and browser environments:
 
 - [`renderToString()`](#rendertostring)
 - [`renderToStaticMarkup()`](#rendertostaticmarkup)
 
-These additional methods depend on a package (`stream`) that is **only available on the server**, and won't work in the browser.
-
-- [`renderToPipeableStream()`](#rendertopipeablestream)
-- [`renderToReadableStream()`](#rendertoreadablestream)
-- [`renderToNodeStream()`](#rendertonodestream) (Deprecated)
-- [`renderToStaticNodeStream()`](#rendertostaticnodestream)
-
-* * *
-
 ## Reference {#reference}
-
-### `renderToString()` {#rendertostring}
-
-```javascript
-ReactDOMServer.renderToString(element)
-```
-
-Render a React element to its initial HTML. React will return an HTML string. You can use this method to generate HTML on the server and send the markup down on the initial request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
-
-If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
-
-* * *
-
-### `renderToStaticMarkup()` {#rendertostaticmarkup}
-
-```javascript
-ReactDOMServer.renderToStaticMarkup(element)
-```
-
-Similar to [`renderToString`](#rendertostring), except this doesn't create extra DOM attributes that React uses internally, such as `data-reactroot`. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save some bytes.
-
-If you plan to use React on the client to make the markup interactive, do not use this method. Instead, use [`renderToString`](#rendertostring) on the server and [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on the client.
-
-* * *
 
 ### `renderToPipeableStream()` {#rendertopipeablestream}
 
@@ -63,47 +40,66 @@ If you plan to use React on the client to make the markup interactive, do not us
 ReactDOMServer.renderToPipeableStream(element, options)
 ```
 
-Render a React element to its initial HTML. Returns a [Control object](https://github.com/facebook/react/blob/3f8990898309c61c817fbf663f5221d9a00d0eaa/packages/react-dom/src/server/ReactDOMFizzServerNode.js#L49-L54) that allows you to pipe the output or abort the request. Fully supports Suspense and streaming of HTML with "delayed" content blocks "popping in" later through javascript execution. [Read more](https://github.com/reactwg/react-18/discussions/37)
+Render a React element to its initial HTML. Returns the `{ pipe, abort }` methods that allows you to pipe the output or abort the request. Fully supports Suspense and streaming of HTML with "delayed" content blocks "popping in" via inline `<script>` tags later. [Read more](https://github.com/reactwg/react-18/discussions/37)
 
 If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
 > Note:
 >
-> This is a Node.js specific API and modern server environments should use renderToReadableStream instead.
+> This is a Node.js-specific API. Environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), like Deno and modern edge runtimes, should use [`renderToReadableStream`](#rendertoreadablestream) instead.
 >
 
-```
+```javascript
+let didError = false;
 const {pipe, abort} = renderToPipeableStream(
   <App />,
   {
-    onAllReady() {
-      res.statusCode = 200;
+    onShellReady() {
+      // The content above all Suspense boundaries is ready.
+      // If something errored before we started streaming, we set the error code appropriately.
+      res.statusCode = didError ? 500 : 200;
       res.setHeader('Content-type', 'text/html');
       pipe(res);
     },
-    onShellError(x) {
+    onShellError(error) {
+      // Something errored before we could complete the shell so we emit an alternative shell.
       res.statusCode = 500;
       res.send(
         '<!doctype html><p>Loading...</p><script src="clientrender.js"></script>'
       );
-    }
+    },
+    onAllReady() {
+      // If you don't want streaming, use this instead of onShellReady.
+      // This will fire after the entire page content is ready.
+      // You can use this for crawlers (SEO) or static generation.
+
+      // res.statusCode = didError ? 500 : 200;
+      // res.setHeader('Content-type', 'text/html');
+      // pipe(res);
+    },
+    onError(x) {
+      didError = true;
+      console.error(x);
+    },
   }
 );
 ```
+
+See the [full list of options](https://github.com/facebook/react/blob/14c2be8dac2d5482fda8a0906a31d239df8551fc/packages/react-dom/src/server/ReactDOMFizzServerNode.js#L36-L46).
 
 * * *
 
 ### `renderToReadableStream()` {#rendertoreadablestream}
 
 ```javascript
-    ReactDOMServer.renderToReadableStream(element, options);
+ReactDOMServer.renderToReadableStream(element, options);
 ```
 
-Streams a React element to its initial HTML. Returns a [Readable Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream). Fully supports Suspense and streaming of HTML. [Read more](https://github.com/reactwg/react-18/discussions/127)
+Streams a React element to its initial HTML. Returns a Promise that resolves to a [Readable Stream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream). Fully supports Suspense and streaming of HTML. [Read more](https://github.com/reactwg/react-18/discussions/127)
 
 If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
-```
+```javascript
 let controller = new AbortController();
 try {
   let stream = await renderToReadableStream(
@@ -115,8 +111,10 @@ try {
     }
   );
   
-  // This is to wait for all suspense boundaries to be ready. You can uncomment
-  // this line if you don't want to stream to the client
+  // This is to wait for all Suspense boundaries to be ready. You can uncomment
+  // this line if you want to buffer the entire HTML instead of streaming it.
+  // You can use this for crawlers (SEO) or static generation:
+
   // await stream.allReady;
 
   return new Response(stream, {
@@ -132,15 +130,23 @@ try {
   );
 }
 ```
+
+See the [full list of options](https://github.com/facebook/react/blob/14c2be8dac2d5482fda8a0906a31d239df8551fc/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js#L27-L35).
+
+> Note:
+>
+> This API depends on [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). For Node.js, use [`renderToPipeableStream`](#rendertopipeablestream) instead.
+>
+
 * * *
 
-### `renderToNodeStream()` {#rendertonodestream} (Deprecated)
+### `renderToNodeStream()`  (Deprecated) {#rendertonodestream}
 
 ```javascript
 ReactDOMServer.renderToNodeStream(element)
 ```
 
-Render a React element to its initial HTML. Returns a [Readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) that outputs an HTML string. The HTML output by this stream is exactly equal to what [`ReactDOMServer.renderToString`](#rendertostring) would return. You can use this method to generate HTML on the server and send the markup down on the initial request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
+Render a React element to its initial HTML. Returns a [Node.js Readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) that outputs an HTML string. The HTML output by this stream is exactly equal to what [`ReactDOMServer.renderToString`](#rendertostring) would return. You can use this method to generate HTML on the server and send the markup down on the initial request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
 
 If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
@@ -169,3 +175,35 @@ If you plan to use React on the client to make the markup interactive, do not us
 > Server-only. This API is not available in the browser.
 >
 > The stream returned from this method will return a byte stream encoded in utf-8. If you need a stream in another encoding, take a look at a project like [iconv-lite](https://www.npmjs.com/package/iconv-lite), which provides transform streams for transcoding text.
+
+* * *
+
+### `renderToString()` {#rendertostring}
+
+```javascript
+ReactDOMServer.renderToString(element)
+```
+
+Render a React element to its initial HTML. React will return an HTML string. You can use this method to generate HTML on the server and send the markup down on the initial request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
+
+If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
+
+> Note
+>
+> This API has limited Suspense support and does not support streaming.
+>
+> On the sever, it is recommended to use either [`renderToPipeableStream`](#rendertopipeablestream) (for Node.js) or [`renderToReadableStream`](#rendertoreadablestream) (for Web Streams) instead.
+
+* * *
+
+### `renderToStaticMarkup()` {#rendertostaticmarkup}
+
+```javascript
+ReactDOMServer.renderToStaticMarkup(element)
+```
+
+Similar to [`renderToString`](#rendertostring), except this doesn't create extra DOM attributes that React uses internally, such as `data-reactroot`. This is useful if you want to use React as a simple static page generator, as stripping away the extra attributes can save some bytes.
+
+If you plan to use React on the client to make the markup interactive, do not use this method. Instead, use [`renderToString`](#rendertostring) on the server and [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on the client.
+
+* * *

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -44,11 +44,6 @@ Render a React element to its initial HTML. Returns the `{ pipe, abort }` method
 
 If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
-> Note:
->
-> This is a Node.js-specific API. Environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), like Deno and modern edge runtimes, should use [`renderToReadableStream`](#rendertoreadablestream) instead.
->
-
 ```javascript
 let didError = false;
 const {pipe, abort} = renderToPipeableStream(
@@ -86,6 +81,11 @@ const {pipe, abort} = renderToPipeableStream(
 ```
 
 See the [full list of options](https://github.com/facebook/react/blob/14c2be8dac2d5482fda8a0906a31d239df8551fc/packages/react-dom/src/server/ReactDOMFizzServerNode.js#L36-L46).
+
+> Note:
+>
+> This is a Node.js-specific API. Environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), like Deno and modern edge runtimes, should use [`renderToReadableStream`](#rendertoreadablestream) instead.
+>
 
 * * *
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -40,13 +40,13 @@ The following methods can be used in both the server and browser environments:
 ReactDOMServer.renderToPipeableStream(element, options)
 ```
 
-Render a React element to its initial HTML. Returns the `{ pipe, abort }` methods that allows you to pipe the output or abort the request. Fully supports Suspense and streaming of HTML with "delayed" content blocks "popping in" via inline `<script>` tags later. [Read more](https://github.com/reactwg/react-18/discussions/37)
+Render a React element to its initial HTML. Returns a stream with a `pipe(res)` method to pipe the output and `abort()` to abort the request. Fully supports Suspense and streaming of HTML with "delayed" content blocks "popping in" via inline `<script>` tags later. [Read more](https://github.com/reactwg/react-18/discussions/37)
 
 If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) on a node that already has this server-rendered markup, React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
 
 ```javascript
 let didError = false;
-const {pipe, abort} = renderToPipeableStream(
+const stream = renderToPipeableStream(
   <App />,
   {
     onShellReady() {
@@ -54,7 +54,7 @@ const {pipe, abort} = renderToPipeableStream(
       // If something errored before we started streaming, we set the error code appropriately.
       res.statusCode = didError ? 500 : 200;
       res.setHeader('Content-type', 'text/html');
-      pipe(res);
+      stream.pipe(res);
     },
     onShellError(error) {
       // Something errored before we could complete the shell so we emit an alternative shell.
@@ -70,7 +70,7 @@ const {pipe, abort} = renderToPipeableStream(
 
       // res.statusCode = didError ? 500 : 200;
       // res.setHeader('Content-type', 'text/html');
-      // pipe(res);
+      // stream.pipe(res);
     },
     onError(x) {
       didError = true;


### PR DESCRIPTION
- Move renderToString + renderToStaticMarkup to the bottom
- Clarify which methods are supported in which environments
- Add links to full options
- Tweak usage examples