### PR TITLE
Fix link typo leading to 404 in /learn/adding-interactivity

### DIFF
--- a/beta/src/pages/learn/adding-interactivity.md
+++ b/beta/src/pages/learn/adding-interactivity.md
@@ -313,7 +313,7 @@ Read **[State as a Snapshot](/learn/state-as-a-snapshot)** to learn why state ap
 
 </LearnMore>
 
-## Queueing a series of state changes {/*queueing-a-series-of-state-changes*/}
+## Queueing a series of state updates {/*queueing-a-series-of-state-updates*/}
 
 This component is buggy: clicking "+3" increments the score only once.
 
@@ -395,9 +395,9 @@ button { display: inline-block; margin: 10px; font-size: 20px; }
 
 </Sandpack>
 
-<LearnMore path="/learn/queueing-a-series-of-state-changes">
+<LearnMore path="/learn/queueing-a-series-of-state-updates">
 
-Read **[Queueing a Series of State Changes](/learn/queueing-a-series-of-state-changes)** to learn how to queue multiple updates before the next render.
+Read **[Queueing a Series of State Updates](/learn/queueing-a-series-of-state-updates)** to learn how to queue multiple updates before the next render.
 
 </LearnMore>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
`adding-interacitivity.md` correctly links to the page "/learn/queueing-a-series-of-state-updates" at the top of the page's YouWillLearn component, but further in it mistypes "updates" as "changes" leading to a 404 page, fixed in the example.

![typo](https://user-images.githubusercontent.com/93528140/181259261-7bd93157-1db7-4bff-9c38-f5e4e9e30e35.png)
Should be 
![fix](https://user-images.githubusercontent.com/93528140/181259595-579a9692-2431-4a44-9d0f-436307ab0da4.png)

