### PR TITLE
Update lists-and-keys.md

### DIFF
--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -119,7 +119,9 @@ const todoItems = todos.map((todo, index) =>
 );
 ```
 
-We don't recommend using indexes for keys if the order of items may change. This can negatively impact performance and may cause issues with component state. Check out Robin Pokorny's article for an [in-depth explanation on the negative impacts of using an index as a key](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318). If you choose not to assign an explicit key to list items then React will default to using indexes as keys.
+We don't recommend using indexes for keys if the order of items may change, or if items can be added to or removed from the array: this can cause issues with component state, leading to elements being rendered in the incorrect order, and to your application displaying incorrect data. (This can happen if such an array is ever filtered, sorted, or has elements added to / removed from it.)
+
+If you choose not to assign an explicit key to list items then React will default to using indexes as keys, though if your specific use case suits using the array index as the item key, it is better to do this explicitly, as it will serve to document this decision in your code, and will avoid linting warnings.
 
 Here is an [in-depth explanation about why keys are necessary](/docs/reconciliation.html#recursing-on-children) if you're interested in learning more.
 


### PR DESCRIPTION
Removed indication that use of indexes for keys can cause issues with performance, as the issue is with behind-the-scenes misidentification of children, not with performance.

Added suggestion to only use key={index} explicitly, in order to self-document the decision to do so, and to avoid linting warnings.

Removed the reference to Robin Pokorny article, as the quality is not suitable:
 - Using on-the-fly custom IDs is not "much better" than using an array items' IDs, if the items have them (Pokorny's reference to the 'nanoid' package); it is more complex, involves adding a dependency, and it solves the problem of generating IDs for new data, not of assigning a unique key when mapping arrays in React applications.
 - Of the three items listed for the "exception from the rule" update, items 1 and 2 are not necessary:
   1. Content can be generated dynamically and can change, as long as the new content is generated strictly in place of the old content.
   2. Although using an item's 'id' property is often a good practice, if available, it is not strictly necessary, as the items' indices will still be persistent and unique as long as the items are not reordered or filtered. (Adding or removing items only at the end of an array is also okay, but likely a bad practice; as items could be added or removed, but probably not both)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
