### PR TITLE
useSyncExternalStore

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -573,7 +573,7 @@ Memoizing the children tells React that it only needs to re-render them when `de
 const [isPending, startTransition] = useTransition();
 ```
 
-Returns a stateful value for the pending state of the transition, and a function to start it.
+Returns a stateful value for the pending state of tuseSyncExternalStorehe transition, and a function to start it.
 
 `startTransition` lets you mark updates in the provided callback as transitions:
 
@@ -670,7 +670,7 @@ The following Hooks are provided for library authors to integrate libraries deep
 ### `useSyncExternalStore` {#usesyncexternalstore}
 
 ```js
-const state = useSyncExternalStore(subscribe, getSnapshot[, getServerSnapshot]);
+const state = useSyncExternalStore(subscribe, getSnapshot, [getServerSnapshot]);
 ```
 
 `useSyncExternalStore` is a hook recommended for reading and subscribing from external data sources in a way that's compatible with concurrent rendering features like selective hydration and time slicing.


### PR DESCRIPTION
under useSyncExternalStore section,
there's a typo in this code on 673page number ""   const state = useSyncExternalStore(subscribe, getSnapshot[, getServerSnapshot]);  ""
it should be ""  const state = useSyncExternalStore(subscribe, getSnapshot , [getServerSnapshot]);  ""

I'm new here so I hope You understand

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
