### PR TITLE
Chore: fix code example

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -279,7 +279,7 @@ This form may seem confusing or unnecessary, but it has a useful property. Singl
 
 ```js
 // Instead of doing this...
-const EnhancedComponent = withRouter(connect(commentSelector)(WrappedComponent))
+const EnhancedComponent = withRouter(connect(commentSelector))(WrappedComponent)
 
 // ... you can use a function composition utility
 // compose(f, g, h) is the same as (...args) => f(g(h(...args)))


### PR DESCRIPTION
Because "const EnhancedComponent = withRouter(connect(commentSelector)(WrappedComponent))"(line 282) is not the same as "const enhance = compose(withRouter, connect(commentSelector)); const EnhancedComponent = enhance(WrappedComponent)"(line 286 ~ 291).

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
