### PR TITLE
Fixes a typo

### DIFF
--- a/beta/src/content/reference/react/Suspense.md
+++ b/beta/src/content/reference/react/Suspense.md
@@ -4,7 +4,7 @@ title: <Suspense>
 
 <Intro>
 
-`<Suspense>` lets you displays a fallback until its children have finished loading.
+`<Suspense>` lets you display a fallback until its children have finished loading.
 
 
 ```js


### PR DESCRIPTION
Suspense page has header 
<Suspense> lets you displays a fallback until its children have finished loading.
instead of  <Suspense> lets you display a fallback until its children have finished loading.

