### PR TITLE
renderToReadableStream: Ensure same var name is used in `onError`

### DIFF
--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -109,9 +109,9 @@ try {
     </html>,
     {
       signal: controller.signal,
-      onError(e) {
+      onError(error) {
         didError = true;
-        console.error(err);
+        console.error(error);
       }
     }
   );


### PR DESCRIPTION
Parameter name did not match used name