### PR TITLE
Fix: [Beta][Bug] Command+Click Search Results Opens New Tab (#5321)

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -20,14 +20,6 @@ export interface SearchProps {
   renderModal?: boolean;
 }
 
-function Hit({hit, children}: any) {
-  return (
-    <Link href={hit.url.replace()}>
-      <a>{children}</a>
-    </Link>
-  );
-}
-
 function Kbd(props: {children?: React.ReactNode}) {
   return (
     <kbd
@@ -134,6 +126,22 @@ export function Search({
     [setIsShowing]
   );
 
+  function Hit({hit, children}: any) {
+    return (
+      <Link href={hit.url.replace()}>
+        <a
+          onClick={(e) => {
+            if (!(e.ctrlKey || e.metaKey)) {
+              // If (ctrl+click) or (cmd+click) is not triggered on search results, close the search modal.
+              onClose();
+            }
+          }}>
+          {children}
+        </a>
+      </Link>
+    );
+  }
+
   useDocSearchKeyboardEvents({isOpen: isShowing, onOpen, onClose});
 
   return (
@@ -171,7 +179,6 @@ export function Search({
             {...options}
             initialScrollY={window.scrollY}
             searchParameters={searchParameters}
-            onClose={onClose}
             navigator={{
               navigate({itemUrl}: any) {
                 Router.push(itemUrl);

--- a/content/blog/2022-03-08-react-18-upgrade-guide.md
+++ b/content/blog/2022-03-08-react-18-upgrade-guide.md
@@ -125,7 +125,7 @@ Finally, this API will continue to work for rendering e-mails:
 
 For more information on the changes to server rendering APIs, see the working group post on [Upgrading to React 18 on the server](https://github.com/reactwg/react-18/discussions/22), a [deep dive on the new Suspense SSR Architecture](https://github.com/reactwg/react-18/discussions/37), and [Shaundai Person’s](https://twitter.com/shaundai) talk on [Streaming Server Rendering with Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc) at React Conf 2021.
 
-## Updates to TypeScript definitions
+## Updates to TypeScript definitions {#updates-to-typescript-definitions}
 
 If your project uses TypeScript, you will need to update your `@types/react` and `@types/react-dom` dependencies to the latest versions. The new types are safer and catch issues that used to be ignored by the type checker. The most notable change is that the `children` prop now needs to be listed explicitly when defining props, for example:
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->



Reference Issue - #5321 







https://user-images.githubusercontent.com/74089487/210314287-dbeb353d-6db7-4c65-975c-e77072575108.mov

I've fixed this issue by adding an onClick listener to the anchor tag inside <Link></Link> component by next/link and closing the tag only if cmd or ctrl is not pressed when clicking on the link.

