### PR TITLE
[Beta] Sandpack: fix accessibility issue on Codeeditor

### DIFF
--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "1.15.3",
+    "@codesandbox/sandpack-react": "1.15.4",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.7.0",

--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "1.14.1",
+    "@codesandbox/sandpack-react": "1.14.2",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.7.0",

--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "1.15.4",
+    "@codesandbox/sandpack-react": "1.15.5",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.7.0",

--- a/beta/package.json
+++ b/beta/package.json
@@ -22,7 +22,7 @@
     "check-all": "npm-run-all prettier lint:fix tsc"
   },
   "dependencies": {
-    "@codesandbox/sandpack-react": "1.14.2",
+    "@codesandbox/sandpack-react": "1.15.3",
     "@docsearch/css": "3.0.0-alpha.41",
     "@docsearch/react": "3.0.0-alpha.41",
     "@headlessui/react": "^1.7.0",

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -717,10 +717,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@1.14.1":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.14.1.tgz#271e8b39e8c178a30f3bdc3a960e9b9eb862552e"
-  integrity sha512-eiRxt5A7pGFSQcj8F95SQHS3JxQkuoZ7J/SDRjj2VMwsRa45jqlDgMTZ4KEMZ3XNF6ySZlcEXo+xQbmQXCfptg==
+"@codesandbox/sandpack-react@1.14.2":
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.14.2.tgz#5bd0bfadb5c4702446725678ff893def50298781"
+  integrity sha512-KaY+7WFcDXS7b6pxmKM5K/5jAATlrjMecU/oUVXj4vfp0MY8LLRFYo5et3D/eAs3Xs5rwh43eJDFN8EmqK29mg==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -717,10 +717,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@1.14.2":
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.14.2.tgz#5bd0bfadb5c4702446725678ff893def50298781"
-  integrity sha512-KaY+7WFcDXS7b6pxmKM5K/5jAATlrjMecU/oUVXj4vfp0MY8LLRFYo5et3D/eAs3Xs5rwh43eJDFN8EmqK29mg==
+"@codesandbox/sandpack-react@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.15.3.tgz#1c365ac3790ae51194f773da6d19af6e3b9cdb8d"
+  integrity sha512-U5m3m6b7Z+uB7Q+0IKSHwOJrU7ZElsi1RvbCFV+0NJLuebeh4GlEup01AiH62Rc0YJy8fO04gtVzeGlrrH0VJQ==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -717,10 +717,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@1.15.4":
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.15.4.tgz#6415f12aa37cf2c6f905624a83e5719274d3d9d1"
-  integrity sha512-oK3LUwaJHDeCBk2hJ7bMXJnWOCxPBN4/etfji9mNg2qDj01Z/gm0QuJw0POaYERROH5C63W5jXKPfkUYOPlDtg==
+"@codesandbox/sandpack-react@1.15.5":
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.15.5.tgz#6ac1b69e64ab66cad69e194df629a826140c3d2c"
+  integrity sha512-S5iVt9l36QzQfBAbk4mS+VUiVoHdwCFil5cdYHutCAfTAzPQn+vvR7ZYrwFl/LoBChh8nH4EAMN9XTowrzQJYw==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"

--- a/beta/yarn.lock
+++ b/beta/yarn.lock
@@ -717,10 +717,10 @@
     codesandbox-import-utils "^1.2.3"
     lodash.isequal "^4.5.0"
 
-"@codesandbox/sandpack-react@1.15.3":
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.15.3.tgz#1c365ac3790ae51194f773da6d19af6e3b9cdb8d"
-  integrity sha512-U5m3m6b7Z+uB7Q+0IKSHwOJrU7ZElsi1RvbCFV+0NJLuebeh4GlEup01AiH62Rc0YJy8fO04gtVzeGlrrH0VJQ==
+"@codesandbox/sandpack-react@1.15.4":
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.15.4.tgz#6415f12aa37cf2c6f905624a83e5719274d3d9d1"
+  integrity sha512-oK3LUwaJHDeCBk2hJ7bMXJnWOCxPBN4/etfji9mNg2qDj01Z/gm0QuJw0POaYERROH5C63W5jXKPfkUYOPlDtg==
   dependencies:
     "@code-hike/classer" "^0.0.0-aa6efee"
     "@codemirror/closebrackets" "^0.19.0"


### PR DESCRIPTION
Bump Sandpack version, which fixes an a11y issue on CodeMirror: 

![Screenshot 2022-10-27 at 22 16 09](https://user-images.githubusercontent.com/4838076/198399742-1a72641e-038c-462a-a0d6-c9a535ad814c.png)
