### PR TITLE
Expand renderToPipeableStream()’s documentation

### DIFF
--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -84,7 +84,7 @@ const stream = renderToPipeableStream(
 
 If you’d like to support clients that can’t run client-side JavaScript such as crawlers, you can wait until **all** suspended blocks are ready and then stream the HTML in one go.
 
-To do so, implement the `onAllReady` callback and start piping the stream into your response here. The `onError` option will be called if an error occurs during rendering, while may mean you HTML will only be partially outputted up to the point the error occurred.
+To do so, implement the `onAllReady` callback and start piping the stream into your response here. The `onError` option will be called if an error occurs during rendering, which may mean you HTML will only be partially outputted up to the point the error occurred.
 
 ```javascript
 let didError = false;

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -116,13 +116,13 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 - `onShellError?: () => void` — called if an error occurs while rendering the initial shell.
 - `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming.
 - `onError?: (error: mixed) => void` — (called when?)
-- `identifierPrefix?: string`
-- `namespaceURI?: string` — supports `http://www.w3.org/2000/svg` for SVGs or `http://www.w3.org/1998/Math/MathML` for MathML
-- `nonce?: string`
-- `bootstrapScriptContent?: string`
-- `bootstrapScripts?: Array<string>`
-- `bootstrapModules?: Array<string>`
-- `progressiveChunkSize?: number`
+- `identifierPrefix?: string` — prefix for all generated [`useId()`](https://reactjs.org/docs/hooks-reference.html#useid) values to prevent collisions in multi-root apps. Must be the same prefix passed to [`hydrateRoot()`](https://reactjs.org/docs/react-dom-client.html#hydrateroot)
+- `namespaceURI?: string` — supports `http://www.w3.org/2000/svg` for SVGs or `http://www.w3.org/1998/Math/MathML` for MathML.
+- `nonce?: string` — sets the [`nonce` attribute](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) to allow scripts in a [script-src Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
+- `bootstrapScriptContent?: string` — inline `<script>` to include.
+- `bootstrapScripts?: Array<string>` — external `<script>` to include.
+- `bootstrapModules?: Array<string>` — external `<script type="module">` to include.
+- `progressiveChunkSize?: number` — [read more](https://github.com/facebook/react/blob/14c2be8dac2d5482fda8a0906a31d239df8551fc/packages/react-server/src/ReactFizzServer.js#L210)
 
 > Note:
 >

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -114,7 +114,7 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 
 #### Options
 
-- `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline `<script>` tags.
+- `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline `<script>` tags once they are ready.
 - `onShellError?: () => void` — called if an error occurs while rendering the initial shell.
 - `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming. Start piping into your response here and the entire HTML tree will be outputted in one go.
 - `onError?: (error: mixed) => void` — (called when?)

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -44,7 +44,6 @@ Render a React element to its initial HTML without interaction. Returns a [Node.
 
 This method fully supports Suspense, allowing you to stream in suspended content blocks as they become ready.
 
-
 An initial HTML shell with your suspense fallbacks is first outputted, and then content blocks are "popped in" when ready via inline `<script>` tags later. [Read more on how this works](https://github.com/reactwg/react-18/discussions/37)
 
 To get this behaviour, implement the `onShellReady` callback and start piping the stream into your response here. The `onShellError` option will be called if an error occurs before the shell was ready. The `onError` option will be called if an error occurs after the shell is ready.

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -122,9 +122,9 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 #### Options
 
 - `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline `<script>` tags once they are ready.
-- `onShellError?: () => void` — called if an error occurs while rendering the initial shell.
+- `onShellError?: () => void` — called if an error occurs while rendering the initial shell. No bytes will be emitted from the stream and `onShellReady` and other callbacks won’t be called.
 - `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming. Start piping into your response here and the entire HTML tree will be outputted in one go.
-- `onError?: (error: mixed) => void` — (called when?)
+- `onError?: (error: mixed) => void` — called if an error occurs during rendering, including from suspended content.
 - `identifierPrefix?: string` — prefix for all generated [`useId()`](https://reactjs.org/docs/hooks-reference.html#useid) values to prevent collisions in multi-root apps. Must be the same prefix passed to [`hydrateRoot()`](https://reactjs.org/docs/react-dom-client.html#hydrateroot)
 - `namespaceURI?: string` — supports `http://www.w3.org/2000/svg` for SVGs or `http://www.w3.org/1998/Math/MathML` for MathML.
 - `nonce?: string` — sets the [`nonce` attribute](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#nonce) to allow scripts in a [script-src Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -112,9 +112,9 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 
 #### Options
 
-- `onShellReady?: () => void` — use to stream a initial shell and then 
+- `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline <script> tags.
 - `onShellError?: () => void` — called if an error occurs while rendering the initial shell.
-- `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming.
+- `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming. Start piping into your response here and the entire HTML tree will be outputted in one go.
 - `onError?: (error: mixed) => void` — (called when?)
 - `identifierPrefix?: string` — prefix for all generated [`useId()`](https://reactjs.org/docs/hooks-reference.html#useid) values to prevent collisions in multi-root apps. Must be the same prefix passed to [`hydrateRoot()`](https://reactjs.org/docs/react-dom-client.html#hydrateroot)
 - `namespaceURI?: string` — supports `http://www.w3.org/2000/svg` for SVGs or `http://www.w3.org/1998/Math/MathML` for MathML.

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -56,7 +56,7 @@ const stream = renderToPipeableStream(
   <App />,
   {
     onError(err) {
-      // Something errored after the shell was completed. It could have been a suspended resource or within a suspensed component tree.
+      // Something errored. It could have been a suspended resource or within a suspensed component tree.
       // This can be called _before_ onShellReady() even though the shell will be successfully outputted, so record that fact so we can send a 500 status.
       didError = true;
       console.error(err);
@@ -93,7 +93,7 @@ const stream = renderToPipeableStream(
   <App />,
   {
     onError(err) {
-      // Something errored after the shell was completed. It could have been a suspended resource or within a suspensed component tree.
+      // Something errored. It could have been a suspended resource or within a suspensed component tree.
       // This can be called _before_ onShellReady() even though the shell will be successfully outputted, so record that fact so we can send a 500 status.
       didError = true;
       console.error(err);

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -63,7 +63,7 @@ const stream = renderToPipeableStream(
     },
     onShellError(error) {
       // Something errored before we could complete the shell so we emit an alternative shell.
-      // The stream can be safely ignored — `onShellReady` won’t be called.
+      // The stream is destroyed and `onShellReady` won’t be called, so you can send your own response.
       res.statusCode = 500;
       res.send(
         '<!doctype html><p>Loading...</p><script src="clientrender.js"></script>'
@@ -100,7 +100,7 @@ const stream = renderToPipeableStream(
     },
     onShellError(error) {
       // Something errored before we could complete the shell so we emit an alternative shell.
-      // The stream can be safely ignored — `onShellReady` won’t be called.
+      // The stream is destroyed and `onShellReady` won’t be called, so you can send your own response.
       res.statusCode = 500;
       res.send(
         '<!doctype html><p>Loading...</p><script src="clientrender.js"></script>'
@@ -122,7 +122,7 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 #### Options
 
 - `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline `<script>` tags once they are ready.
-- `onShellError?: () => void` — called if an error occurs while rendering the initial shell. No bytes will be emitted from the stream and `onShellReady` and other callbacks won’t be called.
+- `onShellError?: () => void` — called if an error occurs while rendering the initial shell. No bytes will be emitted from the stream and `onShellReady` and other callbacks won’t be called, so you can output your own response.
 - `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming. Start piping into your response here and the entire HTML tree will be outputted in one go.
 - `onError?: (error: mixed) => void` — called if an error occurs during rendering, including from suspended content.
 - `identifierPrefix?: string` — prefix for all generated [`useId()`](https://reactjs.org/docs/hooks-reference.html#useid) values to prevent collisions in multi-root apps. Must be the same prefix passed to [`hydrateRoot()`](https://reactjs.org/docs/react-dom-client.html#hydrateroot)

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -114,7 +114,7 @@ If you call [`ReactDOM.hydrateRoot()`](/docs/react-dom-client.html#hydrateroot) 
 
 #### Options
 
-- `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline <script> tags.
+- `onShellReady?: () => void` — called when an initial shell is ready to be streamed. Start piping into your response here and suspended content blocks will "pop in" via inline `<script>` tags.
 - `onShellError?: () => void` — called if an error occurs while rendering the initial shell.
 - `onAllReady?: () => void` — use instead of `onShellReady` to wait for all suspense boundaries to be ready before streaming. Start piping into your response here and the entire HTML tree will be outputted in one go.
 - `onError?: (error: mixed) => void` — (called when?)

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -46,7 +46,7 @@ Rendering a root `<html>` element will include a doctype (`<!DOCTYPE html>`) for
 
 This method fully supports Suspense, allowing you to stream in suspended content blocks as they become ready.
 
-An initial HTML shell with your suspense fallbacks is first outputted, and then content blocks are "popped in" when ready via inline `<script>` tags later. [Read more on how this works](https://github.com/reactwg/react-18/discussions/37)
+An initial HTML "shell" with your suspense fallbacks is sent first, and then content blocks are "popped in" when ready via inline `<script>` tags later. [Read more on how this works](https://github.com/reactwg/react-18/discussions/37)
 
 To get this behaviour, implement the `onShellReady` callback and start piping the stream into your response here.
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -42,6 +42,8 @@ ReactDOMServer.renderToPipeableStream(element, options)
 
 Render a React element to its initial HTML without interaction. Returns a [Node.js stream](https://nodejs.dev/learn/nodejs-streams) with a `pipe(res)` method to pipe the output and `abort()` to abort the request.
 
+Rendering a root `<html>` element will include a doctype (`<!DOCTYPE html>`) for you.
+
 This method fully supports Suspense, allowing you to stream in suspended content blocks as they become ready.
 
 An initial HTML shell with your suspense fallbacks is first outputted, and then content blocks are "popped in" when ready via inline `<script>` tags later. [Read more on how this works](https://github.com/reactwg/react-18/discussions/37)


### PR DESCRIPTION
The documentation to `renderToPipeableStream()` is a sparse. For example, the current documentation links out the React source code for a full list of options. It also doesn’t explain that you can opt-out of the inline `<script>` approach by using the `onAllReady` callback.

This is a draft that I hope can be iterated on to clarify and expand the documentation. I won’t be offended if you don’t like my long headings or how I’ve structure it. I hope it provides a good first step to explain the core behaviour.

See: https://twitter.com/dan_abramov/status/1521297849593614339

Note that some terms seem interchangeable. I’ve tried using “ready” as that what the callbacks are named. It perhaps would be helpful to settle on canonical terms for:

- Suspended content blocks vs suspended content boundaries
- Ready vs Resolved vs Loaded vs Unsuspended
- Initial HTML vs Initial HTML shell

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
