### PR TITLE
perf: preload algolia `DocSearchModal` component on hover of searchbar

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -149,6 +149,9 @@ export function Search({
         aria-label="Search"
         type="button"
         className="inline-flex md:hidden items-center text-lg p-1 ml-4 lg:ml-6"
+        onMouseOver={() => {
+          importDocSearchModalIfNeeded();
+        }}
         onClick={onOpen}>
         <IconSearch className="align-middle" />
       </button>
@@ -156,6 +159,9 @@ export function Search({
       <button
         type="button"
         className="hidden md:flex relative pl-4 pr-0.5 py-1 h-10 bg-secondary-button dark:bg-gray-80 outline-none focus:ring focus:outline-none betterhover:hover:bg-opacity-80 pointer items-center shadow-inner text-left w-full text-gray-30 rounded-lg align-middle text-sm"
+        onMouseOver={() => {
+          importDocSearchModalIfNeeded();
+        }}
         onClick={onOpen}>
         <IconSearch className="mr-3 align-middle text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />
         Search


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Description

Preloaded `DocSearchModal` component from `@docsearch/react/modal` on **hover** of searchbar, so that the `DocSearchModal` will be ready even before user clicks on the searchbar


[preload.webm](https://user-images.githubusercontent.com/42532987/208247166-d2fada6e-defc-4fcc-9f13-8476b332516a.webm)
