### PR TITLE
Display ctrl key in search bar for non-mac browsers

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -29,12 +29,13 @@ function Hit({hit, children}: any) {
 }
 
 function Kbd(props: {children?: React.ReactNode; wide?: boolean}) {
-  const width = props.wide ? 'w-12' : 'w-6';
+  const {wide, ...rest} = props;
+  const width = wide ? 'w-12' : 'w-6';
 
   return (
     <kbd
-      className={`${width} h-6 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center  text-xs text-center rounded`}
-      {...props}
+      className={`${width} h-6 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center text-xs text-center rounded`}
+      {...rest}
     />
   );
 }
@@ -96,16 +97,20 @@ const options = {
   apiKey: siteConfig.algolia.apiKey,
   indexName: siteConfig.algolia.indexName,
 };
+
 let DocSearchModal: any = null;
+
 export function Search({
   searchParameters = {
     hitsPerPage: 5,
   },
 }: SearchProps) {
   const [isShowing, setIsShowing] = useState(false);
-  const [macintosh, setMacintosh] = useState(true);
+  const [ctrlKey, setCtrlKey] = useState(false);
 
-  useEffect(() => setMacintosh(window.navigator.platform.includes('Mac')), []);
+  useEffect(() => {
+    setCtrlKey(document.documentElement.classList.contains('platform-win'));
+  }, []);
 
   const importDocSearchModalIfNeeded = useCallback(
     function importDocSearchModalIfNeeded() {
@@ -165,7 +170,7 @@ export function Search({
         <IconSearch className="mr-3 align-middle text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />
         Search
         <span className="ml-auto hidden sm:flex item-center">
-          <Kbd wide={!macintosh}>{macintosh ? '⌘' : 'Ctrl'}</Kbd>
+          <Kbd wide={ctrlKey}>{ctrlKey ? 'Ctrl' : '⌘'}</Kbd>
           <Kbd>K</Kbd>
         </span>
       </button>

--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -28,10 +28,12 @@ function Hit({hit, children}: any) {
   );
 }
 
-function Kbd(props: {children?: React.ReactNode}) {
+function Kbd(props: {children?: React.ReactNode; wide?: boolean}) {
+  const width = props.wide ? 'w-12' : 'w-6';
+
   return (
     <kbd
-      className="h-6 w-6 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center  text-xs text-center rounded"
+      className={`${width} h-6 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center  text-xs text-center rounded`}
       {...props}
     />
   );
@@ -101,6 +103,9 @@ export function Search({
   },
 }: SearchProps) {
   const [isShowing, setIsShowing] = useState(false);
+  const [macintosh, setMacintosh] = useState(true);
+
+  useEffect(() => setMacintosh(window.navigator.platform.includes('Mac')), []);
 
   const importDocSearchModalIfNeeded = useCallback(
     function importDocSearchModalIfNeeded() {
@@ -160,7 +165,7 @@ export function Search({
         <IconSearch className="mr-3 align-middle text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />
         Search
         <span className="ml-auto hidden sm:flex item-center">
-          <Kbd>⌘</Kbd>
+          <Kbd wide={!macintosh}>{macintosh ? '⌘' : 'Ctrl'}</Kbd>
           <Kbd>K</Kbd>
         </span>
       </button>

--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -106,11 +106,6 @@ export function Search({
   },
 }: SearchProps) {
   const [isShowing, setIsShowing] = useState(false);
-  const [ctrlKey, setCtrlKey] = useState(false);
-
-  useEffect(() => {
-    setCtrlKey(document.documentElement.classList.contains('platform-win'));
-  }, []);
 
   const importDocSearchModalIfNeeded = useCallback(
     function importDocSearchModalIfNeeded() {
@@ -170,7 +165,10 @@ export function Search({
         <IconSearch className="mr-3 align-middle text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />
         Search
         <span className="ml-auto hidden sm:flex item-center">
-          <Kbd wide={ctrlKey}>{ctrlKey ? 'Ctrl' : '⌘'}</Kbd>
+          <Kbd data-platform="mac">⌘</Kbd>
+          <Kbd data-platform="win" wide>
+            Ctrl
+          </Kbd>
           <Kbd>K</Kbd>
         </span>
       </button>

--- a/beta/src/pages/_document.tsx
+++ b/beta/src/pages/_document.tsx
@@ -53,6 +53,19 @@ const MyDocument = () => {
               `,
           }}
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            (function () {
+              // Detect whether the browser is Mac to display either the ⌘ symbol or Ctrl in the search bar
+              document.documentElement.classList.add(
+                  window.navigator.platform.includes('Mac')
+                  ? "platform-mac" 
+                  : "platform-win"
+              );
+            })();
+          `,
+          }}></script>
         <Main />
         <NextScript />
       </body>

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -212,6 +212,17 @@
   }
 }
 
+/**
+  * Hide all content that's relevant only to a specific platform
+  */
+html.platform-mac [data-platform='win'] {
+  display: none;
+}
+
+html.platform-win [data-platform='mac'] {
+  display: none;
+}
+
 .code-step * {
   color: inherit !important;
 }


### PR DESCRIPTION
In the new documentation, there is an option key displayed for all users in the search bar.
This PR provides a check for the navigator platform and changes the displayed key to `Ctrl` when displayed on Windows or Linux.

**Search bar displayed on Mac**
![image](https://user-images.githubusercontent.com/14146321/197397395-b2c9bc22-d87f-474e-95fa-5da984c4f6db.png)

**Search bar displayed on Windows/Linux**
![image](https://user-images.githubusercontent.com/14146321/197397403-b8e07cd3-e904-4946-a0e2-882b8d404b51.png)
 