### PR TITLE
[Beta] Drop next/dynamic usage

### DIFF
--- a/beta/src/components/MDX/Sandpack/index.tsx
+++ b/beta/src/components/MDX/Sandpack/index.tsx
@@ -3,10 +3,9 @@
  */
 
 import * as React from 'react';
-import dynamic from 'next/dynamic';
 import {createFileMap} from './createFileMap';
 
-const SandpackRoot = dynamic(() => import('./SandpackRoot'), {suspense: true});
+const SandpackRoot = React.lazy(() => import('./SandpackRoot'));
 
 const SandpackGlimmer = ({code}: {code: string}) => (
   <div className="sandpack-container my-8">


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->


Ref: https://github.com/vercel/next.js/issues/37197#issuecomment-1138524590

Replace the usage of `next/dynamic` with `React.lazy` (`next/dynamic` with `{ suspense: true }` use `React.lazy` directly under the hood).

By dropping `next/dynamic`, we can also remove `react-lodable` client-side implementation (which is for `{ suspense: false }`) from emitted bundle (see https://github.com/vercel/next.js/issues/37197#issuecomment-1138496911).