### PR TITLE
[beta] Sandpack: fix UI regression on the editor on horizontal scroll

### DIFF
--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -199,6 +199,10 @@ html.dark .sp-wrapper {
   background: var(--sp-colors-surface1);
 }
 
+.sandpack .sp-code-editor .cm-editor .cm-gutters {
+  margin-left: 1px;
+}
+
 .sandpack .sp-code-editor .cm-editor {
   background-color: transparent;
 }

--- a/beta/src/styles/sandpack.css
+++ b/beta/src/styles/sandpack.css
@@ -199,8 +199,7 @@ html.dark .sp-wrapper {
   background: var(--sp-colors-surface1);
 }
 
-.sandpack .sp-code-editor .cm-editor,
-.sandpack .sp-code-editor .cm-editor .cm-gutters {
+.sandpack .sp-code-editor .cm-editor {
   background-color: transparent;
 }
 


### PR DESCRIPTION
For some reason, we removed the background color from the CodeMirror gutter, which caused a bug where the line numbers overlapped the code:
<img width="1011" alt="Screenshot 2022-10-11 at 21 28 14" src="https://user-images.githubusercontent.com/4838076/195192245-cf89a515-7e22-4c62-8e0c-8456584febc2.png">

----

Edit: @gaearon, I could see you introduced this change on https://github.com/reactjs/reactjs.org/pull/5162, do you remember what you were trying to fix? 
