### PR TITLE
[Beta] Fix typo in 'Reusing Logic with Custom Hooks' page

### DIFF
--- a/beta/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/beta/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -279,7 +279,7 @@ function useAuth() {
 Technically, this isn't enforced by React. In principle, you could make a Hook that doesn't call other Hooks. This is often confusing and limiting so it's best to avoid that pattern. However, there may be rare cases where it is helpful. For example, maybe your function doesn't use any Hooks right now, but you plan to add some Hook calls to it in the future. Then it makes sense to name it with the `use` prefix:
 
 ```js {3-4}
-// ✅ Good: A Hook that will likely some other Hooks later
+// ✅ Good: A Hook that will likely use some other Hooks later
 function useAuth() {
   // TODO: Replace with this line when authentication is implemented:
   // return useContext(Auth);


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/9212875/206231082-d73da76c-b687-4e95-aec6-e5de4f58ec58.png)

The comment should be:
> ✅ Good: A Hook that will likely **use** some other Hooks later