### PR TITLE
Update useImperativeHandle sample code

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -464,7 +464,7 @@ useImperativeHandle(ref, createHandle, [deps])
 function FancyInput(props, ref) {
   const inputRef = useRef();
   useImperativeHandle(ref, () => ({
-    focus: () => {
+    fancyFocus: () => {
       inputRef.current.focus();
     }
   }));
@@ -473,7 +473,7 @@ function FancyInput(props, ref) {
 FancyInput = forwardRef(FancyInput);
 ```
 
-In this example, a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.focus()`.
+In this example, a parent component that renders `<FancyInput ref={inputRef} />` would be able to call `inputRef.current.fancyFocus()` which will trigger `inputRef.current.focus()` in `FancyInput` component.
 
 ### `useLayoutEffect` {#uselayouteffect}
 


### PR DESCRIPTION
For new or less experienced users usage `inputRef.current.focus()` in `useImperativeHandle` is ambiguous. For the example, we should use a different property name than the sample action.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
