### PR TITLE
[Beta] Prefetch CodeBlock

### DIFF
--- a/beta/src/components/Layout/MarkdownPage.tsx
+++ b/beta/src/components/Layout/MarkdownPage.tsx
@@ -9,6 +9,8 @@ import PageHeading from 'components/PageHeading';
 import {useRouteMeta} from './useRouteMeta';
 import {TocContext} from '../MDX/TocContext';
 
+import(/* webpackPrefetch: true */ '../MDX/CodeBlock/CodeBlock');
+
 export interface MarkdownProps<Frontmatter> {
   meta: Frontmatter & {description?: string};
   children?: React.ReactNode;


### PR DESCRIPTION
If you land on a page with CodeBlock, then it's already SSR'd so you see a highlighted version.

However if you land on a page without it (like the current landing), and then click a button, we won't block on loading the CodeBlock highlighter logic. We'll just navigate. So you might see an unhighlighted snippet while the code is loading.

Most pages have code blocks. Therefore, prefetch it so that by the time you navigate, it's likely already loaded.