### PR TITLE
[beta] fix(eslint): messages severity

### DIFF
--- a/beta/src/components/MDX/Sandpack/runESLint.tsx
+++ b/beta/src/components/MDX/Sandpack/runESLint.tsx
@@ -35,7 +35,7 @@ const options = {
   },
   rules: {
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
   },
 };
 

--- a/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
+++ b/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
@@ -29,7 +29,9 @@ export const useSandpackLint = () => {
         // Ignore parsing or internal linter errors.
         const isReactRuleError = (error: any) => error.ruleId != null;
         setLintErrors(errors.filter(isReactRuleError));
-        return codeMirrorErrors.filter(isReactRuleError);
+        return codeMirrorErrors
+          .filter(isReactRuleError)
+          .map((error) => ({...error, severity: 'error'}));
       });
       setLintExtensions([onLint]);
     };

--- a/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
+++ b/beta/src/components/MDX/Sandpack/useSandpackLint.tsx
@@ -29,9 +29,7 @@ export const useSandpackLint = () => {
         // Ignore parsing or internal linter errors.
         const isReactRuleError = (error: any) => error.ruleId != null;
         setLintErrors(errors.filter(isReactRuleError));
-        return codeMirrorErrors
-          .filter(isReactRuleError)
-          .map((error) => ({...error, severity: 'error'}));
+        return codeMirrorErrors.filter(isReactRuleError);
       });
       setLintExtensions([onLint]);
     };


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
**This is more a question than a proposal:**

Originally, the `react-hooks/exhaustive-deps` eslint rule throws a warning in the React Docs implementations, and actually whatever you use this rule (vscode, cli, etc). However, currently, this rule is leading to a blocking state in the preview component, even showing a `Lint error` title there. 

So, taking into account the educational purposes of the documentation should we treat all rules as an error or leave the exhaustive-deps rule as a warning and update the preview error? 

**Current**
<img width="973" alt="Screenshot 2022-05-27 at 13 55 38" src="https://user-images.githubusercontent.com/4838076/170704260-596949d7-4b86-4bf3-bb33-0c946d10f04f.png">

**This PR**
<img width="971" alt="Screenshot 2022-05-27 at 13 55 00" src="https://user-images.githubusercontent.com/4838076/170704273-0745e8b1-f71d-4a6c-a1e9-8028564403f1.png">



