### PR TITLE
Fixed forms.md

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -25,7 +25,7 @@ This form has the default HTML form behavior of browsing to a new page when the 
 
 ## Controlled Components {#controlled-components}
 
-In HTML, form elements such as `<input>`, `<textarea>`, and `<select>` typically maintain their own state and update it based on user input. In React, mutable state is typically kept in the state property of components, and only updated with [`setState()`](/docs/react-component.html#setstate).
+In HTML, form elements such as `<input>`, `<textarea>`, and `<select>` typically maintain their own state and updates based on user input. In React, mutable state is typically kept in the state property of components, and only updated with [`setState()`](/docs/react-component.html#setstate).
 
 We can combine the two by making the React state be the "single source of truth". Then the React component that renders a form also controls what happens in that form on subsequent user input. An input form element whose value is controlled by React in this way is called a "controlled component".
 


### PR DESCRIPTION
Deleted "it" from the original sentence "In HTML, form elements such as <input>, <textarea>, and <select> typically maintain their own state and update it based on user input."
Alternatively, use this sentence instead:
"In HTML, form elements such as <input>, <textarea>, and <select> typically maintain their own state and updates itself based on user input."

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
