### PR TITLE
Add Support for All Console Methods and Hide Console Panel if there is a Lint/Syntax Error

### DIFF
--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -4,6 +4,7 @@
 import cn from 'classnames';
 import * as React from 'react';
 import {IconChevron} from 'components/Icon/IconChevron';
+import {formatStr} from 'utils/formatStr';
 
 import {SandpackCodeViewer, useSandpack} from '@codesandbox/sandpack-react';
 import type {SandpackMessageConsoleMethods} from '@codesandbox/sandpack-client';
@@ -20,6 +21,18 @@ const getType = (
   }
 
   return 'error';
+};
+
+const getColor = (
+  message: SandpackMessageConsoleMethods
+): 'text-red-500' | 'text-white' | 'text-yellow-400' => {
+  if (message === 'warn') {
+    return 'text-yellow-400';
+  } else if (message === 'error') {
+    return 'text-red-500';
+  } else {
+    return 'text-white';
+  }
 };
 
 type ConsoleData = Array<{
@@ -45,7 +58,12 @@ export const SandpackConsole = () => {
       }
       if (message.type === 'console' && message.codesandbox) {
         setLogs((prev) => {
-          const newLogs = message.log.filter(({method}) => method === 'log');
+          const newLogs = message.log.map((consoleData) => {
+            return {
+              ...consoleData,
+              data: [formatStr(...consoleData.data)],
+            };
+          });
           let messages = [...prev, ...newLogs];
           while (messages.length > MAX_MESSAGE_COUNT) {
             messages.shift();
@@ -106,8 +124,9 @@ export const SandpackConsole = () => {
                 <div
                   key={id}
                   className={cn(
-                    'last:border-none border-b dark:border-gray-700 text-md p-1 pl-2 leading-6 font-mono min-h-[32px]',
-                    `console-${getType(method)}`
+                    'last:border-none border-b dark:border-gray-700 text-md p-1 pl-2 leading-6 font-mono min-h-[32px] whitespace-pre-wrap',
+                    `console-${getType(method)}`,
+                    `${getColor(method)}`
                   )}>
                   <span className="console-message">
                     {data.map((msg, index) => {

--- a/beta/src/components/MDX/Sandpack/Preview.tsx
+++ b/beta/src/components/MDX/Sandpack/Preview.tsx
@@ -210,7 +210,7 @@ export function Preview({
           loading={!isReady && iframeComputedHeight === null}
         />
       </div>
-      <SandpackConsole />
+      {!error && <SandpackConsole />}
     </div>
   );
 }

--- a/beta/src/utils/formatStr.ts
+++ b/beta/src/utils/formatStr.ts
@@ -1,0 +1,49 @@
+// based on https://github.com/tmpfs/format-util/blob/0e62d430efb0a1c51448709abd3e2406c14d8401/format.js#L1
+// based on https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions
+// Implements s, d, i and f placeholders
+export function formatStr(...inputArgs: any[]): string {
+  const maybeMessage = inputArgs[0];
+  const args = inputArgs.slice(1);
+
+  let formatted: string = String(maybeMessage);
+
+  // If the first argument is a string, check for substitutions.
+  if (typeof maybeMessage === 'string') {
+    if (args.length) {
+      const REGEXP = /(%?)(%([jds]))/g;
+
+      formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+        let arg = args.shift();
+        switch (flag) {
+          case 's':
+            arg += '';
+            break;
+          case 'd':
+          case 'i':
+            arg = parseInt(arg, 10).toString();
+            break;
+          case 'f':
+            arg = parseFloat(arg).toString();
+            break;
+        }
+        if (!escaped) {
+          return arg;
+        }
+        args.unshift(arg);
+        return match;
+      });
+    }
+  }
+
+  // Arguments that remain after formatting.
+  if (args.length) {
+    for (let i = 0; i < args.length; i++) {
+      formatted += ' ' + String(args[i]);
+    }
+  }
+
+  // Update escaped %% values.
+  formatted = formatted.replace(/%{2,2}/g, '%');
+
+  return String(formatted);
+}


### PR DESCRIPTION
This PR:
* Adds support for all console methods. Warning and errors will be yellow and red respectively. Also adds support for whitespace prewrap
* Only show the sandpack console if there is no syntax or lint error.