### PR TITLE
Fixed Sidebar not scrollable. #5333

### DIFF
--- a/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -72,6 +72,7 @@ class StickyResponsiveSidebar extends Component<Props, State> {
           style={{
             opacity: menuOpacity,
             transition: 'opacity 0.5s ease',
+            overflow: 'scroll',
           }}
           css={{
             [media.lessThan('small')]: smallScreenSidebarStyles,
@@ -91,7 +92,7 @@ class StickyResponsiveSidebar extends Component<Props, State> {
             [media.greaterThan('small')]: {
               position: 'fixed',
               zIndex: 2,
-              height: 'calc(100vh - 60px)',
+              height: 'calc(100vh - 100px)',
               overflowY: 'auto',
               WebkitOverflowScrolling: 'touch',
               marginRight: -999,
@@ -101,11 +102,11 @@ class StickyResponsiveSidebar extends Component<Props, State> {
             },
 
             [media.size('small')]: {
-              height: 'calc(100vh - 40px)',
+              height: 'calc(100vh - 100px)',
             },
 
             [media.between('medium', 'large')]: {
-              height: 'calc(100vh - 50px)',
+              height: 'calc(100vh - 100px)',
             },
 
             [media.greaterThan('sidebarFixed')]: {


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2022-12-14 at 9 53 10 PM" src="https://user-images.githubusercontent.com/74089487/207651219-798262a0-3250-491a-876b-fb6a65f9f674.png">

Fixed the Sidebar not scrollable issue due to the height of the sidebar.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
