### PR TITLE
[Beta] Fix double console logs in DEV

### DIFF
--- a/beta/src/components/MDX/Sandpack/Console.tsx
+++ b/beta/src/components/MDX/Sandpack/Console.tsx
@@ -93,7 +93,12 @@ export const SandpackConsole = () => {
   const wrapperRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
+    let isActive = true;
     const unsubscribe = listen((message) => {
+      if (!isActive) {
+        console.warn('Received an unexpected log from Sandpack.');
+        return;
+      }
       if (
         (message.type === 'start' && message.firstLoad) ||
         message.type === 'refresh'
@@ -117,7 +122,10 @@ export const SandpackConsole = () => {
       }
     });
 
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      isActive = false;
+    };
   }, [listen]);
 
   const [isExpanded, setIsExpanded] = React.useState(true);


### PR DESCRIPTION
It looks like Sandpack has a bug, surfaced by Strict Mode. Console logs appear twice because we get messages after already unsubscribing. Adding a temporary workaround to fix double messages while writing docs.

This could in theory break something if `listen` ever chages in PROD. Not sure if that happens. 