### PR TITLE
fixed typo 

### DIFF
--- a/content/languages.yml
+++ b/content/languages.yml
@@ -120,7 +120,7 @@
   code: ne
   status: 0
 - name: Dutch
-  translated_name: Nederlands
+  translated_name: Netherlands
   code: nl
   status: 0
 - name: Polish


### PR DESCRIPTION
Fixed the  spelling of " Nederlands" to "Netherlands" in the languages section. Here is the reference:

![image](https://user-images.githubusercontent.com/98374339/206888415-3f3f6fef-1988-4944-ae10-dc42999d6e27.png)



