### PR TITLE
[Beta] Docs Contributors page

### DIFF
--- a/beta/src/components/Layout/Footer.tsx
+++ b/beta/src/components/Layout/Footer.tsx
@@ -128,6 +128,9 @@ export function Footer() {
               <FooterLink href="/learn/acknowledgements">
                 Acknowledgements
               </FooterLink>
+              <FooterLink href="/learn/docs-contributors">
+                Docs Contributors
+              </FooterLink>
               <FooterLink href="/learn/meet-the-team">Meet the Team</FooterLink>
               <FooterLink href="https://reactjs.org/blog">Blog</FooterLink>
               {/* <FooterLink href="/">Community Resources</FooterLink> */}

--- a/beta/src/content/learn/acknowledgements.md
+++ b/beta/src/content/learn/acknowledgements.md
@@ -2,9 +2,15 @@
 title: Acknowledgements
 ---
 
-## React {/*react*/}
+<Intro>
 
-React was originally created by [Jordan Walke.](https://github.com/jordwalke) Today, React has a [dedicated full-time team working on it](/learn/meet-the-team), as well as over a thousand [open source contributors.](https://github.com/facebook/react/blob/main/AUTHORS) We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
+React was originally created by [Jordan Walke.](https://github.com/jordwalke) Today, React has a [dedicated full-time team working on it](/learn/meet-the-team), as well as over a thousand [open source contributors.](https://github.com/facebook/react/blob/main/AUTHORS)
+
+</Intro>
+
+## Past contributors {/*past-contributors*/}
+
+We'd like to recognize a few people who have made significant contributions to React and its documentation in the past and have helped maintain them over the years:
 
 * [Almero Steyn](https://github.com/AlmeroSteyn)
 * [Andreas Svensson](https://github.com/syranide)
@@ -45,29 +51,6 @@ React was originally created by [Jordan Walke.](https://github.com/jordwalke) To
 This list is not exhaustive.
 
 We'd like to give special thanks to [Tom Occhino](https://github.com/tomocchino) and [Adam Wolff](https://github.com/wolffiex) for their guidance and support over the years. We are also thankful to all the volunteers who [translated React into other languages.](https://translations.reactjs.org/)
-
-## React Docs {/*react-docs*/}
-
-### Documentation {/*documentation*/}
-
-* [Rachel Nabors](https://twitter.com/RachelNabors): editing, writing, illustrating
-* [Dan Abramov](https://twitter.com/dan_abramov): writing, curriculum design
-* [Sylwia Vargas](https://twitter.com/SylwiaVargas): example code
-
-### Design {/*design*/}
-
-* [Dan Lebowitz](https://twitter.com/lebo): design
-* [Razvan Gradinar](https://dribbble.com/GradinarRazvan): design
-* [Maggie Appleton](https://maggieappleton.com/): diagram system
-
-### Development {/*development*/}
-
-* [Jared Palmer](https://twitter.com/jaredpalmer): site development
-* [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)): site development
-* [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), [Danilo Woznica](https://twitter.com/danilowoz)): sandbox integration
-* [Rick Hanlon](https://twitter.com/rickhanlonii): site development
-
-We'd also like to thank countless alpha testers and community members who gave us feedback along the way.
 
 ## Additional Thanks {/*additional-thanks*/}
 

--- a/beta/src/content/learn/docs-contributors.md
+++ b/beta/src/content/learn/docs-contributors.md
@@ -1,0 +1,32 @@
+---
+title: Docs Contributors
+---
+
+<Intro>
+
+React documentation is written and maintained by the [React team](/learn/meet-the-team) and [external contributors.](https://github.com/reactjs/reactjs.org/graphs/contributors) On this page, we'd like to thank a few people who've made significant contributions to this site.
+
+</Intro>
+
+## Content {/*content*/}
+
+* [Rachel Nabors](https://twitter.com/RachelNabors): editing, writing, illustrating
+* [Dan Abramov](https://twitter.com/dan_abramov): writing, curriculum design
+* [Sylwia Vargas](https://twitter.com/SylwiaVargas): example code
+
+## Design {/*design*/}
+
+* [Dan Lebowitz](https://twitter.com/lebo): site design
+* [Razvan Gradinar](https://dribbble.com/GradinarRazvan): sandbox design
+* [Maggie Appleton](https://maggieappleton.com/): diagram system
+* [Sophie Alpert](https://twitter.com/sophiebits): color-coded explanations
+
+## Development {/*development*/}
+
+* [Jared Palmer](https://twitter.com/jaredpalmer): site development
+* [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)): site development
+* [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), [Danilo Woznica](https://twitter.com/danilowoz)): sandbox integration
+* [Rick Hanlon](https://twitter.com/rickhanlonii): site development
+* [Harish Kumar](https://www.strek.in/): development and maintenance
+
+We'd also like to thank countless alpha testers and community members who gave us feedback along the way.

--- a/beta/src/sidebarLearn.json
+++ b/beta/src/sidebarLearn.json
@@ -197,6 +197,9 @@
             "title": "Acknowledgements",
             "path": "/learn/acknowledgements"
           }, {
+            "title": "Docs Contributors",
+            "path": "/learn/docs-contributors"
+          }, {
             "title": "Meet the Team",
             "path": "/learn/meet-the-team"
           }]


### PR DESCRIPTION
As previously discussed with some of the docs contributors, it would be nice to extract the docs acknowledgements out of the generic Acknowledgements page. If we establish some kind of more persistent workflow around this, the page could potentially become a "Docs Team" page or even get merged with the main Team page. But for now I wanted to follow through on extracting it. Bonus: added a few more people.