### PR TITLE
Revert "[beta] Update Sandpack bundler URL"

### DIFF
--- a/beta/src/components/MDX/Sandpack/SandpackRoot.tsx
+++ b/beta/src/components/MDX/Sandpack/SandpackRoot.tsx
@@ -84,7 +84,7 @@ function SandpackRoot(props: SandpackProps) {
         autorun={autorun}
         initMode="user-visible"
         initModeObserverOptions={{rootMargin: '1400px 0px'}}
-        bundlerURL="https://6fcf8196.sandpack-bundler.pages.dev"
+        bundlerURL="https://22530bfe.sandpack-bundler.pages.dev"
         logLevel={SandpackLogLevel.None}>
         <CustomPreset
           isSingleFile={isSingleFile}


### PR DESCRIPTION
Reverts reactjs/reactjs.org#4715

Let's see if this fixes examples being down