### PR TITLE
[Beta] Fix the blank page displayed when the page navigate

### DIFF
--- a/beta/src/components/SocialBanner.tsx
+++ b/beta/src/components/SocialBanner.tsx
@@ -18,7 +18,7 @@ export default function SocialBanner() {
       if (y === 0) {
         // We're trying to reset scroll.
         // If we already scrolled past the banner, consider it as y = 0.
-        const bannerHeight = ref.current!.offsetHeight; // Could be zero (e.g. mobile)
+        const bannerHeight = ref.current?.offsetHeight ?? 0; // Could be zero (e.g. mobile)
         y = Math.min(window.scrollY, bannerHeight);
       }
       return realScrollTo(x, y);


### PR DESCRIPTION
Steps to reproduce:

1. Jump to a page that Not Found. For example,
   1. Jump to page [State: A Component's Memory](https://beta.reactjs.org/learn/state-a-components-memory#challenges)
   2. Click `4. Remove unnecessary state` in challenges
   3. Click on the [why this didn’t work](https://beta.reactjs.org/learn/troubleshooting-state-updates#setting-state-does-not-update-variables) link
2. Click on the Learn or API Menu on the left bar

The page will be blank.