### PR TITLE
Update Refs and the DOM: Use HTML element or DOM element instead of node

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -11,7 +11,7 @@ redirect_from:
   - "tips/children-undefined.html"
 ---
 
-Refs provide a way to access DOM nodes or React elements created in the render method.
+Refs provide a way to access HTML elements or React elements created in the render method.
 
 In the typical React dataflow, [props](/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 


### PR DESCRIPTION
Unless text nodes or other non-node HTML elements can be assigned a ref, using the word *node* leads to confusion.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
