### PR TITLE
Remove Singapore from the list

### DIFF
--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -153,9 +153,6 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 ## Scotland (UK) {#scotland-uk}
 * [Edinburgh](https://www.meetup.com/React-Scotland/)
 
-## Singapore {#singapore}
-* [Singapore - React Knowledgeable](https://reactknowledgeable.org/)
-
 ## Spain {#spain}
 * [Barcelona](https://www.meetup.com/ReactJS-Barcelona/)
 * [Canarias](https://www.meetup.com/React-Canarias/)


### PR DESCRIPTION
React Knowledgeable website seems to go to some spam website now and the community facebook page has been updated since 2019. Probably no longer active

https://www.facebook.com/reactknowledgeable/

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
