### PR TITLE
[Beta] Exclude Markdown parser

### DIFF
--- a/beta/next.config.js
+++ b/beta/next.config.js
@@ -46,8 +46,12 @@ const nextConfig = {
     // Don't bundle the shim unnecessarily.
     config.resolve.alias['use-sync-external-store/shim'] = 'react';
 
-    const {IgnorePlugin} = require('webpack');
+    const {IgnorePlugin, NormalModuleReplacementPlugin} = require('webpack');
     config.plugins.push(
+      new NormalModuleReplacementPlugin(
+        /@codemirror\/lang-markdown/,
+        require.resolve('./src/utils/codemirrorMarkdownShim.js')
+      ),
       new IgnorePlugin({
         checkResource(resource, context) {
           if (

--- a/beta/src/utils/codemirrorMarkdownShim.js
+++ b/beta/src/utils/codemirrorMarkdownShim.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ */
+
+export function markdown() {
+  return 'Not used on React Beta site.';
+}


### PR DESCRIPTION
We don't have sandboxes with Markdown.

A proper fix would be upstream in https://github.com/codesandbox/sandpack/issues/588.