### PR TITLE
[Beta] Enable Selective Hydration in more places

### DIFF
--- a/beta/src/components/Layout/Nav/MobileNav.tsx
+++ b/beta/src/components/Layout/Nav/MobileNav.tsx
@@ -57,7 +57,10 @@ export function MobileNav() {
           API
         </TabButton>
       </div>
-      <SidebarRouteTree routeTree={tree as RouteItem} isMobile={true} />
+      {/* No fallback UI so need to be careful not to spend directly inside. */}
+      <React.Suspense fallback={null}>
+        <SidebarRouteTree routeTree={tree as RouteItem} isMobile={true} />
+      </React.Suspense>
     </>
   );
 }

--- a/beta/src/components/Layout/Nav/MobileNav.tsx
+++ b/beta/src/components/Layout/Nav/MobileNav.tsx
@@ -57,7 +57,7 @@ export function MobileNav() {
           API
         </TabButton>
       </div>
-      {/* No fallback UI so need to be careful not to spend directly inside. */}
+      {/* No fallback UI so need to be careful not to suspend directly inside. */}
       <React.Suspense fallback={null}>
         <SidebarRouteTree routeTree={tree as RouteItem} isMobile={true} />
       </React.Suspense>

--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -26,7 +26,7 @@ export function Page({routeTree, children}: PageProps) {
               <Sidebar />
             </div>
 
-            {/* No fallback UI so need to be careful not to spend directly inside. */}
+            {/* No fallback UI so need to be careful not to suspend directly inside. */}
             <React.Suspense fallback={null}>
               <div className="flex flex-1 w-full h-full self-stretch">
                 <div className="w-full min-w-0">

--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -26,14 +26,17 @@ export function Page({routeTree, children}: PageProps) {
               <Sidebar />
             </div>
 
-            <div className="flex flex-1 w-full h-full self-stretch">
-              <div className="w-full min-w-0">
-                <main className="flex flex-1 self-stretch mt-16 sm:mt-10 flex-col items-end justify-around">
-                  {children}
-                  <Footer />
-                </main>
+            {/* No fallback UI so need to be careful not to spend directly inside. */}
+            <React.Suspense fallback={null}>
+              <div className="flex flex-1 w-full h-full self-stretch">
+                <div className="w-full min-w-0">
+                  <main className="flex flex-1 self-stretch mt-16 sm:mt-10 flex-col items-end justify-around">
+                    {children}
+                    <Footer />
+                  </main>
+                </div>
               </div>
-            </div>
+            </React.Suspense>
           </div>
         </SidebarContext.Provider>
       </MenuProvider>

--- a/beta/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/beta/src/components/Layout/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ export function Sidebar() {
         {isMobileSidebar ? (
           <MobileNav />
         ) : (
-          /* No fallback UI so need to be careful not to spend directly inside. */
+          /* No fallback UI so need to be careful not to suspend directly inside. */
           <React.Suspense fallback={null}>
             <SidebarRouteTree routeTree={routeTree} />
           </React.Suspense>

--- a/beta/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/beta/src/components/Layout/Sidebar/Sidebar.tsx
@@ -42,7 +42,10 @@ export function Sidebar() {
         {isMobileSidebar ? (
           <MobileNav />
         ) : (
-          <SidebarRouteTree routeTree={routeTree} />
+          /* No fallback UI so need to be careful not to spend directly inside. */
+          <React.Suspense fallback={null}>
+            <SidebarRouteTree routeTree={routeTree} />
+          </React.Suspense>
         )}
       </nav>
       <div className="sticky bottom-0 hidden lg:block">


### PR DESCRIPTION
Let's see if this works!

The idea is to add more Suspense boundaries. React will use this as a signal to hydrate them asynchronously instead of doing everything in a single pass. 

I don't have fallback UI for this. It's a bit risky because if something suspends, we'll render null. But we don't have anything suspending directly inside these trees. If we add something, we'll need to give it its own Suspense to prevent triggering these. Or maybe we can make some actual glimmers as fallbacks later.

## Before (with 6x slowdown)

There's one long hydration task.

<img width="823" alt="Screenshot 2022-05-25 at 22 59 49" src="https://user-images.githubusercontent.com/810438/170375129-02359e28-a34e-4705-87da-ec999bd7b692.png">

## After (with 6x slowdown)

Hydrating is time-sliced so we block the browser less. It's especially noticeable for the long tail of MDX content at the end.

<img width="852" alt="Screenshot 2022-05-25 at 23 02 23" src="https://user-images.githubusercontent.com/810438/170375239-bcf00e43-0cff-4259-a7fb-af509e9a62c6.png">
