### PR TITLE
Replaced old ReactDOM API with new React v18 API

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -36,6 +36,7 @@ function Greeting(props) {
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root')); 
+// Try changing to isLoggedIn={true}:
 root.render(<Greeting isLoggedIn={false} />);
 ```
 

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -35,9 +35,8 @@ function Greeting(props) {
   return <GuestGreeting />;
 }
 
-ReactDOM
-  .createRoot(document.getElementById('root'))
-  .render(<Greeting isLoggedIn={false} />);
+const root = ReactDOM.createRoot(document.getElementById('root')); 
+root.render(<Greeting isLoggedIn={false} />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/ZpVxNq?editors=0011)
@@ -108,9 +107,8 @@ class LoginControl extends React.Component {
   }
 }
 
-ReactDOM
-  .createRoot(document.getElementById('root'))
-  .render(<LoginControl />);
+const root = ReactDOM.createRoot(document.getElementById('root')); 
+root.render(<LoginControl />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/QKzAgB?editors=0010)
@@ -138,9 +136,8 @@ function Mailbox(props) {
 
 const messages = ['React', 'Re: React', 'Re:Re: React'];
 
-ReactDOM
-  .createRoot(document.getElementById('root'))
-  .render(<Mailbox unreadMessages={messages} />);
+const root = ReactDOM.createRoot(document.getElementById('root')); 
+root.render(<Mailbox unreadMessages={messages} />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/ozJddz?editors=0010)
@@ -241,9 +238,8 @@ class Page extends React.Component {
   }
 }
 
-ReactDOM
-  .createRoot(document.getElementById('root'))
-  .render(<Page />);
+const root = ReactDOM.createRoot(document.getElementById('root')); 
+root.render(<Page />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/Xjoqwm?editors=0010)

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -35,11 +35,9 @@ function Greeting(props) {
   return <GuestGreeting />;
 }
 
-ReactDOM.render(
-  // Try changing to isLoggedIn={true}:
-  <Greeting isLoggedIn={false} />,
-  document.getElementById('root')
-);
+ReactDOM
+  .createRoot(document.getElementById('root'))
+  .render(<Greeting isLoggedIn={false} />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/ZpVxNq?editors=0011)
@@ -110,10 +108,9 @@ class LoginControl extends React.Component {
   }
 }
 
-ReactDOM.render(
-  <LoginControl />,
-  document.getElementById('root')
-);
+ReactDOM
+  .createRoot(document.getElementById('root'))
+  .render(<LoginControl />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/QKzAgB?editors=0010)
@@ -140,10 +137,10 @@ function Mailbox(props) {
 }
 
 const messages = ['React', 'Re: React', 'Re:Re: React'];
-ReactDOM.render(
-  <Mailbox unreadMessages={messages} />,
-  document.getElementById('root')
-);
+
+ReactDOM
+  .createRoot(document.getElementById('root'))
+  .render(<Mailbox unreadMessages={messages} />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/ozJddz?editors=0010)
@@ -244,10 +241,9 @@ class Page extends React.Component {
   }
 }
 
-ReactDOM.render(
-  <Page />,
-  document.getElementById('root')
-);
+ReactDOM
+  .createRoot(document.getElementById('root'))
+  .render(<Page />);
 ```
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/Xjoqwm?editors=0010)


### PR DESCRIPTION
Replaced old ReactDOM API with new React v18 API
```
ReactDOM.render(
  // Try changing to isLoggedIn={true}:
  <Greeting isLoggedIn={false} />,
  document.getElementById('root')
);
```
The above implementation has been replaced by the following implementation according to React v18. 

```
ReactDOM
  .createRoot(document.getElementById('root'))
  .render(<LoginControl />);
```
<!--

Thank you for the PR! Contributors like you keep React awesomely!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
