### PR TITLE
Fix for ReactDOM.createRoot() example

### DIFF
--- a/beta/src/content/reference/react-dom/client/createRoot.md
+++ b/beta/src/content/reference/react-dom/client/createRoot.md
@@ -24,7 +24,7 @@ Call `createRoot` to create a React root for displaying content inside a browser
 
 ```js
 const domNode = document.getElementById('root');
-const root = createRoot(domNode);
+const root = ReactDOM.createRoot(domNode);
 ```
 
 React will create a root for the `domNode`, and take over managing the DOM inside it. After you've created a root, you need to call [`root.render`](#root-render) to display a React component inside of it:

--- a/beta/src/content/reference/react-dom/client/createRoot.md
+++ b/beta/src/content/reference/react-dom/client/createRoot.md
@@ -23,8 +23,10 @@ const root = createRoot(domNode, options?)
 Call `createRoot` to create a React root for displaying content inside a browser DOM element.
 
 ```js
+import { createRoot } from 'react-dom/client';
+
 const domNode = document.getElementById('root');
-const root = ReactDOM.createRoot(domNode);
+const root = createRoot(domNode);
 ```
 
 React will create a root for the `domNode`, and take over managing the DOM inside it. After you've created a root, you need to call [`root.render`](#root-render) to display a React component inside of it:


### PR DESCRIPTION
Fixing the code for ReactDOM.createRoot() example