### PR TITLE
Move React Native EU 2022 to Past Conferences

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -12,15 +12,6 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences {#upcoming-conferences}
 
-### React Native EU 2022: Powered by {callstack} {#react-native-eu-2022-powered-by-callstack}
-September 1-2, 2022 - Remote event
-
-[Website](https://www.react-native.eu/?utm_campaign=React_Native_EU&utm_source=referral&utm_content=reactjs_community_conferences) -
-[Twitter](https://twitter.com/react_native_eu) -
-[Linkedin](https://www.linkedin.com/showcase/react-native-eu) -
-[Facebook](https://www.facebook.com/reactnativeeu/) - 
-[Instagram](https://www.instagram.com/reactnative_eu/)
-
 ### React Finland 2022 {#react-finland-2022}
 September 12 - 16, 2022. In-person in Helsinki, Finland
 
@@ -52,6 +43,15 @@ May, 2023. Salt Lake City, UT
 [Website](https://remix.run/conf/2023) - [Twitter](https://twitter.com/remix_run)
 
 ## Past Conferences {#past-conferences}
+
+### React Native EU 2022: Powered by {callstack} {#react-native-eu-2022-powered-by-callstack}
+September 1-2, 2022 - Remote event
+
+[Website](https://www.react-native.eu/?utm_campaign=React_Native_EU&utm_source=referral&utm_content=reactjs_community_conferences) -
+[Twitter](https://twitter.com/react_native_eu) -
+[Linkedin](https://www.linkedin.com/showcase/react-native-eu) -
+[Facebook](https://www.facebook.com/reactnativeeu/) - 
+[Instagram](https://www.instagram.com/reactnative_eu/)
 
 ### ReactNext 2022 {#react-next-2022}
 June 28, 2022. Tel-Aviv, Israel


### PR DESCRIPTION
React Native EU 2022 has now finished, so moving it from the Upcoming Conferences section to the Past Conferences section.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
