### PR TITLE
[Beta] Fix scroll jumps on navigating to fragments

### DIFF
--- a/beta/src/components/MDX/ExpandableExample.tsx
+++ b/beta/src/components/MDX/ExpandableExample.tsx
@@ -28,20 +28,17 @@ function ExpandableExample({children, excerpt, type}: ExpandableExampleProps) {
   const isExample = type === 'Example';
   const id = children[0].props.id;
 
-  const queuedExpandRef = useRef<boolean>(true);
   const {asPath} = useRouter();
-  // init as expanded to prevent flash
-  const [isExpanded, setIsExpanded] = useState(true);
+  const shouldAutoExpand = id === asPath.split('#')[1];
+  const queuedExpandRef = useRef<boolean>(shouldAutoExpand);
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  // asPath would mismatch between server and client, reset here instead of put it into init state
   useEffect(() => {
     if (queuedExpandRef.current) {
       queuedExpandRef.current = false;
-      if (id !== asPath.split('#')[1]) {
-        setIsExpanded(false);
-      }
+      setIsExpanded(true);
     }
-  }, [asPath, id]);
+  }, []);
 
   return (
     <details


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/reactjs/reactjs.org/pull/5310.

Previously, we would expand all deep dives in SSR and then collapse them in an Effect except the one that has the current fragment hash. This doesn't make sense and causes layout jumps on hydration. Particularly I've observed jumps on mobile Safari when navigating to a fragment anchor that comes *after* a deep dive because the deep dive expansion shifts layout. What we should be doing instead is keep them all collapsed, and then auto-expand the one that's in the hash. It's fine if it shifts layout because the fragment navigation case is not the common one.