### PR TITLE
[Beta] Prevent text overflow

### DIFF
--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -47,7 +47,9 @@ export function Page({children, toc}: PageProps) {
           <React.Suspense fallback={null}>
             <div className="flex flex-1 w-full h-full self-stretch min-w-0">
               <main className="w-full self-stretch h-full mx-auto relative w-full min-w-0">
-                <article key={asPath}>{children}</article>
+                <article className="break-words" key={asPath}>
+                  {children}
+                </article>
                 <Footer />
               </main>
             </div>

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -74,6 +74,7 @@
   body {
     padding: 0;
     margin: 0;
+    overflow-x: hidden;
   }
 
   /* Start purging... */


### PR DESCRIPTION
Fixes mobile layout on pages with long non-breaking headers, like `createContext(defaultValue)`