### PR TITLE
[Beta] Move search outside tabs

### DIFF
--- a/beta/src/components/Layout/Nav/Nav.tsx
+++ b/beta/src/components/Layout/Nav/Nav.tsx
@@ -241,6 +241,11 @@ export default function Nav() {
             </button>
           </div>
         </div>
+        {!isOpen && (
+          <div className="hidden lg:block sm:pt-10 lg:pt-4">
+            <Search />
+          </div>
+        )}
         <div className="px-0 pt-2 w-full 2xl:max-w-xs hidden lg:flex items-center self-center border-b-0 lg:border-b border-border dark:border-border-dark">
           <NavLink
             href="/learn"
@@ -328,11 +333,6 @@ export default function Nav() {
             `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-xs z-10`,
             isOpen ? 'block z-40' : 'hidden lg:block'
           )}>
-          {!isOpen && (
-            <div className="px-5 sm:pt-10 lg:pt-4">
-              <Search />
-            </div>
-          )}
           <nav
             role="navigation"
             style={{'--bg-opacity': '.2'} as React.CSSProperties} // Need to cast here because CSS vars aren't considered valid in TS types (cuz they could be anything)


### PR DESCRIPTION
Search is not tab-specific.

## Before
<img width="329" alt="Screenshot 2022-12-20 at 20 38 19" src="https://user-images.githubusercontent.com/810438/208741463-561a7cc1-e80d-44ea-b91a-8d4de9f7a3d6.png">

## After

<img width="325" alt="Screenshot 2022-12-20 at 20 37 46" src="https://user-images.githubusercontent.com/810438/208741453-475cc022-fbcd-4818-ac50-4e378be4087a.png">
