### PR TITLE
Fix behavior of renderToStaticMarkup

### DIFF
--- a/content/blog/2022-03-08-react-18-upgrade-guide.md
+++ b/content/blog/2022-03-08-react-18-upgrade-guide.md
@@ -296,7 +296,7 @@ If you need to support Internet Explorer we recommend you stay with React 17.
 ### React DOM Server {#react-dom-server}
 
 * **`renderToString`:** Will no longer error when suspending on the server. Instead, it will emit the fallback HTML for the closest `<Suspense>` boundary and then retry rendering the same content on the client. It is still recommended that you switch to a streaming API like `renderToPipeableStream` or `renderToReadableStream` instead.
-* **`renderToStaticMarkup`:** Will no longer error when suspending on the server. Instead, it will emit the fallback HTML for the closest `<Suspense>` boundary and retry rendering on the client.
+* **`renderToStaticMarkup`:** Will no longer error when suspending on the server. Instead, it will emit the fallback HTML for the closest `<Suspense>` boundary.
 
 ## Changelog {#changelog}
 


### PR DESCRIPTION
If I understand correctly, output from `renderToStaticMarkup` cannot be hydrated, so it's impossible to retry the rendering of its contents on the client.