### PR TITLE
[beta] Fix 'queueing a series of state changes->updates' typo in beta docs

### DIFF
--- a/beta/src/content/learn/adding-interactivity.md
+++ b/beta/src/content/learn/adding-interactivity.md
@@ -313,7 +313,7 @@ Read **[State as a Snapshot](/learn/state-as-a-snapshot)** to learn why state ap
 
 </LearnMore>
 
-## Queueing a series of state changes {/*queueing-a-series-of-state-changes*/}
+## Queueing a series of state updates {/*queueing-a-series-of-state-updates*/}
 
 This component is buggy: clicking "+3" increments the score only once.
 
@@ -395,9 +395,9 @@ button { display: inline-block; margin: 10px; font-size: 20px; }
 
 </Sandpack>
 
-<LearnMore path="/learn/queueing-a-series-of-state-changes">
+<LearnMore path="/learn/queueing-a-series-of-state-updates">
 
-Read **[Queueing a Series of State Changes](/learn/queueing-a-series-of-state-changes)** to learn how to queue multiple updates before the next render.
+Read **[Queueing a Series of State Updates](/learn/queueing-a-series-of-state-updates)** to learn how to queue multiple updates before the next render.
 
 </LearnMore>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
In the [Queueing a Series of State Changes](https://beta.reactjs.org/learn/adding-interactivity#queueing-a-series-of-state-changes) section in the beta docs, when you click the "Read More" button, it leads to a broken link (see screenshot).

Before:
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/3220734/196491417-baf9e5e5-cbae-4c55-ba77-422ea7926fe4.png">

This is happening because the page is actually called "Queueing a Series of State _Updates_" instead of "... State _Changes_". This fix updates these instances, and fixes the broken link.

After:
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/3220734/196493485-2d80df48-63d6-4461-836e-13cd5074fc82.png">
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/3220734/196494935-87dd2db1-fd38-42c4-8ecf-e84492323bb3.png">

