### PR TITLE
[Beta] Fix HTML layout shift

### DIFF
--- a/beta/src/components/Layout/Page.tsx
+++ b/beta/src/components/Layout/Page.tsx
@@ -36,27 +36,22 @@ export function Page({children, toc}: PageProps) {
     <>
       <SocialBanner />
       <SidebarContext.Provider value={routeTree}>
-        <div className="h-auto flex flex-col lg:flex-row">
-          <div className="fixed lg:sticky top-0 left-0 right-0 py-0 lg:w-80 flex-none lg:static shadow lg:shadow-none z-50">
+        <div className="grid grid-cols-only-content lg:grid-cols-sidebar-content 2xl:grid-cols-sidebar-content-toc">
+          <div className="fixed lg:sticky top-0 left-0 right-0 py-0 shadow lg:shadow-none z-50">
             <Nav />
           </div>
-
-          <div className="lg:hidden h-16 mb-2" />
-
           {/* No fallback UI so need to be careful not to suspend directly inside. */}
           <React.Suspense fallback={null}>
-            <div className="flex flex-1 w-full h-full self-stretch min-w-0">
-              <main className="w-full self-stretch h-full mx-auto relative w-full min-w-0">
-                <article className="break-words" key={asPath}>
-                  {children}
-                </article>
-                <Footer />
-              </main>
-            </div>
+            <main className="min-w-0">
+              <div className="lg:hidden h-16 mb-2" />
+              <article className="break-words" key={asPath}>
+                {children}
+              </article>
+              <Footer />
+            </main>
           </React.Suspense>
-
-          <div className="lg:w-80 flex-none lg:max-w-xs hidden 2xl:block">
-            {toc.length > 0 && <Toc headings={toc} />}
+          <div className="hidden lg:max-w-xs 2xl:block">
+            {toc.length > 0 && <Toc headings={toc} key={asPath} />}
           </div>
         </div>
       </SidebarContext.Provider>

--- a/beta/tailwind.config.js
+++ b/beta/tailwind.config.js
@@ -68,6 +68,11 @@ module.exports = {
         code: 'calc(1em - 20%)',
       },
       colors,
+      gridTemplateColumns: {
+        'only-content': 'auto',
+        'sidebar-content': '20rem auto',
+        'sidebar-content-toc': '20rem auto 20rem',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
I think there's a problem with using flexbox for main layout. Both left and right sidebars have fixed width on desktop. If the page streams in, the left sidebar streams first, then the content, the the right sidebar. But this will cause a jump because the browser doesn't know the right sidebar is going to be of a specific size. I'm not sure how to fix this with flexbox.

In this PR I'll try to switch it to Grid. It also simplifies the CSS itself. (Not sure how much of the stuff I'm deleting is actually useful for something, but I guess we'll find out.)

As a drive-by fix, I've added a `key` to TOC since it should never need to be reconciled.
