### PR TITLE
Update Docs

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -72,6 +72,10 @@ function WarningButton() {
 
 If you don't use a JavaScript bundler and loaded React from a `<script>` tag, it is already in scope as the `React` global.
 
+>**Note:**
+>
+>Since version 17, there is a new [JSX Transform](/blog/2020/09/22/introducing-the-new-jsx-transform.html) that allows you not to import React.
+
 ### Using Dot Notation for JSX Type {#using-dot-notation-for-jsx-type}
 
 You can also refer to a React component using dot-notation from within JSX. This is convenient if you have a single module that exports many React components. For example, if `MyComponents.DatePicker` is a component, you can use it directly from JSX with:

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -412,6 +412,10 @@ Children passed to a custom component can be anything, as long as that component
 
 `false`, `null`, `undefined`, and `true` are valid children. They simply don't render. These JSX expressions will all render to the same thing:
 
+>**Note:**
+>
+>Since version 18, React rendering `undefined`.
+
 ```js
 <div />
 


### PR DESCRIPTION
The old version of documentation (about class-based components) doesn't seem to have updated the new changes.
Can you check if these fixes are correct?