### PR TITLE
Fix grammar

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -48,7 +48,7 @@ Function and Class components both have some additional features that we will di
 
 ## Rendering a Component {#rendering-a-component}
 
-Previously, we only encountered React elements that represent DOM tags:
+Previously, we encountered only React elements that represent DOM tags:
 
 ```js
 const element = <div />;


### PR DESCRIPTION
In sentence:
> Previously, we only encountered React elements that represent DOM tags

emphasis is on "React elements" and not the action "encountered". So, "only" needs to be placed before "React elements".

For examples,
```
- We only played.        // we did nothing else apart from playing
- We played only chess.  // we played no other games but chess
```

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
