### PR TITLE
update useEffect doc to bring attention to when cleanup runs

### DIFF
--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -226,7 +226,7 @@ function FriendStatus(props) {
 
 **Why did we return a function from our effect?** This is the optional cleanup mechanism for effects. Every effect may return a function that cleans up after it. This lets us keep the logic for adding and removing subscriptions close to each other. They're part of the same effect!
 
-**When exactly does React clean up an effect?** React performs the cleanup when the component unmounts. However, as we learned earlier, effects run for every render and not just once. This is why React *also* cleans up effects from the previous render before running the effects next time. We'll discuss [why this helps avoid bugs](#explanation-why-effects-run-on-each-update) and [how to opt out of this behavior in case it creates performance issues](#tip-optimizing-performance-by-skipping-effects) later below.
+**When exactly does React clean up an effect?** Not only does React perform the cleanup when the component unmounts it *also* performs the clean up before each rerender. We'll discuss [why this helps avoid bugs](#explanation-why-effects-run-on-each-update) and [how to opt out of this behavior in case it creates performance issues](#tip-optimizing-performance-by-skipping-effects) later below.
 
 >Note
 >

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -132,7 +132,7 @@ By default, effects run after every completed render, but you can choose to fire
 
 #### Cleaning up an effect {#cleaning-up-an-effect}
 
-Often, effects create resources that need to be cleaned up before the component leaves the screen, such as a subscription or timer ID. To do this, the function passed to `useEffect` may return a clean-up function. For example, to create a subscription:
+Often, effects create resources (subscriptions, timers, listeners) that need to be cleaned up before the component leaves the screen or before the component rerenders. To do this, the function passed to `useEffect` may return a clean-up function. For example, to create a subscription:
 
 ```js
 useEffect(() => {
@@ -144,7 +144,7 @@ useEffect(() => {
 });
 ```
 
-The clean-up function runs before the component is removed from the UI to prevent memory leaks. Additionally, if a component renders multiple times (as they typically do), the **previous effect is cleaned up before executing the next effect**. In our example, this means a new subscription is created on every update. To avoid firing an effect on every update, refer to the next section.
+The clean-up function runs **before the component is removed from the UI** (preventing memory leaks) and **before the component rerenders** (as they typically do). In our example, a new subscription is created on initial render **and** on every update. To avoid firing an effect on every update, refer to the next section.
 
 #### Timing of effects {#timing-of-effects}
 


### PR DESCRIPTION
Hi there, I was thinking about the useEffect hook documentation, and specifically how people like myself will skim doc (sometimes only reading the first sentence of a paragraph) looking for a quick answer. 

The question I think could use a dead-simple answer is 'when do effect cleanup functions run?'. If you read the doc too quickly, I think the takeaway might be 'React performs the cleanup when the component unmounts.'.

Here are some proposed changes, maybe too many. Please let me know if any of them are useful/desirable. I will gladly make any edits.

Thanks.

Addl note:
I'm aware of the additional section 'Does useEffect run after every render?'. My eyes just never found it.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
