### PR TITLE
[Beta] Fix a word from useMemo to useCallback

### DIFF
--- a/beta/src/content/apis/react/useCallback.md
+++ b/beta/src/content/apis/react/useCallback.md
@@ -348,7 +348,7 @@ button[type="button"] {
 
 In this example, the `ShoppingForm` implementation is also **artificially slowed down** so that you can see what happens when some React component you're rendering is genuinely slow. Try incrementing the counter and toggling the theme.
 
-Unlike in the previous example, toggling the theme is also slow now! This is because **there is no `useMemo` call in this version,** so `handleSubmit` is always a new function, and the slowed down `ShoppingForm` component can't skip re-rendering.
+Unlike in the previous example, toggling the theme is also slow now! This is because **there is no `useCallback` call in this version,** so `handleSubmit` is always a new function, and the slowed down `ShoppingForm` component can't skip re-rendering.
 
 <Sandpack>
 


### PR DESCRIPTION
Fixes the word that is referring to `useMemo` instead of `useCallback` in new Beta API page of `useCallback`.