### PR TITLE
[beta] Replace ReactDOM.render with createRoot in docs

### DIFF
--- a/beta/src/pages/learn/render-and-commit.md
+++ b/beta/src/pages/learn/render-and-commit.md
@@ -44,12 +44,10 @@ When your app starts, you need to trigger the initial render. Frameworks and san
 
 ```js index.js active
 import Image from './Image.js';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(
-  <Image />,
-  document.getElementById('root')
-);
+const root = createRoot(document.getElementById('root'));
+root.render(<Image />);
 ```
 
 ```js Image.js
@@ -114,12 +112,10 @@ function Image() {
 
 ```js index.js
 import Gallery from './Gallery.js';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(
-  <Gallery />,
-  document.getElementById('root')
-);
+const root = createRoot(document.getElementById('root'));
+root.render(<Gallery />);
 ```
 
 ```css


### PR DESCRIPTION
So I just stumbled upon the page [Render and Commit](https://beta.reactjs.org/learn/render-and-commit#step-1-trigger-a-render) at React beta docs, and I notice that playgrounds' console has logged some warnings:

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/40715044/187015819-5a4f8f74-4bdb-4f53-9ca8-049ded9d533d.png">

It turns out that those playgrounds are still using the legacy `ReactDOM.render` method. The PR updates them.
