### PR TITLE
[Beta] Fix empty message styling in console

### DIFF
--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -106,10 +106,10 @@ export const SandpackConsole = () => {
                 <div
                   key={id}
                   className={cn(
-                    'last:border-none border-b dark:border-gray-700 text-md p-1 pl-2 leading-6 font-mono',
+                    'last:border-none border-b dark:border-gray-700 text-md p-1 pl-2 leading-6 font-mono min-h-[32px]',
                     `console-${getType(method)}`
                   )}>
-                  <span className={cn('console-message')}>
+                  <span className="console-message">
                     {data.map((msg, index) => {
                       if (typeof msg === 'string') {
                         return <span key={`${msg}-${index}`}>{msg}</span>;

--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -112,9 +112,7 @@ export const SandpackConsole = () => {
                   <span className={cn('console-message')}>
                     {data.map((msg, index) => {
                       if (typeof msg === 'string') {
-                        return msg.trim().length ? (
-                          <span key={`${msg}-${index}`}>{msg}</span>
-                        ) : undefined;
+                        return <span key={`${msg}-${index}`}>{msg}</span>;
                       }
 
                       let children;

--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -112,7 +112,9 @@ export const SandpackConsole = () => {
                   <span className={cn('console-message')}>
                     {data.map((msg, index) => {
                       if (typeof msg === 'string') {
-                        return <span key={`${msg}-${index}`}>{msg}</span>;
+                        return msg.trim().length ? (
+                          <span key={`${msg}-${index}`}>{msg}</span>
+                        ) : undefined;
                       }
 
                       let children;


### PR DESCRIPTION
Should we probably stop empty consoles getting added inside? When the user is entering console.log it adds an empty console statement inside the console. which might be confusing? Or we might want to increase the debounce timing for updating the preview once the code is updated.

https://user-images.githubusercontent.com/32865581/176703214-87cdbafc-6dd2-4050-826b-5d062e388710.mov

