### PR TITLE
[Beta] Remove `useEvent` link

### DIFF
--- a/beta/src/content/apis/react/useEvent.md
+++ b/beta/src/content/apis/react/useEvent.md
@@ -4,7 +4,7 @@ title: useEvent
 
 <Wip>
 
-This section is incomplete, please see the old docs for [useEvent](https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md).
+This section is incomplete, please see the RFC doc for [useEvent](https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md).
 
 </Wip>
 

--- a/beta/src/content/apis/react/useEvent.md
+++ b/beta/src/content/apis/react/useEvent.md
@@ -1,0 +1,22 @@
+---
+title: useEvent
+---
+
+<Wip>
+
+This section is incomplete, please see the old docs for [useEvent](https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md).
+
+</Wip>
+
+
+<Intro>
+
+`useEvent` is a Hook to define an event handler with an always-stable function identity.
+
+```js
+useEvent(callback)
+```
+
+</Intro>
+
+<InlineToc />

--- a/beta/src/content/apis/react/useEvent.md
+++ b/beta/src/content/apis/react/useEvent.md
@@ -11,7 +11,7 @@ This section is incomplete, please see the RFC doc for [useEvent](https://github
 
 <Intro>
 
-`useEvent` is a Hook to define an event handler with an always-stable function identity.
+`useEvent` is a React Hook that lets you extract non-reactive Effect logic into an [Event function.](/learn/separating-events-from-effects#declaring-an-event-function)
 
 ```js
 useEvent(callback)

--- a/beta/src/content/learn/separating-events-from-effects.md
+++ b/beta/src/content/learn/separating-events-from-effects.md
@@ -406,7 +406,7 @@ This section describes an **experimental API that has not yet been added to Reac
 
 </Gotcha>
 
-Use a special Hook called `useEvent` to extract this non-reactive logic out of your Effect:
+Use a special Hook called [`useEvent`](/apis/react/useEvent) to extract this non-reactive logic out of your Effect:
 
 ```js {1,4-6}
 import { useEffect, useEvent } from 'react';

--- a/beta/src/content/learn/separating-events-from-effects.md
+++ b/beta/src/content/learn/separating-events-from-effects.md
@@ -394,7 +394,7 @@ In other words, you *don't* want this line to be reactive, even though it is ins
       // ...
       showNotification('Connected!', theme);
       // ...
-````
+```
 
 You need a way to separate this non-reactive logic from the reactive Effect around it.
 
@@ -406,7 +406,7 @@ This section describes an **experimental API that has not yet been added to Reac
 
 </Gotcha>
 
-Use a special Hook called [`useEvent`](/apis/react/useEvent) to extract this non-reactive logic out of your Effect:
+Use a special Hook called `useEvent` to extract this non-reactive logic out of your Effect:
 
 ```js {1,4-6}
 import { useEffect, useEvent } from 'react';

--- a/beta/src/sidebarReference.json
+++ b/beta/src/sidebarReference.json
@@ -114,6 +114,11 @@
               "wip": true
             },
             {
+              "title": "useEvent",
+              "path": "/apis/react/useEvent",
+              "wip": true
+            },
+            {
               "title": "useId",
               "path": "/apis/react/useId",
               "wip": true
@@ -152,11 +157,6 @@
             {
               "title": "useTransition",
               "path": "/apis/react/useTransition",
-              "wip": true
-            },
-            {
-              "title": "useEvent",
-              "path": "/apis/react/useEvent",
               "wip": true
             }
           ]

--- a/beta/src/sidebarReference.json
+++ b/beta/src/sidebarReference.json
@@ -153,6 +153,11 @@
               "title": "useTransition",
               "path": "/apis/react/useTransition",
               "wip": true
+            },
+            {
+              "title": "useEvent",
+              "path": "/apis/react/useEvent",
+              "wip": true
             }
           ]
         },


### PR DESCRIPTION
Remove the link to `useEvent` because it is 404 when opened.