### PR TITLE
Update the 5th code snippet - this keyword missing

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -135,7 +135,7 @@ function withSubscription(WrappedComponent, selectData) {
       super(props);
       this.handleChange = this.handleChange.bind(this);
       this.state = {
-        data: selectData(DataSource, props)
+        data: selectData(DataSource, this.props)
       };
     }
 


### PR DESCRIPTION
adding the this keyword in front of the props in the 5th code snippet mentionned in the line number 9.
"this" keyword missing.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
