### PR TITLE
removed unused useState from the code example in synchronizing-with-effects

### DIFF
--- a/beta/src/content/learn/synchronizing-with-effects.md
+++ b/beta/src/content/learn/synchronizing-with-effects.md
@@ -488,7 +488,7 @@ Let's try running this code:
 <Sandpack>
 
 ```js
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { createConnection } from './chat.js';
 
 export default function ChatRoom() {


### PR DESCRIPTION
Following code example from `synchronizing-with-effects` only use `useEffect`, so removed unused `useState`

```
import { useState, useEffect } from 'react';
import { createConnection } from './chat.js';

export default function ChatRoom() {
  useEffect(() => {
    const connection = createConnection();
    connection.connect();
  }, []);
  return <h1>Welcome to the chat!</h1>;
}
```


