### PR TITLE
Revert "Scroll behavior"

### DIFF
--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -45,9 +45,9 @@
   /* Write your own custom base styles here */
   html {
     color-scheme: light;
+
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-tap-highlight-color: transparent;
-    scroll-behavior: smooth;
   }
 
   html.dark {

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -12,7 +12,6 @@ html {
   font-style: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
Reverts reactjs/reactjs.org#5182

I don't think this is needed. It forces sandboxes in the middle to initialize even though we scroll them out of view, and in general it delays the user from getting to the part they need.