### PR TITLE
docs: update setState hook in docs

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -187,6 +187,14 @@ In a function, we already have `setCount` and `count` as variables so we don't n
   </button>
 ```
 
+Alternatively, we can use the second form of setState() that accepts a function. That function will receive the previous state as the first argument `prevState`, which will always contain the modified state in the recent `setCount` call:
+
+```js{1}
+  <button onClick={() => setCount((prevState) => prevState + 1)}>
+    Click me
+  </button>
+```
+
 ## Recap {#recap}
 
 Let's now **recap what we learned line by line** and check our understanding.


### PR DESCRIPTION
Updated the doc to reflect the change for prevState callback on the [useState hook](https://reactjs.org/docs/hooks-state.html)  based on #4572



<img width="910" alt="Screen Shot 2022-04-18 at 18 28 07" src="https://user-images.githubusercontent.com/56383747/163840720-f5a39f74-7333-4b16-b9a0-a02bf69fd1d7.png">

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
