### PR TITLE
Fix typo: Travel plan example

### DIFF
--- a/beta/src/pages/learn/choosing-the-state-structure.md
+++ b/beta/src/pages/learn/choosing-the-state-structure.md
@@ -774,7 +774,7 @@ export const initialTravelPlan = {
         childPlaces: [],
       }, {
         id: 41,
-        title: 'New Zeland',
+        title: 'New Zealand',
         childPlaces: [],
       }, {
         id: 42,

--- a/beta/src/pages/learn/choosing-the-state-structure.md
+++ b/beta/src/pages/learn/choosing-the-state-structure.md
@@ -1079,7 +1079,7 @@ export const initialTravelPlan = {
   },
   41: {
     id: 41,
-    title: 'New Zeland',
+    title: 'New Zealand',
     childIds: []
   },
   42: {
@@ -1422,7 +1422,7 @@ export const initialTravelPlan = {
   },
   41: {
     id: 41,
-    title: 'New Zeland',
+    title: 'New Zealand',
     childIds: []
   },
   42: {
@@ -1766,7 +1766,7 @@ export const initialTravelPlan = {
   },
   41: {
     id: 41,
-    title: 'New Zeland',
+    title: 'New Zealand',
     childIds: []
   },
   42: {


### PR DESCRIPTION
Fixed typo in travel plan example ("New Zeland" -> "New Zealand").