### PR TITLE
Rename "this.state.value" to disambiguate vs "event.target.value"

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -35,18 +35,18 @@ For example, if we want to make the previous example log the name when it is sub
 class NameForm extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {value: ''};
+    this.state = {inputValue: ''};
 
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({inputValue: event.target.value});
   }
 
   handleSubmit(event) {
-    alert('A name was submitted: ' + this.state.value);
+    alert('A name was submitted: ' + this.state.inputValue);
     event.preventDefault();
   }
 
@@ -55,7 +55,7 @@ class NameForm extends React.Component {
       <form onSubmit={this.handleSubmit}>
         <label>
           Name:
-          <input type="text" value={this.state.value} onChange={this.handleChange} />
+          <input type="text" value={this.state.inputValue} onChange={this.handleChange} />
         </label>
         <input type="submit" value="Submit" />
       </form>
@@ -66,7 +66,7 @@ class NameForm extends React.Component {
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/VmmPgp?editors=0010)
 
-Since the `value` attribute is set on our form element, the displayed value will always be `this.state.value`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
+Since the `value` attribute is set on our form element, the displayed value will always be `this.state.inputValue`, making the React state the source of truth. Since `handleChange` runs on every keystroke to update the React state, the displayed value will update as the user types.
 
 With a controlled component, the input's value is always driven by the React state. While this means you have to type a bit more code, you can now pass the value to other UI elements too, or reset it from other event handlers.
 
@@ -87,7 +87,7 @@ class EssayForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 'Please write an essay about your favorite DOM element.'
+      areaValue: 'Please write an essay about your favorite DOM element.'
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -95,11 +95,11 @@ class EssayForm extends React.Component {
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({areaValue: event.target.value});
   }
 
   handleSubmit(event) {
-    alert('An essay was submitted: ' + this.state.value);
+    alert('An essay was submitted: ' + this.state.areaValue);
     event.preventDefault();
   }
 
@@ -108,7 +108,7 @@ class EssayForm extends React.Component {
       <form onSubmit={this.handleSubmit}>
         <label>
           Essay:
-          <textarea value={this.state.value} onChange={this.handleChange} />
+          <textarea value={this.state.areaValue} onChange={this.handleChange} />
         </label>
         <input type="submit" value="Submit" />
       </form>
@@ -117,7 +117,7 @@ class EssayForm extends React.Component {
 }
 ```
 
-Notice that `this.state.value` is initialized in the constructor, so that the text area starts off with some text in it.
+Notice that `this.state.areaValue` is initialized in the constructor, so that the text area starts off with some text in it.
 
 ## The select Tag {#the-select-tag}
 
@@ -138,18 +138,18 @@ Note that the Coconut option is initially selected, because of the `selected` at
 class FlavorForm extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {value: 'coconut'};
+    this.state = {selectValue: 'coconut'};
 
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleChange(event) {
-    this.setState({value: event.target.value});
+    this.setState({selectValue: event.target.value});
   }
 
   handleSubmit(event) {
-    alert('Your favorite flavor is: ' + this.state.value);
+    alert('Your favorite flavor is: ' + this.state.selectValue);
     event.preventDefault();
   }
 
@@ -158,7 +158,7 @@ class FlavorForm extends React.Component {
       <form onSubmit={this.handleSubmit}>
         <label>
           Pick your favorite flavor:
-          <select value={this.state.value} onChange={this.handleChange}>
+          <select value={this.state.selectValue} onChange={this.handleChange}>
             <option value="grapefruit">Grapefruit</option>
             <option value="lime">Lime</option>
             <option value="coconut">Coconut</option>


### PR DESCRIPTION
Several examples utilize a state property named "value", as in `this.state = {value: ''};` and `this.state.value`.

However, the term "value" is also an important attribute on various form fields, and referenced in the onChange code examples as `this.setState({value: event.target.value});`.

Having to distinguish between different uses of the word "value" may cause confusion for those new to JS/JSX, since sometimes "value" refers to the HTML attribute name, while other times "value" refers to the state property name.

I've renamed each to a camelCase property name such as inputValue or areaValue or selectValue.  If you'd like it to remain more consistent between the examples, perhaps each could be changed to fieldValue.