### PR TITLE
Explicitly list what methods are included in unmounting and remounting

### DIFF
--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -172,10 +172,6 @@ When the component unmounts, effects are destroyed as normal:
   * Effect effects are destroyed.
 ```
 
-> Note:
->
-> This only applies to development mode, _production behavior is unchanged_.
-
 Unmounting and remounting includes:
 
 - `componentDidMount`
@@ -183,6 +179,10 @@ Unmounting and remounting includes:
 - `useEffect`
 - `useLayoutEffect`
 - `useInsertionEffect`
+
+> Note:
+>
+> This only applies to development mode, _production behavior is unchanged_.
 
 For help supporting common issues, see:
   - [How to support Reusable State in Effects](https://github.com/reactwg/react-18/discussions/18)

--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -21,7 +21,7 @@ In the above example, strict mode checks will *not* be run against the `Header` 
 * [Warning about deprecated findDOMNode usage](#warning-about-deprecated-finddomnode-usage)
 * [Detecting unexpected side effects](#detecting-unexpected-side-effects)
 * [Detecting legacy context API](#detecting-legacy-context-api)
-* [Detecting unsafe effects](#detecting-unsafe-effects)
+* [Ensuring reusable state](#ensuring-reusable-state)
 
 Additional functionality will be added with future releases of React.
 
@@ -175,6 +175,14 @@ When the component unmounts, effects are destroyed as normal:
 > Note:
 >
 > This only applies to development mode, _production behavior is unchanged_.
+
+Unmounting and remounting includes:
+
+- `componentDidMount`
+- `componentWillUnmount`
+- `useEffect`
+- `useLayoutEffect`
+- `useInsertionEffect`
 
 For help supporting common issues, see:
   - [How to support Reusable State in Effects](https://github.com/reactwg/react-18/discussions/18)


### PR DESCRIPTION
[Preview](https://reactjs-60pzl97ut-fbopensource.vercel.app/docs/strict-mode.html#ensuring-reusable-state)
To help discoverability of what Strict Effects affects (e.g. CTRL+f "componentDidMount").
Originally reported in  https://github.com/facebook/react/issues/24467#issuecomment-1114185870