### PR TITLE
Fix function name in refs code example

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -119,7 +119,7 @@ class AutoFocusTextInput extends React.Component {
   }
 
   componentDidMount() {
-    this.textInput.current.focusTextInput();
+    this.textInput.current.focus();
   }
 
   render() {


### PR DESCRIPTION
The code example in _docs/refs-and-the-dom_ is incorrectly calling a function from the previous code item.

This PR updates the method called from `focusTextInput` to `focus`, which is the method existent in the current object.

**Current in the website:**
<img width="945" alt="current" src="https://user-images.githubusercontent.com/25709306/177476177-bcf53b56-91dc-4373-b05e-06582ffdc795.png">

**After the update:**
<img width="941" alt="update" src="https://user-images.githubusercontent.com/25709306/177476162-7466bfbe-ff3c-44a6-a9b5-42c5b6ba2a74.png">

