### PR TITLE
[Beta] Pregenerate TOC

### DIFF
--- a/beta/next.config.js
+++ b/beta/next.config.js
@@ -3,7 +3,7 @@
  */
 
 const path = require('path');
-const {remarkPlugins} = require('./plugins/markdownToHtml');
+const {remarkPlugins, rehypePlugins} = require('./plugins/markdownToHtml');
 const redirects = require('./src/redirects.json');
 
 /**
@@ -74,6 +74,7 @@ const nextConfig = {
           loader: '@mdx-js/loader',
           options: {
             remarkPlugins,
+            rehypePlugins,
           },
         },
         path.join(__dirname, './plugins/md-layout-loader'),

--- a/beta/package.json
+++ b/beta/package.json
@@ -67,6 +67,7 @@
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",
     "gray-matter": "^4.0.2",
+    "hast-util-to-html": "^7.1.3",
     "husky": "^7.0.4",
     "is-ci": "^3.0.1",
     "lint-staged": ">=10",

--- a/beta/plugins/markdownToHtml.js
+++ b/beta/plugins/markdownToHtml.js
@@ -1,9 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
 const remark = require('remark');
 const externalLinks = require('remark-external-links'); // Add _target and rel to external links
 const customHeaders = require('./remark-header-custom-ids'); // Custom header id's for i18n
 const images = require('remark-images'); // Improved image syntax
 const unrwapImages = require('remark-unwrap-images'); // Removes <p> wrapper around images
 const smartyPants = require('./remark-smartypants'); // Cleans up typography
+const toc = require('./rehype-toc'); // Adds table of contents metadata
 const html = require('remark-html');
 
 module.exports = {
@@ -14,6 +19,7 @@ module.exports = {
     unrwapImages,
     smartyPants,
   ],
+  rehypePlugins: [toc],
   markdownToHtml,
 };
 

--- a/beta/plugins/md-layout-loader.js
+++ b/beta/plugins/md-layout-loader.js
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
 const fm = require('gray-matter');
 const path = require('path');
 

--- a/beta/plugins/rehype-toc.js
+++ b/beta/plugins/rehype-toc.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
+const toHtml = require('hast-util-to-html');
+const visit = require('unist-util-visit');
+
+module.exports = function generateToc(options) {
+  return function transformer(tree, vfile) {
+    let toc = [];
+    visit(tree, ['element', 'jsx'], (node) => {
+      if (node.type === 'element') {
+        if (node.tagName === 'h2' || node.tagName === 'h3') {
+          const id = node.properties?.id;
+          const depth = parseInt(node.tagName.charAt(1), 10);
+          toc.push({url: '#' + id, depth, html: toHtml(node.children)});
+        }
+      } else if (node.type === 'jsx') {
+        // This is a bit hacky. Match on the closing tag
+        // because the opening tag could have attribute.
+        if (node.value === '</Recap>') {
+          toc.push({
+            depth: 0,
+            html: 'Recap',
+            url: '#recap',
+          });
+        } else if (node.value === '</Challenges>') {
+          toc.push({
+            depth: 0,
+            html: 'Challenges',
+            url: '#challenges',
+          });
+        }
+      }
+    });
+    if (toc.length > 0) {
+      toc.unshift({
+        depth: 1,
+        html: 'Overview',
+        url: '#',
+      });
+    }
+
+    tree.children.push({
+      type: 'export',
+      value:
+        'export const toc = [' +
+        toc
+          .map(
+            (item) => `{
+          url: ${JSON.stringify(item.url)},
+          depth: ${JSON.stringify(item.depth)},
+          jsx: <>${item.html}</>
+        },`
+          )
+          .join('\n') +
+        '];\n',
+    });
+
+    return tree;
+  };
+};

--- a/beta/plugins/remark-smartypants.js
+++ b/beta/plugins/remark-smartypants.js
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
 const visit = require('unist-util-visit');
 const retext = require('retext');
 const smartypants = require('retext-smartypants');

--- a/beta/src/components/Layout/MarkdownPage.tsx
+++ b/beta/src/components/Layout/MarkdownPage.tsx
@@ -17,7 +17,7 @@ export interface MarkdownProps<Frontmatter> {
   children?: React.ReactNode;
   toc: Array<{
     url: string;
-    text: React.ReactNode;
+    jsx: React.ReactNode;
     depth: number;
   }>;
 }

--- a/beta/src/components/Layout/Toc.tsx
+++ b/beta/src/components/Layout/Toc.tsx
@@ -9,7 +9,7 @@ import {useTocHighlight} from './useTocHighlight';
 export function Toc({
   headings,
 }: {
-  headings: Array<{url: string; text: React.ReactNode; depth: number}>;
+  headings: Array<{url: string; jsx: React.ReactNode; depth: number}>;
 }) {
   const {currentIndex} = useTocHighlight();
   // TODO: We currently have a mismatch between the headings in the document
@@ -58,7 +58,7 @@ export function Toc({
                       'block hover:text-link dark:hover:text-link-dark leading-normal py-2'
                     )}
                     href={h.url}>
-                    {h.text}
+                    {h.jsx}
                   </a>
                 </li>
               );

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -2477,7 +2477,7 @@ hast-util-sanitize@^3.0.0:
   dependencies:
     xtend "^4.0.0"
 
-hast-util-to-html@^7.0.0:
+hast-util-to-html@^7.0.0, hast-util-to-html@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.3.tgz#9f339ca9bea71246e565fc79ff7dbfe98bb50f5e"
   integrity sha512-yk2+1p3EJTEE9ZEUkgHsUSVhIpCsL/bvT8E5GzmWc+N1Po5gBw+0F8bo7dpxXR0nu0bQVxVZGX2lBGF21CmeDw==


### PR DESCRIPTION
Replaces runtime generation of TOC with an early Markdown AST pass. Similar approach to https://github.com/reactjs/reactjs.org/pull/4081/. Unfortunately we can't remove the MaxWidth runtime wrapping the same way because the actual final tree structure matters, and we don't have this info at the Markdown AST time.