### PR TITLE
[Beta] Fix Typo in 'Updating Arrays in State'

### DIFF
--- a/beta/src/content/learn/updating-arrays-in-state.md
+++ b/beta/src/content/learn/updating-arrays-in-state.md
@@ -214,7 +214,7 @@ Here, `artists.filter(a => a.id !== artist.id)` means "create an array that cons
 
 If you want to change some or all items of the array, you can use `map()` to create a **new** array. The function you will pass to `map` can decide what to do with each item, based on its data or its index (or both).
 
-In this example, an array holds coordinates of two circles and a square. When you press the button, it moves only the circles down by 100 pixels. It does this by producing a new array of data using `map()`:
+In this example, an array holds coordinates of two circles and a square. When you press the button, it moves only the circles down by 50 pixels. It does this by producing a new array of data using `map()`:
 
 <Sandpack>
 


### PR DESCRIPTION
Fixes typo in `Updating Arrays in State` content.
- Example description says circle will move down by 100 pixels where as the example moves them down by 50.

### Before 
![image](https://user-images.githubusercontent.com/98329009/192134101-e73795d1-3726-4278-9438-b9732b4ef234.png)

### After
![image](https://user-images.githubusercontent.com/98329009/192134133-5f079924-39bb-4c97-ab1e-3f3f36c44770.png)

