### PR TITLE
Changing Page Title

### DIFF
--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -1,6 +1,6 @@
 ---
 id: dom-elements
-title: DOM Elements
+title: DOM Elements - Differences in Attributes
 layout: docs
 category: Reference
 permalink: docs/dom-elements.html
@@ -16,11 +16,7 @@ redirect_from:
 
 React implements a browser-independent DOM system for performance and cross-browser compatibility. We took the opportunity to clean up a few rough edges in browser DOM implementations.
 
-In React, all DOM properties and attributes (including event handlers) should be camelCased. For example, the HTML attribute `tabindex` corresponds to the attribute `tabIndex` in React. The exception is `aria-*` and `data-*` attributes, which should be lowercased. For example, you can keep `aria-label` as `aria-label`.
-
-## Differences In Attributes {#differences-in-attributes}
-
-There are a number of attributes that work differently between React and HTML:
+In React, all DOM properties and attributes (including event handlers) should be camelCased. For example, the HTML attribute `tabindex` corresponds to the attribute `tabIndex` in React. The exception is `aria-*` and `data-*` attributes, which should be lowercased. For example, you can keep `aria-label` as `aria-label`. There are a number of attributes that work differently between React and HTML:
 
 ### checked {#checked}
 


### PR DESCRIPTION
The page title does not exactly reflect the page content and I think it would be helpful to rename the page title to **DOM Elements - Differences In Attributes**.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
