### PR TITLE
404 is shown for 1 second before matching client paths

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -15,25 +15,31 @@ import {sharedStyles} from 'theme';
 type Props = {
   location: Location,
 };
-
-const PageNotFound = ({location}: Props) => (
-  <Layout location={location}>
-    <Container>
-      <div css={sharedStyles.articleLayout.container}>
-        <div css={sharedStyles.articleLayout.content}>
-          <Header>Page Not Found</Header>
-          <TitleAndMetaTags title="React - Page Not Found" />
-          <div css={sharedStyles.markdown}>
-            <p>We couldn't find what you were looking for.</p>
-            <p>
-              Please contact the owner of the site that linked you to the
-              original URL and let them know their link is broken.
-            </p>
-          </div>
-        </div>
-      </div>
-    </Container>
-  </Layout>
-);
+const PageNotFound = ({location}: Props) => {
+  const browser = typeof window !== 'undefined' && window;
+  return (
+    <div>
+      {browser && (
+        <Layout location={location}>
+          <Container>
+            <div css={sharedStyles.articleLayout.container}>
+              <div css={sharedStyles.articleLayout.content}>
+                <Header>Page Not Found</Header>
+                <TitleAndMetaTags title="React - Page Not Found" />
+                <div css={sharedStyles.markdown}>
+                  <p>We couldn't find what you were looking for.</p>
+                  <p>
+                    Please contact the owner of the site that linked you to the
+                    original URL and let them know their link is broken.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Container>
+        </Layout>
+      )}
+    </div>
+  );
+};
 
 export default PageNotFound;


### PR DESCRIPTION
Hi React Team,

This is my first time open source contribution. I have followed the React Guidelines too. 
Issue: When we hit the blogs Link from [Beta] docs, the 404 page is shown for a second and then actual content is got through graphQl Query and is displayed. It's not naive to say that it creates a bad UX. I myself ( while i was on slow internet ), thought that docs server is down and moved away from website twice. I have been working on this and found out that this thing was fixed in Gastby new versions, and there is an implemenation/work around to fix this into previous versions ( that react docs are using). I have managed to fix it and am creating this PR. Please do let me know if there are further changes required in this PR. I have tested it and it's working fine. :) 


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
