### PR TITLE
Fix escaped Docsearch title

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -180,6 +180,14 @@ export function Search({
             transformItems={(items: any[]) => {
               return items.map((item) => {
                 const url = new URL(item.url);
+
+                Object.keys(item._highlightResult.hierarchy).forEach((key) => {
+                  item._highlightResult.hierarchy[key].value =
+                    item._highlightResult.hierarchy[key].value
+                      .replaceAll('&lt;', '<')
+                      .replaceAll('&gt;', '>');
+                });
+
                 return {
                   ...item,
                   url: item.url.replace(url.origin, '').replace('#__next', ''),


### PR DESCRIPTION
Manually un-escaping the tags from the highlighted results from DocSearch.

DocSearch seems to not have a way to prevent escaping the string.

https://github.com/reactjs/reactjs.org/issues/5116