### PR TITLE
Fixed typo in passing-data-deeply-with-context.md

### DIFF
--- a/beta/src/pages/learn/passing-data-deeply-with-context.md
+++ b/beta/src/pages/learn/passing-data-deeply-with-context.md
@@ -21,7 +21,7 @@ Usually, you will pass information from a parent component to a child component 
 
 [Passing props](/learn/passing-props-to-a-component) is a great way to explicitly pipe data through your UI tree to the components that use it.
 
-But passing props can become verbose and inconvenient when you need to pass some prop deeply through the tree, or if many components need the same prop. The nearest common ancestor could be far removed from the components that need data, and [lifting state up](/learn/sharing-state-between-components) that high can lead to a situation sometimes called "prop drilling."
+But passing props can become verbose and inconvenient when you need to pass some prop deeply through the tree, or if many components need the same prop. The nearest common ancestor could be far above from the components that need data, and [lifting state up](/learn/sharing-state-between-components) that high can lead to a situation sometimes called "prop drilling."
 
 <DiagramGroup>
 


### PR DESCRIPTION
Typo fix: "far removed" to " far above"

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
