### PR TITLE
[Beta] Add missing styles to search box in modal

### DIFF
--- a/beta/src/styles/algolia.css
+++ b/beta/src/styles/algolia.css
@@ -39,6 +39,7 @@ html.dark {
   @apply bg-gray-10;
   @apply outline-none;
   @apply h-auto;
+  @apply focus-within:ring;
 }
 html.dark .DocSearch-Form {
   @apply bg-gray-80;
@@ -87,6 +88,7 @@ html.dark .DocSearch-Footer {
   @apply leading-tight;
   @apply text-primary;
   @apply appearance-none !important;
+  @apply focus:outline-none;
 }
 html.dark .DocSearch-Input {
   @apply text-primary-dark;


### PR DESCRIPTION
The style when focused now matches that of the search box in the sidebar.

Existing style in sidebar:
![image](https://user-images.githubusercontent.com/47396035/199620893-b2474d33-9e63-4575-8b35-a8a8f9f5b8db.png)

Style in modal before this PR:
![image](https://user-images.githubusercontent.com/47396035/199620988-928a3f87-c8d4-41c9-81a2-0a577ad53356.png)

Style in modal after this PR:
![image](https://user-images.githubusercontent.com/47396035/199621515-92b52eaa-2578-4501-9f10-e1500af8278c.png)

This was most noticeable in Firefox because of the default browser focus styling, which was not visible in Chromium.

