### PR TITLE
fix: [beta] detele Adding to an array setName to aviod re-render

### DIFF
--- a/beta/src/pages/learn/updating-arrays-in-state.md
+++ b/beta/src/pages/learn/updating-arrays-in-state.md
@@ -67,7 +67,6 @@ export default function List() {
         onChange={e => setName(e.target.value)}
       />
       <button onClick={() => {
-        setName('');
         artists.push({
           id: nextId++,
           name: name,
@@ -121,7 +120,6 @@ export default function List() {
         onChange={e => setName(e.target.value)}
       />
       <button onClick={() => {
-        setName('');
         setArtists([
           ...artists,
           { id: nextId++, name: name }


### PR DESCRIPTION
when I read the `updating-arrays-in-state`, Maybe someone will confuse about that use array.push() and setArray() look likes the same result. So I delete the setName('') to avoid the re-render. If I misunderstand the meaning of the case, You can close the pr, thank you.