### PR TITLE
[Beta] fix(sandpack): revert minimal babel implementation

### DIFF
--- a/beta/src/components/MDX/Sandpack/SandpackRoot.tsx
+++ b/beta/src/components/MDX/Sandpack/SandpackRoot.tsx
@@ -87,8 +87,7 @@ function SandpackRoot(props: SandpackProps) {
           autorun,
           initMode: 'user-visible',
           initModeObserverOptions: {rootMargin: '1400px 0px'},
-          bundlerURL:
-            'https://71d9edc6.sandpack-bundler.pages.dev/?babel=minimal',
+          bundlerURL: 'https://94be751e.sandpack-bundler.pages.dev',
           logLevel: SandpackLogLevel.None,
         }}>
         <CustomPreset


### PR DESCRIPTION
Unfortunately, I'm reverting the minimal babel implementation made on https://github.com/reactjs/reactjs.org/pull/5164, as it proves that unhandled custom plugins like dynamic imports and others we're not aware of. So, here's the plan:

1. Rollback immediately in order to fix the issues;
2. Sucrase: we've been playing with it a bit, and we're looking forward to implementing the missing pieces to replace Babel (which is huge) with Sucrase. We can't make any promises, but we're actively working on it, and we can expect something soon;

@gaearon, I think we should merge this asap.

Fix https://github.com/reactjs/reactjs.org/issues/5244, fix https://github.com/reactjs/reactjs.org/issues/5241