### PR TITLE
Add nextContext to the argument list of shouldComponentUpdate

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -251,7 +251,7 @@ The methods in this section correspond to uncommon use cases. They're handy once
 ### `shouldComponentUpdate()` {#shouldcomponentupdate}
 
 ```javascript
-shouldComponentUpdate(nextProps, nextState)
+shouldComponentUpdate(nextProps, nextState, nextContext)
 ```
 
 Use `shouldComponentUpdate()` to let React know if a component's output is not affected by the current change in state or props. The default behavior is to re-render on every state change, and in the vast majority of cases you should rely on the default behavior.


### PR DESCRIPTION
Hi folks,

I believe it will be useful to have all arguments for `shouldComponentUpdate` method in the documentation.

An example of `shouldComponentUpdate` call: https://github.com/facebook/react/blob/3bb71dfd4bfc68920e758cd5fcf9fbfa44b99a21/packages/react-reconciler/src/ReactFiberClassComponent.new.js#L318

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
