### PR TITLE
Prefer build-time and render-time server-rendering to the SSG/SSR dis…

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -57,7 +57,7 @@ When you're ready to deploy to production, running `npm run build` will create a
 
 ### Next.js {#nextjs}
 
-[Next.js](https://nextjs.org/) is a popular and lightweight framework for **static and server‑rendered applications** built with React. It includes **styling and routing solutions** out of the box, and assumes that you're using [Node.js](https://nodejs.org/) as the server environment.
+[Next.js](https://nextjs.org/) is a popular and lightweight framework for **build-time and request-time server‑rendered applications** built with React. It includes **styling and routing solutions** out of the box, and assumes that you're using [Node.js](https://nodejs.org/) as the server environment.
 
 Learn Next.js from [its official guide](https://nextjs.org/learn/).
 


### PR DESCRIPTION
Ok, this sounds like a weird change, but bear with me. I've been doing some [formal research on SSR](https://tinyurl.com/ssr-theory) and I am convinced that we can vastly improve the current state of the industry by starting to use some better wording.

SSG and SSR is the terminology chosen by Next to distinguish build-time and request-time server-rendering. This terminology is historical, and well accepted, as most people mean "it's rendered at request-time, server-side" when they say SSR, and "it's rendered at build-time, server-side" when they say static.

Should we keep pushing this terminology? No, I can prove formally why it's wrong.

- It confuses many people, that don't get why "Server-Side Rendering" doesnt just mean "it's rendered on the server"

- People believe that there are 2 ways to do server-render. It's been true for a while but many technologies are exploring the space in between: Next.js ISR, Gatsby Deferred Static Rendering.

- It opposes SSR and SSG. If you see server-rendering as a big cache system for the web, SSG is simply a cache warm at build-time. SSR is a "cache miss". Next.js got it correctly, as ISR is "a cache that fills up when requested", well... like any good cache should do :)

I prefer to oppose "rendering times", so "Request Time Rendering" and "Build Time Rendering" for instance, making it clearer that those are not really incompatible choices, just configuration choice about when you render a page.

- It has been hindering further research on websites optimization.  Namely, people think you cannot use the Request object.

[SvelteKit](https://kit.svelte.dev/docs/page-options#prerender-when-not-to-prerender) states "The basic rule is this: for a page to be prerenderable, any two users hitting it directly must get the same content from the server."
This is maybe true for SvelteKit, but not true in the general case. I've heard the same idea from Gatsby, Astro. Even Next says that getStaticProps should be used when "The data can be publicly cached (not user-specific)" (which is all the more funny that I've coded a demo that bypass this limitation... using only Next.js)

With a simple redirection proxy (not even a full-fledged server, just something that can read "req" and redirect to any URL), you can bypass this limitation. If you don't believe me, check [Vercel Platforms implementation](https://github.com/vercel/platforms). It uses a tiny middleware and is able to prerender the same page for *different tenants*.

The problem is that the SSG/SSR distinction makes this way less obvious. The term "static" implies "there won't be any request processing". That's true at the app level, but apps are still run on servers. We can still put proxies in front of them. Therefore, we can make the "static"... dynamic again, and imagine incredible optimization, like prerendering paid, private, A/B tested, themed, internationalized, multi-tenant content without even running any Node server.

So, to sum it up, I believe this sentence is more correct this way

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
