### PR TITLE
fix sandbox tab button styles when selected

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -58,6 +58,7 @@ html.dark .sp-wrapper {
 .sp-tabs .sp-tab-button {
   color: #087ea4;
   padding: 0 4px;
+  border-bottom: 2px solid transparent;
 }
 
 html.dark .sp-tabs .sp-tab-button {


### PR DESCRIPTION
Sandbox tab buttons text is moving up a little bit when activated because of added border-bottom, so this adds a transparent border-bottom to prevent it.