### PR TITLE
Reduce sandbox button text sizes,show dropdown button by default for …

### DIFF
--- a/beta/src/components/MDX/Sandpack/DownloadButton.tsx
+++ b/beta/src/components/MDX/Sandpack/DownloadButton.tsx
@@ -88,7 +88,7 @@ ${css}
 
   return (
     <button
-      className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
+      className="text-xs text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
       onClick={downloadHTML}
       title="Download Sandbox"
       type="button">

--- a/beta/src/components/MDX/Sandpack/FilesDropdown.tsx
+++ b/beta/src/components/MDX/Sandpack/FilesDropdown.tsx
@@ -22,9 +22,9 @@ export function FilesDropdown() {
         {({open}) => (
           <span
             className={cn(
-              'h-full py-2 px-1 mt-px -mb-px flex border-b-2 text-link dark:text-link-dark border-link dark:border-link-dark items-center text-md leading-tight truncate'
+              'h-full py-2 px-1 mt-px -mb-px flex border-b-2 text-link dark:text-link-dark border-link dark:border-link-dark items-center text-sm leading-tight truncate'
             )}
-            style={{maxWidth: '160px'}}>
+            style={{maxWidth: '150px'}}>
             {getFileName(activePath)}
             <span className="ml-2">
               <IconChevron displayDirection={open ? 'up' : 'down'} />

--- a/beta/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/beta/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -15,7 +15,7 @@ import {FilesDropdown} from './FilesDropdown';
 
 export function NavigationBar({showDownload}: {showDownload: boolean}) {
   const {sandpack} = useSandpack();
-  const [dropdownActive, setDropdownActive] = React.useState(false);
+  const [dropdownActive, setDropdownActive] = React.useState(true);
   const {openPaths, clients} = sandpack;
   const clientId = Object.keys(clients)[0];
   const {refresh} = useSandpackNavigation(clientId);
@@ -31,6 +31,10 @@ export function NavigationBar({showDownload}: {showDownload: boolean}) {
   }, [dropdownActive]);
 
   React.useEffect(() => {
+    if (openPaths.length === 1) {
+      setDropdownActive(false);
+      return;
+    }
     if (openPaths.length > 1) {
       resizeHandler();
       window.addEventListener('resize', resizeHandler);
@@ -48,7 +52,7 @@ export function NavigationBar({showDownload}: {showDownload: boolean}) {
 
   return (
     <div className="bg-wash dark:bg-card-dark flex justify-between items-center relative z-10 border-b border-border dark:border-border-dark rounded-t-lg rounded-b-none">
-      <div className="px-4 lg:px-6">
+      <div className="px-3 lg:px-6">
         {dropdownActive ? <FilesDropdown /> : <FileTabs />}
       </div>
       <div

--- a/beta/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
+++ b/beta/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
@@ -9,7 +9,7 @@ import {IconNewPage} from '../../Icon/IconNewPage';
 export const OpenInCodeSandboxButton = () => {
   return (
     <UnstyledOpenInCodeSandboxButton
-      className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1 ml-2 md:ml-1"
+      className="text-xs text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1 ml-2 md:ml-1"
       title="Open in CodeSandbox">
       <IconNewPage
         className="inline ml-1 mr-1 relative"

--- a/beta/src/components/MDX/Sandpack/ResetButton.tsx
+++ b/beta/src/components/MDX/Sandpack/ResetButton.tsx
@@ -11,7 +11,7 @@ export interface ResetButtonProps {
 export const ResetButton: React.FC<ResetButtonProps> = ({onReset}) => {
   return (
     <button
-      className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
+      className="text-xs text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1"
       onClick={onReset}
       title="Reset Sandbox"
       type="button">


### PR DESCRIPTION
### **Issue:** 

If a sandbox example in a page had multiple tabs, it was causing an overflow when viewed in mobile devices which was breaking the nav bar and the announcement. eg: https://beta.reactjs.org/learn/reusing-logic-with-custom-hooks, https://beta.reactjs.org/learn/scaling-up-with-reducer-and-context

https://user-images.githubusercontent.com/49617008/188349045-88d52fe2-41f7-41ee-a35a-16184ad8cee2.mp4

### **Fixes:** 
- Reduce the font size of _Download_, _Reset_ and _Open in CodeSandbox_ buttons so that the file tabs are highlighted more which results in a better user experience
- Set the file dropdown state for Sandbox files as true by default  which helps to maintain the responsiveness while the Sandbox loads

### **Commits**:
- Reduce sandbox button text sizes, show dropdown button by default for sandbox in mobile devices
