### PR TITLE
Disable Next.js scroll restoration

### DIFF
--- a/beta/next.config.js
+++ b/beta/next.config.js
@@ -13,7 +13,6 @@ const nextConfig = {
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx', 'md'],
   experimental: {
     plugins: true,
-    scrollRestoration: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/beta/patches/next+12.1.7-canary.11.patch
+++ b/beta/patches/next+12.1.7-canary.11.patch
@@ -1,0 +1,80 @@
+diff --git a/node_modules/next/dist/client/index.js b/node_modules/next/dist/client/index.js
+index 8541301..e020783 100644
+--- a/node_modules/next/dist/client/index.js
++++ b/node_modules/next/dist/client/index.js
+@@ -471,7 +471,11 @@ function renderError(renderErrorProps) {
+ let reactRoot = null;
+ // On initial render a hydrate should always happen
+ let shouldHydrate = true;
+-function renderReactElement(domEl, fn) {
++function renderReactElement(domEl, fn
++// ~~~~~~~~~ MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++, REACT_DOCS_IS_POPSTATE // Added this argument
++// ~~~~~~~~~ /MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++) {
+     // mark start of hydrate/render
+     if (_utils.ST) {
+         performance.mark('beforeRender');
+@@ -484,10 +488,16 @@ function renderReactElement(domEl, fn) {
+             // TODO: Remove shouldHydrate variable when React 18 is stable as it can depend on `reactRoot` existing
+             shouldHydrate = false;
+         } else {
+-            const startTransition = _react.default.startTransition;
+-            startTransition(()=>{
++            // ~~~~~~~~~ MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++            if (REACT_DOCS_IS_POPSTATE) { // Added this branch
+                 reactRoot.render(reactEl);
+-            });
++            } else { // The else block contents is the original code
++                const startTransition = _react.default.startTransition;
++                startTransition(()=>{
++                    reactRoot.render(reactEl);
++                });
++            }
++            // ~~~~~~~~~ /MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         }
+     } else {
+         // The check for `.hydrate` is there to support React alternatives like preact
+@@ -796,7 +806,11 @@ function doRender(input) {
+             });
+         }
+         if (input.scroll) {
+-            window.scrollTo(input.scroll.x, input.scroll.y);
++            // ~~~~~~~~~ MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++            if (!input.scroll.REACT_DOCS_IS_POPSTATE) { // Added this condition
++              window.scrollTo(input.scroll.x, input.scroll.y);
++            }
++            // ~~~~~~~~~ /MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         }
+     }
+     function onRootCommit() {
+@@ -815,6 +829,9 @@ function doRender(input) {
+                 onRootCommit
+             ]
+         }, process.env.__NEXT_STRICT_MODE ? /*#__PURE__*/ _react.default.createElement(_react.default.StrictMode, null, elem) : elem)
++    // ~~~~~~~~~ MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++    , input.scroll && input.scroll.REACT_DOCS_IS_POPSTATE // Added this argument
++    // ~~~~~~~~~ /MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     );
+     return renderPromise;
+ }
+diff --git a/node_modules/next/dist/shared/lib/router/router.js b/node_modules/next/dist/shared/lib/router/router.js
+index 572e21b..538091f 100644
+--- a/node_modules/next/dist/shared/lib/router/router.js
++++ b/node_modules/next/dist/shared/lib/router/router.js
+@@ -416,6 +416,15 @@ class Router {
+                     }
+                 }
+             }
++            // ~~~~~~~~~ MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++            // I don't want Next.js to do anythnig on scroll for Back/Forward buttons.
++            // Instead I want to let the browser take care of it with auto scroll restoration.
++            // Unfortunately, Next.js still tries to scroll to top on Back, so let's not do that.
++            forcedScroll = {
++              REACT_DOCS_IS_POPSTATE: true
++            };
++            // ~~~~~~~~~ /MANUAL EDIT FOR REACT DOCS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++
+             this._key = key;
+             const { pathname  } = (0, _parseRelativeUrl).parseRelativeUrl(url);
+             // Make sure we don't re-render on initial load,


### PR DESCRIPTION
I am adding a hack. I don't want to keep it forever. If someone in the future finds this PR and it causes some pains (like with upgrading Next), feel free to revert it but ping me so I can add it back. Eventually this hack shouldn't be needed because it's really **due to how the current Next.js router works, and it's a known issue that should be resolved by the upcoming one.**

The problematic behavior is this. Basically, if you scroll even a little bit, the Back gesture no longer shows a preview of the previous/next page during the swipe. This feels confusing and disorienting.

https://user-images.githubusercontent.com/810438/189459660-fd1745fd-eee0-4e1e-a39c-99cb85fcffc2.MP4

I only have a vague understanding of the issue, but here's what I gather so far:

- Browsers these days have automatic scroll restoration. You normally don't need to do anything special.
- However, (?) it seems like automatic restoration assumes that you're going to update the UI during popstate or at least close enough to it.
- Next.js doesn't update the UI during popstate. It waits for a Promise tick (although in PROD it resolves immediately with cached data). Then it renders in `startTransition`.
- Since the route transition is asynchronous, (it seems like?) we can't rely on browser built-in scroll restoration. We use Next.js's scroll restoration. But something that Next.js does breaks the swipe gesture preview. I assume this is somehow related to the timing of when Next.js calls `scrollTo`. Here is a [related post](https://stackoverflow.com/questions/68472768/how-can-i-control-disable-the-swipe-snapshot-used-in-ios-for-navigation-purposes) but with the *opposite* problem. If someone wants to dig in why Next.js's custom scroll restoration breaks that heuristic, be my guest! Then maybe we can fix that part and remove my hack.
- Anyway, I *don't* want Next.js scroll restoration, and I *do* want to rely on the browser one so that we don't break the gesture.
- For that to work, I need to help the browser. I need to make `popstate` synchronously update the UI. Which this PR (almost) does:
  - It removes `startTransition` during `popstate`, which I believe should not be happening in the first place. Transitions should be used for navigations like links, not for the Back button click. We already fixed something similar in vanilla React in https://github.com/facebook/react/pull/20774, so I think Next.js should have some kind of similar behavior.
  - It doesn't get rid of the Promise tick... I don't know why this PR works anyway. I guess waiting for Promise.resolve is fine?
- But this is not the end. Even if you disable Next.js "scroll restoration" option in the config, Next.js is *still* going to call `scrollTo()`. For navigations to new links this is 100% reasonable (we want to scroll to top). But I don't think it should be doing this on `popstate` since my whole point is that I wanted to let the browser do it! So I disabled the codepath that tries to `scrollTo(0, 0)` on `popstate`, since that interferes with what the browser does.

This seems enough to fix the Safari issue on iOS.

Unfortunately this introduces **DEV-only** jumps on Back/Forward because in DEV, there's not just a Promise tick but an actual refetch on every navigation (even Back navigation). This seems unfortunate.

Overall, all of this is super hacky and I'm happy to get rid of this when/if the new Next.js router fixes this. For now, I'm ok maintaining this hack.