### PR TITLE
Make the usage of the `props` parameter explicit

### DIFF
--- a/beta/src/content/learn/index.md
+++ b/beta/src/content/learn/index.md
@@ -479,10 +479,10 @@ The information you pass down like this is called _props_. Now the `MyApp` compo
 Finally, change `MyButton` to *read* the props you have passed from its parent component:
 
 ```js {1,3}
-function MyButton({ count, onClick }) {
+function MyButton(props) {
   return (
-    <button onClick={onClick}>
-      Clicked {count} times
+    <button onClick={props.onClick}>
+      Clicked {props.count} times
     </button>
   );
 }
@@ -497,10 +497,10 @@ This is called "lifting state up". By moving state up, we've shared it between c
 ```js
 import { useState } from 'react';
 
-function MyButton({ count, onClick }) {
+function MyButton(props) {
   return (
-    <button onClick={onClick}>
-      Clicked {count} times
+    <button onClick={props.onClick}>
+      Clicked {props.count} times
     </button>
   );
 }


### PR DESCRIPTION
As the expected audience for this document are first-time users of React, it is more clear what is happening if you don't destructure in the function definition the first time you demonstrate passing `props` into a component.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
