### PR TITLE
Fix link to new URL

### DIFF
--- a/content/docs/accessibility.md
+++ b/content/docs/accessibility.md
@@ -376,7 +376,7 @@ These are toolboxes filled with HTML attributes that are fully supported in JSX 
 
 Each type of widget has a specific design pattern and is expected to function in a certain way by users and user agents alike:
 
-- [WAI-ARIA Authoring Practices - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices/#aria_ex)
+- [ARIA Authoring Practices Guide (APG) - Design Patterns and Examples](https://www.w3.org/WAI/ARIA/apg/patterns/)
 - [Heydon Pickering - ARIA Examples](https://heydonworks.com/article/practical-aria-examples/)
 - [Inclusive Components](https://inclusive-components.design/)
 

--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -46,7 +46,7 @@ A typical use case for portals is when a parent component has an `overflow: hidd
 >
 > When working with portals, remember that [managing keyboard focus](/docs/accessibility.html#programmatically-managing-focus) becomes very important.
 >
-> For modal dialogs, ensure that everyone can interact with them by following the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal).
+> For modal dialogs, ensure that everyone can interact with them by following the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
 
 [**Try it on CodePen**](https://codepen.io/gaearon/pen/yzMaBd)
 


### PR DESCRIPTION
[WAI-ARIA Authroing Practices](https://www.w3.org/TR/wai-aria-practices/) has been redesigned as [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/) and the URL has been changed.