### PR TITLE
docs: fix optional argument representation

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -507,7 +507,7 @@ There are just two of them: `setState()` and `forceUpdate()`.
 ### `setState()` {#setstate}
 
 ```javascript
-setState(updater, [callback])
+setState(updater[, callback])
 ```
 
 `setState()` enqueues changes to the component state and tells React that this component and its children need to be re-rendered with the updated state. This is the primary method you use to update the user interface in response to event handlers and server responses.


### PR DESCRIPTION
This change was introduced in https://github.com/reactjs/reactjs.org/pull/2164, but is mildly inconsistent with the existing syntax in line 542, that follows the original intent from https://github.com/reactjs/reactjs.org/commit/0560d6be8b343b63c4412d35204d5b24847a0eac so I'd like to see it reverted.