### PR TITLE
Change 'options object' to 'createOptions function'

### DIFF
--- a/beta/src/content/apis/react/useEffect.md
+++ b/beta/src/content/apis/react/useEffect.md
@@ -1526,7 +1526,7 @@ With this fix, typing into the input doesn't reconnect the chat. Unlike an objec
 
 ### Removing unnecessary function dependencies {/*removing-unnecessary-function-dependencies*/}
 
-If your Effect depends on an object or a function created during rendering, it might run more often than needed. For example, this Effect re-connects after every render because the `options` object is [different for every render:](/learn/removing-effect-dependencies#does-some-reactive-value-change-unintentionally)
+If your Effect depends on an object or a function created during rendering, it might run more often than needed. For example, this Effect re-connects after every render because the `createOptions` function is [different for every render:](/learn/removing-effect-dependencies#does-some-reactive-value-change-unintentionally)
 
 ```js {4-9,12,16}
 function ChatRoom({ roomId }) {


### PR DESCRIPTION
The section under consideration 'Removing unnecessary function dependencies' should use the text 'createOptions function' instead of 'options object' to match the given example correctly. The 'options object' text is being used correctly for the previous section which talks about 'Removing unnecessary object dependencies' however, it must be updated for this section.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
