### PR TITLE
[Beta] Remove unused prop from context examples

### DIFF
--- a/beta/src/content/apis/react/useContext.md
+++ b/beta/src/content/apis/react/useContext.md
@@ -797,7 +797,7 @@ const initialTasks = [
 import { useState, useContext } from 'react';
 import { useTasksDispatch } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useTasksDispatch();
   return (

--- a/beta/src/content/learn/scaling-up-with-reducer-and-context.md
+++ b/beta/src/content/learn/scaling-up-with-reducer-and-context.md
@@ -1009,7 +1009,7 @@ const initialTasks = [
 import { useState, useContext } from 'react';
 import { TasksDispatchContext } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useContext(TasksDispatchContext);
   return (
@@ -1228,7 +1228,7 @@ const initialTasks = [
 import { useState } from 'react';
 import { useTasksDispatch } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useTasksDispatch();
   return (

--- a/beta/src/content/learn/scaling-up-with-reducer-and-context.md
+++ b/beta/src/content/learn/scaling-up-with-reducer-and-context.md
@@ -696,7 +696,7 @@ export default function TaskList() {
 To update the task list, any component can read the `dispatch` function from context and call it:
 
 ```js {3,9-13}
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useContext(TasksDispatchContext);
   // ...
@@ -785,7 +785,7 @@ export const TasksDispatchContext = createContext(null);
 import { useState, useContext } from 'react';
 import { TasksDispatchContext } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useContext(TasksDispatchContext);
   return (


### PR DESCRIPTION
- `onAddTask` prop is unused when replaced with `TasksDispatchContext` 

No props are passed to `<AddTask />` in these examples:

![image](https://user-images.githubusercontent.com/98329009/192250374-90dc425f-6396-48b6-9e91-5b1d37589a59.png)
