### PR TITLE
[beta] Update CodeStep colors

### DIFF
--- a/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
+++ b/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
@@ -49,10 +49,14 @@ const CodeBlock = function CodeBlock({
         className: cn(
           'code-step bg-opacity-10 dark:bg-opacity-20 relative rounded px-1 py-[1.5px] border-b-[2px] border-opacity-60',
           {
-            'bg-blue-40 border-blue-40': line.step === 1,
-            'bg-yellow-40 border-yellow-40': line.step === 2,
-            'bg-green-40 border-green-40': line.step === 3,
-            'bg-purple-40 border-purple-40': line.step === 4,
+            'bg-blue-40 border-blue-40 text-blue-60 dark:text-blue-30 font-bold':
+              line.step === 1,
+            'bg-yellow-40 border-yellow-40 text-yellow-60 dark:text-yellow-30 font-bold':
+              line.step === 2,
+            'bg-red-40 border-red-40 text-red-60 dark:text-red-30 font-bold':
+              line.step === 3,
+            'bg-purple-40 border-purple-40 text-purple-60 dark:text-purple-30 font-bold':
+              line.step === 4,
           }
         ),
       })

--- a/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
+++ b/beta/src/components/MDX/CodeBlock/CodeBlock.tsx
@@ -53,7 +53,7 @@ const CodeBlock = function CodeBlock({
               line.step === 1,
             'bg-yellow-40 border-yellow-40 text-yellow-60 dark:text-yellow-30 font-bold':
               line.step === 2,
-            'bg-red-40 border-red-40 text-red-60 dark:text-red-30 font-bold':
+            'bg-green-40 border-green-40 text-green-60 dark:text-green-30 font-bold':
               line.step === 3,
             'bg-purple-40 border-purple-40 text-purple-60 dark:text-purple-30 font-bold':
               line.step === 4,

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -41,7 +41,8 @@ function CodeStep({children, step}: {children: any; step: number}) {
             step === 1,
           'bg-yellow-40 border-yellow-40 text-yellow-60 dark:text-yellow-30':
             step === 2,
-          'bg-red-40 border-red-40 text-red-60 dark:text-red-30': step === 3,
+          'bg-green-40 border-green-40 text-green-60 dark:text-green-30':
+            step === 3,
           'bg-purple-40 border-purple-40 text-purple-60 dark:text-purple-30':
             step === 4,
         }

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -37,10 +37,13 @@ function CodeStep({children, step}: {children: any; step: number}) {
       className={cn(
         'code-step bg-opacity-10 dark:bg-opacity-20 relative rounded px-[6px] py-[1.5px] border-b-[2px] border-opacity-60',
         {
-          'bg-blue-40 border-blue-40': step === 1,
-          'bg-yellow-40 border-yellow-40': step === 2,
-          'bg-green-40 border-green-40': step === 3,
-          'bg-purple-40 border-purple-40': step === 4,
+          'bg-blue-40 border-blue-40 text-blue-60 dark:text-blue-30':
+            step === 1,
+          'bg-yellow-40 border-yellow-40 text-yellow-60 dark:text-yellow-30':
+            step === 2,
+          'bg-red-40 border-red-40 text-red-60 dark:text-red-30': step === 3,
+          'bg-purple-40 border-purple-40 text-purple-60 dark:text-purple-30':
+            step === 4,
         }
       )}>
       {children}

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -213,14 +213,15 @@
 }
 
 .code-step * {
-  color: black !important;
+  color: inherit !important;
 }
+
 .code-step code {
   background: none !important;
   padding: 2px !important;
 }
 html.dark .code-step * {
-  color: white !important;
+  color: inherit !important;
 }
 
 .mdx-heading {


### PR DESCRIPTION
## Overview

Adds font color to the CodeStep highlights to make it easier to tell the colors apart.

I also changed from:
- Blue
- Yellow
- Green
- Purple

To:
- Blue
- Yellow
- Purple
- Red

### Before (Light)

<img width="884" alt="Screen Shot 2022-09-21 at 10 35 01 PM" src="https://user-images.githubusercontent.com/2440089/191645666-a03ff494-82d1-4b6c-aa8e-5d281ac7b6c3.png">

### After (Light)

<img width="884" alt="Screen Shot 2022-09-21 at 10 44 54 PM" src="https://user-images.githubusercontent.com/2440089/191646800-32cdc348-ab3c-45e1-96bf-7a30e45b0d6e.png">


### Before (Dark)

<img width="884" alt="Screen Shot 2022-09-21 at 10 35 05 PM" src="https://user-images.githubusercontent.com/2440089/191645674-6b99b632-60bd-4c42-82a9-3f17ad0ff8b6.png">

### After (Dark)


<img width="884" alt="Screen Shot 2022-09-21 at 10 44 49 PM" src="https://user-images.githubusercontent.com/2440089/191646816-2567e39f-a5b4-462c-a754-9c37f5f42b05.png">
