### PR TITLE
[Beta] add a link to using `AbortSignal`

### DIFF
--- a/beta/src/pages/learn/you-might-not-need-an-effect.md
+++ b/beta/src/pages/learn/you-might-not-need-an-effect.md
@@ -739,7 +739,7 @@ function SearchResults({ query }) {
 }
 ```
 
-This ensures that when your Effect fetches data, all responses except the last requested one will be ignored.
+This ensures that when your Effect fetches data, all responses except the last requested one will be ignored. Note that in this example, you can also use a [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#aborting_a_fetch_operation_using_an_explicit_signal) instead.
 
 Handling race conditions is not the only difficulty with implementing data fetching. You might also want to think about how to cache the responses (so that the user can click Back and see the previous screen instantly instead of a spinner), how to fetch them on the server (so that the initial server-rendered HTML contains the fetched content instead of a spinner), and how to avoid network waterfalls (so that a child component that needs to fetch data doesn't have to wait for every parent above it to finish fetching their data before it can start). **These issues apply to any UI library, not just React. Solving them is not trivial, which is why modern [frameworks](/learn/start-a-new-react-project#building-with-a-full-featured-framework) provide more efficient built-in data fetching mechanisms than writing Effects directly in your components.**
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I appreciate the docs is not using lots of APIs outside of React scope which may confuse the reader, but I also think in this particular example, a link to using `AbortSignal` would be beneficial. Compared to the relatively simple boolean check, using `AbortSignal` is superior as it can _cancel_ the request all together.

#1142 was contributing the same effort (to current docs, not beta), but the situation has changed a lot. This API is now [available in major browsers](https://caniuse.com/mdn-api_fetch_init_signal_parameter) for more than 4 years, almost as old as `<script type="module">`, so this is not too out of place.