### PR TITLE
Tutorial markdown changes for React18

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -106,7 +106,7 @@ cd ..
 
 ```js
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 ```
 


### PR DESCRIPTION
Since ReactDOM.render has been deprecated from React-18, we have to have start using createRoot which is part of react-dom/client.

The [starter code](https://codepen.io/gaearon/pen/oWWQNa?editors=0010) having the ReactDOM.createRoot but we documented like we have to import ReactDOM from 'react-dom'. That's making confusion to the new react developers and also facing this warning in the console.

`Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".`


Changes👇

Before:
<img width="1671" alt="Before" src="https://user-images.githubusercontent.com/30945817/166890659-ffae8896-83df-4717-bfca-ac014d97c2ed.png">

After:
<img width="1673" alt="After" src="https://user-images.githubusercontent.com/30945817/166890740-8397a9ea-8832-47f3-8c9b-feec0ca363ca.png">
