### PR TITLE
fix(reference-react-dom-client): fix the hydration mismatch note as per React 18

### DIFF
--- a/content/docs/reference-react-dom-client.md
+++ b/content/docs/reference-react-dom-client.md
@@ -83,4 +83,4 @@ Same as [`createRoot()`](#createroot), but is used to hydrate a container whose 
 
 > Note
 > 
-> React expects that the rendered content is identical between the server and the client. It can patch up differences in text content, but you should treat mismatches as bugs and fix them. In development mode, React warns about mismatches during hydration. There are no guarantees that attribute differences will be patched up in case of mismatches. This is important for performance reasons because in most apps, mismatches are rare, and so validating all markup would be prohibitively expensive.
+> React expects that the rendered content is identical between the server and the client. Starting React v18, Hydration mismatches due to missing or extra text content are treated like errors instead of warnings.


### PR DESCRIPTION
As per [the breaking change mentioned in React 18 Upgrade Guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#other-breaking-changes), hydration mismatch is now treated as an error instead of a warning and React doesn't try to patch text nodes.

I think the note on `hydrateRoot` wasn't updated for this change.

Let me know if you need some rephrasing or if I misunderstood some part. Thanks!