### PR TITLE
[beta] fix(eslint): exclude parsing errors

### DIFF
--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import {useSandpack, LoadingOverlay} from '@codesandbox/sandpack-react';
 import cn from 'classnames';
 import {Error} from './Error';
-import type {LintDiagnostic} from './utils';
+import type {LintDiagnostic} from './useSandpackLint';
 
 const generateRandomId = (): string =>
   Math.floor(Math.random() * 10000).toString();

--- a/beta/src/components/MDX/Sandpack/runESLint.tsx
+++ b/beta/src/components/MDX/Sandpack/runESLint.tsx
@@ -41,7 +41,7 @@ const options = {
 
 export const runESLint = (
   doc: Text
-): {errors: any[]; codeMirrorPayload: Diagnostic[]} => {
+): {errors: any[]; codeMirrorErrors: Diagnostic[]} => {
   const codeString = doc.toString();
   const errors = linter.verify(codeString, options) as any[];
 
@@ -50,7 +50,7 @@ export const runESLint = (
     2: 'error',
   };
 
-  const codeMirrorPayload = errors
+  const codeMirrorErrors = errors
     .map((error) => {
       if (!error) return undefined;
 
@@ -65,6 +65,7 @@ export const runESLint = (
       });
 
       return {
+        ruleId: error.ruleId,
         from,
         to,
         severity: severity[error.severity],
@@ -74,7 +75,7 @@ export const runESLint = (
     .filter(Boolean) as Diagnostic[];
 
   return {
-    codeMirrorPayload,
+    codeMirrorErrors,
     errors: errors.map((item) => {
       return {
         ...item,

--- a/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
+++ b/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
@@ -25,10 +25,11 @@ export const useSandpackLint = () => {
   const onLint = linter(async (props: EditorView) => {
     const {runESLint} = await import('./runESLint');
     const editorState = props.state.doc;
-    let {errors, codeMirrorPayload} = runESLint(editorState);
-    // Only show errors from rules, not parsing errors etc
-    setLintErrors(errors.filter((e) => !e.fatal));
-    return codeMirrorPayload;
+    let {errors, codeMirrorErrors} = runESLint(editorState);
+    // Ignore parsing or internal linter errors.
+    const isReactRuleError = (error: any) => error.ruleId != null;
+    setLintErrors(errors.filter(isReactRuleError));
+    return codeMirrorErrors.filter(isReactRuleError);
   });
 
   return {lintErrors, lintExtensions: [onLint]};


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Hey! I noted that https://github.com/reactjs/reactjs.org/pull/4666 was trying to remove parsing errors from the Eslint list of errors, but it was missing to filter the errors to the CodeMirror errors too. So it addresses: 
- Filter parsing errors from CodeMirror integration;
- Avoid redundant calls for eslint diagnostic;

| Before | After |
| - | - |
| <img width="506" alt="Screenshot 2022-05-23 at 14 52 44" src="https://user-images.githubusercontent.com/4838076/169834852-5cef85fb-11dd-4ad1-9f35-e590942d92bf.png"> | <img width="489" alt="Screenshot 2022-05-23 at 14 53 15" src="https://user-images.githubusercontent.com/4838076/169834954-bdf2f4a5-1113-483d-b069-38d58131949b.png"> | 


