### PR TITLE
[Beta] Force SSG failure on all rendering errors

### DIFF
--- a/beta/patches/next+12.3.2-canary.7.patch
+++ b/beta/patches/next+12.3.2-canary.7.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/next/dist/server/render.js b/node_modules/next/dist/server/render.js
+index 3a141de..72a8749 100644
+--- a/node_modules/next/dist/server/render.js
++++ b/node_modules/next/dist/server/render.js
+@@ -752,9 +752,14 @@ async function renderToHTML(req, res, pathname, query, renderOpts) {
+             // Enabling react concurrent rendering mode: __NEXT_REACT_ROOT = true
+             const renderShell = async (EnhancedApp, EnhancedComponent)=>{
+                 const content = renderContent(EnhancedApp, EnhancedComponent);
+-                return await (0, _nodeWebStreamsHelper).renderToInitialStream({
+-                    ReactDOMServer,
+-                    element: content
++                return new Promise((resolve, reject) => {
++                    (0, _nodeWebStreamsHelper).renderToInitialStream({
++                        ReactDOMServer,
++                        element: content,
++                        streamOptions: {
++                            onError: reject
++                        }
++                    }).then(resolve, reject);
+                 });
+             };
+             const createBodyResult = (initialStream, suffix)=>{


### PR DESCRIPTION
Next doesn't have an `onError` handler and currently lets `<Suspense>` fallback on all SSG errrors. Even if a build fails like https://github.com/reactjs/reactjs.org/pull/5105, CI passes. I'm adding this hack which makes the build fail on CI if there's an error thrown during SSG render pass. Ideally Next would let this be customizable somehow.