### PR TITLE
[Beta] Fix you-might-not-need-an-effect.md challenge 4 expected output

### DIFF
--- a/beta/src/content/learn/you-might-not-need-an-effect.md
+++ b/beta/src/content/learn/you-might-not-need-an-effect.md
@@ -1594,7 +1594,7 @@ button {
 
 This `Form` component lets you send a message to a friend. When you submit the form, the `showForm` state variable is set to `false`. This triggers an Effect calling `sendMessage(message)`, which sends the message (you can see it in the console). After the message is sent, you see a "Thank you" dialog with an "Open chat" button that lets you get back to the form.
 
-Your app's users are sending way too many messages. To make chatting a little bit more difficult, you've decided to show the "Thank you" dialog *first* rather than the form. Change the `showForm` state variable to initialize to `false` instead of `true`. As soon as you make that change, the console will show that an empty message was sent twice. Something in this logic is wrong!
+Your app's users are sending way too many messages. To make chatting a little bit more difficult, you've decided to show the "Thank you" dialog *first* rather than the form. Change the `showForm` state variable to initialize to `false` instead of `true`. As soon as you make that change, the console will show that an empty message was sent. Something in this logic is wrong!
 
 What's the root cause of this problem? And how can you fix it?
 


### PR DESCRIPTION
In [you-might-not-need-an-effect](https://beta.reactjs.org/learn/you-might-not-need-an-effect) challenge 4 text

> Change the `showForm` state variable to initialize to `false` instead of `true`. As soon as you make that change, the console will show that an empty message was sent **twice**. Something in this logic is wrong!

But according to the given code empty message only appears once, since there is only one re-render and `useEffect` runs only once after the re-render.

```
export default function Form() {
  const [showForm, setShowForm] = useState(false);
  const [message, setMessage] = useState('');

  useEffect(() => {
    if (!showForm) {
      sendMessage(message);
    }
  }, [showForm, message]);

  function handleSubmit(e) {
    e.preventDefault();
    setShowForm(false);
  }

  if (!showForm) {
    return (
      <>
        <h1>Thanks for using our services!</h1>
        <button onClick={() => {
          setMessage('');
          setShowForm(true);
        }}>
          Open chat
        </button>
      </>
    );
  }

  return (
    <form onSubmit={handleSubmit}>
      <textarea
        placeholder="Message"
        value={message}
        onChange={e => setMessage(e.target.value)}
      />
      <button type="submit" disabled={message === ''}>
        Send
      </button>
    </form>
  );
}

function sendMessage(message) {
  console.log('Sending message: ' + message);
}


```

So fixed the solution text as below, telling that empty message only appear once.

> Change the `showForm` state variable to initialize to `false` instead of `true`. As soon as you make that change, the console will show that **an empty message was sent**



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
