### PR TITLE
docs: reorder steps in 'adding local state to class'

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -104,22 +104,7 @@ The `render` method will be called each time an update happens, but as long as w
 
 We will move the `date` from props to state in three steps:
 
-1) Replace `this.props.date` with `this.state.date` in the `render()` method:
-
-```js{6}
-class Clock extends React.Component {
-  render() {
-    return (
-      <div>
-        <h1>Hello, world!</h1>
-        <h2>It is {this.state.date.toLocaleTimeString()}.</h2>
-      </div>
-    );
-  }
-}
-```
-
-2) Add a [class constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes#Constructor) that assigns the initial `this.state`:
+1) Add a [class constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes#Constructor) that assigns the initial `state`:
 
 ```js{4}
 class Clock extends React.Component {
@@ -149,6 +134,21 @@ Note how we pass `props` to the base constructor:
 ```
 
 Class components should always call the base constructor with `props`.
+
+2) Replace `this.props.date` with `this.state.date` in the `render()` method:
+
+```js{6}
+class Clock extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Hello, world!</h1>
+        <h2>It is {this.state.date.toLocaleTimeString()}.</h2>
+      </div>
+    );
+  }
+}
+```
 
 3) Remove the `date` prop from the `<Clock />` element:
 


### PR DESCRIPTION
This reverses the order of steps 1 & 2 in the [Adding Local State to a Class](https://reactjs.org/docs/state-and-lifecycle.html#adding-local-state-to-a-class) section. The current order puts the app in a broken state and throws the reader off as it puzzles the reader where does `this.state` come from. It makes more sense to define the state first and then use it