### PR TITLE
error with path

### DIFF
--- a/beta/src/sidebarReference.json
+++ b/beta/src/sidebarReference.json
@@ -1,7 +1,7 @@
 {
   "title": "API Reference",
   "heading": true,
-  "path": "/reference",
+  "path": "/reference/react",
   "routes": [
     {
       "heading": true,


### PR DESCRIPTION
GET https://beta.reactjs.org/_next/data/g5upX8ct9MOy4awwejzle/reference.json?markdownPath=reference 404

maybe you will add 'index.md' inside 'reference/' but for now i think why not to do it?