### PR TITLE
Remove useless comma

### DIFF
--- a/beta/src/pages/learn/choosing-the-state-structure.md
+++ b/beta/src/pages/learn/choosing-the-state-structure.md
@@ -1050,7 +1050,7 @@ export const initialTravelPlan = {
   35: {
     id: 35,
     title: 'Oceania',
-    childIds: [36, 37, 38, 39, 40, 41,, 42],   
+    childIds: [36, 37, 38, 39, 40, 41, 42],   
   },
   36: {
     id: 36,


### PR DESCRIPTION
Found an additional comma typo when I implemented this example with typescript.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
