### PR TITLE
fixed having duplicate tailwind classes in pages/blog

### DIFF
--- a/beta/src/pages/blog/index.tsx
+++ b/beta/src/pages/blog/index.tsx
@@ -33,7 +33,7 @@ export default function RecentPosts() {
                 RSS
               </a>
             </div>
-            <p className="text-primary dark:text-primary-dark text-xl text-primary dark:text-primary-dark leading-large">
+            <p className="text-primary dark:text-primary-dark text-xl leading-large">
               Offical React.js news, announcements, and release notes.
             </p>
           </header>


### PR DESCRIPTION
Fixes a duplication of tailwind classes found in `src/pages/blog/index.tsx`
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
