### PR TITLE
[Beta] Show illustration credit on hover/tap

### DIFF
--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -181,7 +181,7 @@ function AuthorCredit({
 }) {
   return (
     <div className="sr-only group-hover:not-sr-only group-focus-within:not-sr-only hover:sr-only">
-      <p className="absolute left-1/2 -bottom-2 -translate-x-1/2 translate-y-full text-center text-secondary dark:text-secondary-dark text-base leading-tight">
+      <p className="absolute left-1/2 -top-2 -translate-x-1/2 -translate-y-full text-center text-secondary dark:text-secondary-dark text-base leading-tight">
         <cite>
           Illustrated by{' '}
           {authorLink ? (

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -173,27 +173,35 @@ function Recipes(props: any) {
 }
 
 function AuthorCredit({
-  author,
-  authorLink,
+  author = 'Rachel Lee Nabors',
+  authorLink = 'http://rachelnabors.com/',
 }: {
   author: string;
   authorLink: string;
 }) {
   return (
-    <p className="text-center text-secondary dark:text-secondary-dark text-base mt-2">
-      <cite>
-        Illustrated by{' '}
-        {authorLink ? (
-          <a className="text-link dark:text-link-dark" href={authorLink}>
-            {author}
-          </a>
-        ) : (
-          author
-        )}
-      </cite>
-    </p>
+    <div className="sr-only group-hover:not-sr-only group-focus-within:not-sr-only hover:sr-only">
+      <p className="absolute left-1/2 -bottom-2 -translate-x-1/2 translate-y-full text-center text-secondary dark:text-secondary-dark text-base leading-tight">
+        <cite>
+          Illustrated by{' '}
+          {authorLink ? (
+            <a className="text-link dark:text-link-dark" href={authorLink}>
+              {author}
+            </a>
+          ) : (
+            author
+          )}
+        </cite>
+      </p>
+    </div>
   );
 }
+
+const IllustrationContext = React.createContext<{
+  isInBlock?: boolean;
+}>({
+  isInBlock: false,
+});
 
 function Illustration({
   caption,
@@ -208,8 +216,10 @@ function Illustration({
   author: string;
   authorLink: string;
 }) {
+  const {isInBlock} = React.useContext(IllustrationContext);
+
   return (
-    <div className="my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
+    <div className="relative group before:absolute before:-inset-y-16 before:inset-x-0 my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
       <figure className="my-8 flex justify-center">
         <img
           src={src}
@@ -223,7 +233,7 @@ function Illustration({
           </figcaption>
         ) : null}
       </figure>
-      {author ? <AuthorCredit author={author} authorLink={authorLink} /> : null}
+      {!isInBlock && <AuthorCredit author={author} authorLink={authorLink} />}
     </div>
   );
 }
@@ -257,25 +267,28 @@ function IllustrationBlock({
     </figure>
   ));
   return (
-    <div className="my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
-      {title ? (
-        <h3 className="text-center text-xl font-bold leading-9 mb-4">
-          {title}
-        </h3>
-      ) : null}
-      {sequential ? (
-        <ol className="mdx-illustration-block flex">
-          {images.map((x: any, i: number) => (
-            <li className="flex-1" key={i}>
-              {x}
-            </li>
-          ))}
-        </ol>
-      ) : (
-        <div className="mdx-illustration-block">{images}</div>
-      )}
-      {author ? <AuthorCredit author={author} authorLink={authorLink} /> : null}
-    </div>
+    <IllustrationContext.Provider value={{isInBlock: true}}>
+      <div className="relative group before:absolute before:-inset-y-16 before:inset-x-0 my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
+        {title ? (
+          <h3 className="text-center text-xl font-bold leading-9 mb-4">
+            {title}
+          </h3>
+        ) : null}
+        {sequential ? (
+          <ol className="mdx-illustration-block flex">
+            {images.map((x: any, i: number) => (
+              <li className="flex-1" key={i}>
+                {x}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <div className="mdx-illustration-block">{images}</div>
+        )}
+
+        <AuthorCredit author={author} authorLink={authorLink} />
+      </div>
+    </IllustrationContext.Provider>
   );
 }
 

--- a/beta/src/components/MDX/MDXComponents.tsx
+++ b/beta/src/components/MDX/MDXComponents.tsx
@@ -181,11 +181,15 @@ function AuthorCredit({
 }) {
   return (
     <div className="sr-only group-hover:not-sr-only group-focus-within:not-sr-only hover:sr-only">
-      <p className="absolute left-1/2 -top-2 -translate-x-1/2 -translate-y-full text-center text-secondary dark:text-secondary-dark text-base leading-tight">
+      <p className="bg-card dark:bg-card-dark text-center text-sm text-secondary dark:text-secondary-dark leading-tight dark:text-secondary-dark p-2 rounded-lg absolute left-1/2 top-0 -translate-x-1/2 -translate-y-full group-hover:flex group-hover:opacity-100 after:content-[''] after:absolute after:left-1/2 after:top-[95%] after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-card after:dark:border-t-card-dark opacity-0 transition-opacity duration-300">
         <cite>
           Illustrated by{' '}
           {authorLink ? (
-            <a className="text-link dark:text-link-dark" href={authorLink}>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              className="text-link dark:text-link-dark"
+              href={authorLink}>
               {author}
             </a>
           ) : (
@@ -238,6 +242,8 @@ function Illustration({
   );
 }
 
+const isInBlockTrue = {isInBlock: true};
+
 function IllustrationBlock({
   sequential,
   author,
@@ -265,7 +271,7 @@ function IllustrationBlock({
     </figure>
   ));
   return (
-    <IllustrationContext.Provider value={{isInBlock: true}}>
+    <IllustrationContext.Provider value={isInBlockTrue}>
       <div className="relative group before:absolute before:-inset-y-16 before:inset-x-0 my-16 mx-0 2xl:mx-auto max-w-4xl 2xl:max-w-6xl">
         {sequential ? (
           <ol className="mdx-illustration-block flex">
@@ -278,7 +284,6 @@ function IllustrationBlock({
         ) : (
           <div className="mdx-illustration-block">{images}</div>
         )}
-
         <AuthorCredit author={author} authorLink={authorLink} />
       </div>
     </IllustrationContext.Provider>


### PR DESCRIPTION
Based on https://github.com/reactjs/reactjs.org/pull/5183 with a few fixes. For now, hardcoded as a default prop.

### Desktop

https://user-images.githubusercontent.com/810438/196512057-3bcd495c-7674-4d07-9e4c-7eb4a85888e7.mov

### Mobile

https://user-images.githubusercontent.com/810438/196512072-a61cc1bb-1124-466c-b059-43f4427b1f4b.mov

