### PR TITLE
Small correction

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -583,7 +583,7 @@ component.forceUpdate(callback)
 
 By default, when your component's state or props change, your component will re-render. If your `render()` method depends on some other data, you can tell React that the component needs re-rendering by calling `forceUpdate()`.
 
-Calling `forceUpdate()` will cause `render()` to be called on the component, skipping `shouldComponentUpdate()`. This will trigger the normal lifecycle methods for child components, including the `shouldComponentUpdate()` method of each child. React will still only update the DOM if the markup changes.
+Calling `forceUpdate()` will cause `render()` to be called on the component, skipping `shouldComponentUpdate()`. This will trigger the normal lifecycle methods for child components, including the `shouldComponentUpdate()` method of each child. React will still update the DOM only if the markup changes.
 
 Normally you should try to avoid all uses of `forceUpdate()` and only read from `this.props` and `this.state` in `render()`.
 
@@ -635,7 +635,7 @@ The `displayName` string is used in debugging messages. Usually, you don't need 
 
 `this.props` contains the props that were defined by the caller of this component. See [Components and Props](/docs/components-and-props.html) for an introduction to props.
 
-In particular, `this.props.children` is a special prop, typically defined by the child tags in the JSX expression rather than in the tag itself.
+In particular, `this.props.children` is a special prop, typically represents the child tags in the JSX expression.
 
 ### `state` {#state}
 


### PR DESCRIPTION
1. In the section:
> `this.props` contains the props that were defined by the caller of this component. See Components and Props for an introduction to props.
In particular, `this.props.children` is a special prop, typically defined by the child tags in the JSX expression rather than in the tag itself.

 The statement “`this.props.children` represents the child tags”  is more clear than “`this.props.children` is defined by the child tags”. Because in the statement above we are saying “The caller component defines the props contained in `this.props`”.

2. These two statements have different meaning: 
- React will still only update the DOM...
- React will still update the DOM only if the markup changes.

I think we mean the later statment.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
