### PR TITLE
[Beta] Anchor for individual challenges & deepdive

### DIFF
--- a/beta/src/components/MDX/Challenges/Challenge.tsx
+++ b/beta/src/components/MDX/Challenges/Challenge.tsx
@@ -9,6 +9,7 @@ import {ChallengeContents} from './Challenges';
 import {IconHint} from '../../Icon/IconHint';
 import {IconSolution} from '../../Icon/IconSolution';
 import {IconArrowSmall} from '../../Icon/IconArrowSmall';
+import {H4} from '../Heading';
 
 interface ChallengeProps {
   isRecipes?: boolean;
@@ -45,14 +46,16 @@ export function Challenge({
   return (
     <div className="p-5 sm:py-8 sm:px-8">
       <div>
-        <h3 className="text-xl text-primary dark:text-primary-dark mb-2">
+        <H4
+          className="text-xl text-primary dark:text-primary-dark mb-2 mt-0 font-medium"
+          id={currentChallenge.id}>
           <div className="font-bold block md:inline">
             {isRecipes ? 'Example' : 'Challenge'} {currentChallenge.order} of{' '}
             {totalChallenges}
             <span className="text-primary dark:text-primary-dark">: </span>
           </div>
           {currentChallenge.name}
-        </h3>
+        </H4>
         {currentChallenge.content}
       </div>
       <div className="flex justify-between items-center mt-4">

--- a/beta/src/components/MDX/Challenges/Challenges.tsx
+++ b/beta/src/components/MDX/Challenges/Challenges.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {Children, useRef, useEffect, useState, useCallback} from 'react';
+import {Children, useRef, useEffect, useState} from 'react';
 import * as React from 'react';
 import cn from 'classnames';
 import {H2} from 'components/MDX/Heading';
@@ -83,20 +83,15 @@ export function Challenges({
   const {asPath} = useRouter();
   const [isMounted, setMounted] = useState(false);
 
-  const scrollIntoView = useCallback(() => {
-    scrollAnchorRef.current!.scrollIntoView({
-      block: 'start',
-      behavior: 'smooth',
-    });
-  }, []);
-
   useEffect(() => {
     const challengeIndex = challenges.findIndex(
       (challenge) => challenge.id === asPath.split('#')[1]
     );
     if (challengeIndex !== -1) {
       if (isMounted) {
-        scrollIntoView();
+        scrollAnchorRef.current!.scrollIntoView({
+          block: 'start',
+        });
       } else {
         setActiveIndex(challengeIndex);
       }
@@ -104,12 +99,15 @@ export function Challenges({
     if (!isMounted) {
       setMounted(true);
     }
-  }, [asPath, challenges, isMounted, scrollIntoView]);
+  }, [asPath, challenges, isMounted]);
 
   useEffect(() => {
     if (queuedScrollRef.current === true) {
       queuedScrollRef.current = false;
-      scrollIntoView();
+      scrollAnchorRef.current!.scrollIntoView({
+        block: 'start',
+        behavior: 'smooth',
+      });
     }
   });
 

--- a/beta/src/components/MDX/Challenges/Challenges.tsx
+++ b/beta/src/components/MDX/Challenges/Challenges.tsx
@@ -2,13 +2,14 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {Children, useRef, useEffect, useState} from 'react';
+import {Children, useRef, useEffect, useState, useCallback} from 'react';
 import * as React from 'react';
 import cn from 'classnames';
 import {H2} from 'components/MDX/Heading';
 import {H4} from 'components/MDX/Heading';
 import {Challenge} from './Challenge';
 import {Navigation} from './Navigation';
+import {useRouter} from 'next/router';
 
 interface ChallengesProps {
   children: React.ReactElement[];
@@ -79,14 +80,36 @@ export function Challenges({
   const queuedScrollRef = useRef<boolean>(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const currentChallenge = challenges[activeIndex];
+  const {asPath} = useRouter();
+  const [isMounted, setMounted] = useState(false);
+
+  const scrollIntoView = useCallback(() => {
+    scrollAnchorRef.current!.scrollIntoView({
+      block: 'start',
+      behavior: 'smooth',
+    });
+  }, []);
+
+  useEffect(() => {
+    const challengeIndex = challenges.findIndex(
+      (challenge) => challenge.id === asPath.split('#')[1]
+    );
+    if (challengeIndex !== -1) {
+      if (isMounted) {
+        scrollIntoView();
+      } else {
+        setActiveIndex(challengeIndex);
+      }
+    }
+    if (!isMounted) {
+      setMounted(true);
+    }
+  }, [asPath, challenges, isMounted, scrollIntoView]);
 
   useEffect(() => {
     if (queuedScrollRef.current === true) {
       queuedScrollRef.current = false;
-      scrollAnchorRef.current!.scrollIntoView({
-        block: 'start',
-        behavior: 'smooth',
-      });
+      scrollIntoView();
     }
   });
 

--- a/beta/src/components/MDX/ExpandableExample.tsx
+++ b/beta/src/components/MDX/ExpandableExample.tsx
@@ -10,7 +10,7 @@ import {IconCodeBlock} from '../Icon/IconCodeBlock';
 import {Button} from '../Button';
 import {H4} from './Heading';
 import {useRouter} from 'next/router';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 interface ExpandableExampleProps {
   children: React.ReactNode;
@@ -28,19 +28,20 @@ function ExpandableExample({children, excerpt, type}: ExpandableExampleProps) {
   const isExample = type === 'Example';
   const id = children[0].props.id;
 
+  const queuedExpandRef = useRef<boolean>(true);
   const {asPath} = useRouter();
-  // use mounted state here incase of browser goBack
-  const [isMounted, setMounted] = useState(false);
   // init as expanded to prevent flash
   const [isExpanded, setIsExpanded] = useState(true);
 
   // asPath would mismatch between server and client, reset here instead of put it into init state
   useEffect(() => {
-    if (!isMounted) {
-      setMounted(true);
-      setIsExpanded(id === asPath.split('#')[1]);
+    if (queuedExpandRef.current) {
+      queuedExpandRef.current = false;
+      if (id !== asPath.split('#')[1]) {
+        setIsExpanded(false);
+      }
     }
-  }, [asPath, id, isMounted]);
+  }, [asPath, id]);
 
   return (
     <details

--- a/beta/src/components/MDX/ExpandableExample.tsx
+++ b/beta/src/components/MDX/ExpandableExample.tsx
@@ -9,6 +9,8 @@ import {IconDeepDive} from '../Icon/IconDeepDive';
 import {IconCodeBlock} from '../Icon/IconCodeBlock';
 import {Button} from '../Button';
 import {H4} from './Heading';
+import {useRouter} from 'next/router';
+import {useEffect, useState} from 'react';
 
 interface ExpandableExampleProps {
   children: React.ReactNode;
@@ -17,15 +19,28 @@ interface ExpandableExampleProps {
 }
 
 function ExpandableExample({children, excerpt, type}: ExpandableExampleProps) {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const isDeepDive = type === 'DeepDive';
-  const isExample = type === 'Example';
-
   if (!Array.isArray(children) || children[0].type.mdxName !== 'h4') {
     throw Error(
       `Expandable content ${type} is missing a corresponding title at the beginning`
     );
   }
+  const isDeepDive = type === 'DeepDive';
+  const isExample = type === 'Example';
+  const id = children[0].props.id;
+
+  const {asPath} = useRouter();
+  // use mounted state here incase of browser goBack
+  const [isMounted, setMounted] = useState(false);
+  // init as expanded to prevent flash
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // asPath would mismatch between server and client, reset here instead of put it into init state
+  useEffect(() => {
+    if (!isMounted) {
+      setMounted(true);
+      setIsExpanded(id === asPath.split('#')[1]);
+    }
+  }, [asPath, id, isMounted]);
 
   return (
     <details
@@ -67,7 +82,7 @@ function ExpandableExample({children, excerpt, type}: ExpandableExampleProps) {
         </h5>
         <div className="mb-4">
           <H4
-            id={children[0].props.id}
+            id={id}
             className="text-xl font-bold text-primary dark:text-primary-dark">
             {children[0].props.children}
           </H4>


### PR DESCRIPTION
prev PR here: https://github.com/reactjs/reactjs.org/pull/5310#issuecomment-1335866959

### What's included

- Made DeepDive's content auto-expand once accessed via a direct link.  
- Made individual challenges linkable.  

### Does this affect the UI

Expected to be no, Individual Challenges' styles have been updated to fit the previous layout.  

~~### Test results~~

~~All the included functions work well, but perhaps it needs further caution to watch closely when we access the page via the browser `goBack` button, and check if there are unexpected/unnecessary renders, breaks during scroll, etc.~~

---

<details>

<summary>Discussion points</summary>


#### 1. To auto-expand the content

As well known, we can directly set the initial state rather than reset it inside `useEffect` later.  
However, to check the initial expanded status for DeepDive, I faced an issue using the nextjs `asPath` to get the current generated URL, as shown below

>Using the `asPath` field may lead to a mismatch between client and server if the page is rendered using server-side rendering or [automatic static optimization](https://nextjs.org/docs/advanced-features/automatic-static-optimization). Avoid using `asPath` until the `isReady` field is `true`.  

ref: [nextjs router docs](https://nextjs.org/docs/api-reference/next/router#router-object)

there are some workarounds I've tried

- dynamic import without SSR for part of the component which uses that initial status -> seems won't work cause we are using that state at the very beginning in `<details />`.  
- use [suppressHydrationWarning](https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning) for all the elements using that state -> seems not to be a good practice at this moment.  
- use Effect to reset the state from default `false` to `true` if we are on a DeepDive anchor, this could cause page flash/re-rendering.  

After those attempts, I just realized that why don't we use a default `true` for that status to make that workaround better, because

- If we are on a DeepDive, expanded at the beginning so no more broken user experience.  
- If not, the expanded content would change its status to `false` without being seen.  

Now they work as expected, but after all, I guess it's still a workaround so maybe it's not the best way to do it and could be changed later if possible.

#### 2. For the browser's `goBack`

We definitely want to maintain our DeepDive content expanded even if we route to another place and then go back again (if we are on the DeepDive already), that's the reason I use mounted state rather than an independent variable outside the component to make the Effect only run once (as recommended in docs), and set the state inside Effect without further conditions.  

#### 3. About the multiple linkable individual challenges

Each challenge is now having its own anchor, but except for the default (first) one, others won't anchor in the first place cause they are not been rendered.

Assuming we are not gonna step into the _render all, visible one_ solution, lacking further tricks known, the only way that came to my mind is to use an Effect again.  

In this way, I used the previous `scrollIntoVIew` without thinking, I must admit this may not be the best solution, and if it really won't match the expected behavior, closing this would be fine. Please let me know if there are better ways to do that, thanks for reading!

</details>