### PR TITLE
Added online autoprefixer for better understanding

### DIFF
--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -78,7 +78,7 @@ function HelloWorldComponent() {
 }
 ```
 
-Note that styles are not autoprefixed. To support older browsers, you need to supply corresponding style properties:
+Note that styles are not autoprefixed. Use autoprefixer [online version](https://goonlinetools.com/autoprefixer/) that allows you to enter your non-prefixed CSS and gives you a autoprefixed CSS. To support older browsers, you need to supply corresponding style properties:
 
 ```js
 const divStyle = {


### PR DESCRIPTION
Added online version of Autoprefixer. So users can instantly auto prefix CSS without installing it.
