### PR TITLE
Fixes layout shift

### DIFF
--- a/beta/src/components/MDX/ExpandableCallout.tsx
+++ b/beta/src/components/MDX/ExpandableCallout.tsx
@@ -41,6 +41,7 @@ function ExpandableCallout({children, type}: ExpandableCalloutProps) {
   return (
     <div
       className={cn(
+        'expandable-callout',
         'pt-8 pb-4 px-5 sm:px-8 my-8 relative rounded-none shadow-inner -mx-5 sm:mx-auto sm:rounded-lg',
         variant.containerClasses
       )}>

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -302,3 +302,9 @@ html.dark .sp-devtools > div {
     max-height: unset;
   }
 }
+
+.expandable-callout .sp-stack:nth-child(2) {
+  min-width: 431px;
+  min-height: 40vh;
+  max-height: 40vh;
+}


### PR DESCRIPTION
Fixes 
- https://github.com/reactjs/reactjs.org/issues/4638


Seems like the pitfall sandpack had output at bottom and the output screen didn't have a min height so it was reducing when the iframe inside it was killed. So added a default min height when it is inside expandable callouts