### PR TITLE
fix: correct order of future conference dates content

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -27,11 +27,6 @@ December 2, 2022. In-person in Berlin, Germany + remote (hybrid event)
 
 [Website](https://reactday.berlin) - [Twitter](https://twitter.com/reactdayberlin) - [Facebook](https://www.facebook.com/reactdayberlin/) - [Videos](https://www.youtube.com/c/ReactConferences)
 
-### ReactNext 2023 {#reactnext}
-June 27th, 2023. Tel Aviv, Israel
-
-[Website](https://www.react-next.com/) - [Facebook](https://www.facebook.com/ReactNextConf) - [Youtube](https://www.youtube.com/@ReactNext)
-
 ### RemixConf 2023 {#remixconf-2023}
 May, 2023. Salt Lake City, UT
 
@@ -51,6 +46,11 @@ May 31 - June 2, 2023. Atlanta, GA, USA
 June 2 & 6, 2023. In-person in Amsterdam, Netherlands + remote first interactivity (hybrid event)
 
 [Website](https://reactsummit.com) - [Twitter](https://twitter.com/reactsummit) - [Facebook](https://www.facebook.com/reactamsterdam) - [Videos](https://youtube.com/c/ReactConferences)
+
+### ReactNext 2023 {#reactnext}
+June 27th, 2023. Tel Aviv, Israel
+
+[Website](https://www.react-next.com/) - [Facebook](https://www.facebook.com/ReactNextConf) - [Youtube](https://www.youtube.com/@ReactNext)
 
 ## Past Conferences {#past-conferences}
 


### PR DESCRIPTION
- Update markdown word placement
- Move June 2023 conference date behind May 2023 dates
