### PR TITLE
[Beta] Fixed a dead link in useTransition.md

### DIFF
--- a/beta/src/content/apis/react/useTransition.md
+++ b/beta/src/content/apis/react/useTransition.md
@@ -1489,7 +1489,7 @@ function TabContainer() {
 
 * `useTransition` is a Hook, so it can only be called inside components or custom Hooks. If you need to start a transition somewhere else (for example, from a data library), call the standalone [`startTransition`](/apis/react/startTransition) instead.
 
-* You can wrap an update into a transition only if you have access to the `set` function of that state. If you want to start a transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/apis/react/usedeferredvalue) instead.
+* You can wrap an update into a transition only if you have access to the `set` function of that state. If you want to start a transition in response to some prop or a custom Hook return value, try [`useDeferredValue`](/apis/react/useDeferredValue) instead.
 
 * The function you pass to `startTransition` must be synchronous. React immediately executes this function, marking all state updates that happen while it executes as transitions. If you try to perform more state updates later (for example, in a timeout), they won't be marked as transitions.
 


### PR DESCRIPTION
In the paragraph:
```
You can wrap an update into a transition only if you have access to the set function of that state. If you want to start a transition in response to some prop or a custom Hook return value, try useDeferredValue instead.
```

The `useDeferredValue` link pointed to `usedeferredvalue` which is an invalid URL, this commit fixes that.

In an other paragraph:
```
Alternatively, you can have one state variable, and add useDeferredValue which will “lag behind” the real value. It will trigger non-blocking re-renders to “catch up” with the new value automatically.
```

The link was correct, so I updated it to be the same.