### PR TITLE
fix: Use relative LICENSE-DOCS path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ If your language does not have a translation and you would like to create one, p
 - `yarn reset` to clear the local cache
 
 ## License
-Content submitted to [reactjs.org](https://reactjs.org/) is CC-BY-4.0 licensed, as found in the [LICENSE-DOCS.md](https://github.com/open-source-explorer/reactjs.org/blob/master/LICENSE-DOCS.md) file.
+Content submitted to [reactjs.org](https://reactjs.org/) is CC-BY-4.0 licensed, as found in the [LICENSE-DOCS.md](LICENSE-DOCS.md) file.


### PR DESCRIPTION
Clicked the `LICENSE-DOCS.md` link in the `README.md` & realized afterwards that I'd been sent to another repository.
I've updated the absolute `LICENSE-DOCS.md` path to a relative path. 🙂 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
