### PR TITLE
fix useref: small typo in the code snipped

### DIFF
--- a/beta/src/pages/apis/useref.md
+++ b/beta/src/pages/apis/useref.md
@@ -592,7 +592,7 @@ const MyInput = forwardRef(({ value, onChange }, ref) => {
       ref={ref}
     />
   );
-};
+});
 
 export default MyInput;
 ```


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Added a missing closing bracket in the code snippet for `forwardRef` function. Feel free to merge or disregard if already fixed. 
Thanks! 