### PR TITLE
[Beta] Remount Page Content

### DIFF
--- a/beta/src/pages/_app.tsx
+++ b/beta/src/pages/_app.tsx
@@ -60,5 +60,9 @@ export default function MyApp({Component, pageProps}: AppProps) {
     );
   }
 
-  return <Page routeTree={routeTree}>{content}</Page>;
+  return (
+    <Page routeTree={routeTree}>
+      <React.Fragment key={router.pathname}>{content}</React.Fragment>
+    </Page>
+  );
 }


### PR DESCRIPTION
I broke this in https://github.com/reactjs/reactjs.org/pull/4975. Since it no longer remounts _accidentally_, the page content is reconciled between navigations. But we don't want that. So, we want a key.