### PR TITLE
[Beta] Update sandboxes to use 18

### DIFF
--- a/beta/patches/@codesandbox+sandpack-react+0.14.3-experimental.1.patch
+++ b/beta/patches/@codesandbox+sandpack-react+0.14.3-experimental.1.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@codesandbox/sandpack-react/dist/esm/index.js b/node_modules/@codesandbox/sandpack-react/dist/esm/index.js
+index 4acfc3a..cdb83f1 100644
+--- a/node_modules/@codesandbox/sandpack-react/dist/esm/index.js
++++ b/node_modules/@codesandbox/sandpack-react/dist/esm/index.js
+@@ -566,17 +566,16 @@ var REACT_TEMPLATE = {
+     },
+     "/index.js": {
+       code: `import React, { StrictMode } from "react";
+-import ReactDOM from "react-dom";
++import { createRoot } from "react-dom";
+ import "./styles.css";
+ 
+ import App from "./App";
+ 
+-const rootElement = document.getElementById("root");
+-ReactDOM.render(
++const root = createRoot(document.getElementById("root"));
++root.render(
+   <StrictMode>
+     <App />
+-  </StrictMode>,
+-  rootElement
++  </StrictMode>
+ );`
+     },
+     "/styles.css": {
+@@ -611,8 +610,8 @@ h1 {
+     }
+   },
+   dependencies: {
+-    react: "^17.0.0",
+-    "react-dom": "^17.0.0",
++    react: "^18.0.0",
++    "react-dom": "^18.0.0",
+     "react-scripts": "^4.0.0"
+   },
+   entry: "/index.js",


### PR DESCRIPTION
Could make a custom template but I'm too lazy. At some point https://github.com/codesandbox/sandpack/pull/460 will get merged and then we can remove this. I've done some cursory testing and it seems fine.