### PR TITLE
Change in Handling events page

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -145,4 +145,4 @@ Inside a loop, it is common to want to pass an extra parameter to an event handl
 
 The above two lines are equivalent, and use [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) and [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) respectively.
 
-In both cases, the `e` argument representing the React event will be passed as a second argument after the ID. With an arrow function, we have to pass it explicitly, but with `bind` any further arguments are automatically forwarded.
+In both cases, the `e` argument representing the React event will be passed as the last argument after the ID. With an arrow function, we have to pass it explicitly, but with `bind` any further arguments are automatically forwarded.


### PR DESCRIPTION
https://reactjs.org/docs/handling-events.html

Handling Events -> Passing Arguments to Event Handlers 

Since the event argument may not always be second, but actually is always the last, this change proposes to make it clear.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
