### PR TITLE
[Beta] fix typo in useMemo() documentation

### DIFF
--- a/beta/src/content/apis/react/useMemo.md
+++ b/beta/src/content/apis/react/useMemo.md
@@ -40,7 +40,7 @@ On the initial render, the <CodeStep step={3}>value</CodeStep> you'll get from `
 
 On every subsequent render, React will compare the <CodeStep step={2}>dependencies</CodeStep> with the dependencies you passed during the last render. If none of the dependencies have changed (compared with [`Object.is`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)), `useMemo` will return the value you already calculated before. Otherwise, React will re-run your calculation and return the new value.
 
-In other words, `useCallback` caches a calculation result between re-renders until its dependencies change.
+In other words, `useMemo` caches a calculation result between re-renders until its dependencies change.
 
 **Let's walk through an example to see when this is useful.**
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Change `useCallback` to `useMemo`

before:
![telegram-cloud-photo-size-2-5298952726945842483-y](https://user-images.githubusercontent.com/42495435/192261252-82c42f32-8f6d-4c4e-8465-752b6c18d250.jpg)

after:
![telegram-cloud-photo-size-2-5298952726945842474-y](https://user-images.githubusercontent.com/42495435/192261286-a3b62af8-8249-404e-b020-3e12c0bf1585.jpg)
