### PR TITLE
fix typo in higher-order-components.md

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -124,7 +124,7 @@ const BlogPostWithSubscription = withSubscription(
 
 The first parameter is the wrapped component. The second parameter retrieves the data we're interested in, given a `DataSource` and the current props.
 
-When `CommentListWithSubscription` and `BlogPostWithSubscription` are rendered, `CommentList` and `BlogPost` will be passed a `data` prop with the most current data retrieved from `DataSource`:
+When `CommentListWithSubscription` and `BlogPostWithSubscription` are rendered, `CommentList` and `BlogPost` will be passed to a `data` prop with the most current data retrieved from `DataSource`:
 
 ```js
 // This function takes a component...


### PR DESCRIPTION
In my perception, this "to" should not be omitted. Adding it would make it clearer. 