### PR TITLE
[beta] Fix inconsistent anchor link on `flushSync` page

### DIFF
--- a/beta/src/content/reference/react-dom/flushSync.md
+++ b/beta/src/content/reference/react-dom/flushSync.md
@@ -24,7 +24,7 @@ flushSync(callback)
 
 ## Reference {/*reference*/}
 
-### `flushSync(callback)` {/*create-root*/}
+### `flushSync(callback)` {/*flushsync*/}
 
 Call `flushSync` to force React to flush any pending work and update the DOM synchronously.
 


### PR DESCRIPTION
Could not find any usage of `create-root` in the docs.  This makes existing links effectively 404 with regards to the anchor but this is a beta after all.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
