### PR TITLE
Fix typo in tutorial-tic-tac-toe.md

### DIFF
--- a/beta/src/content/learn/tutorial-tic-tac-toe.md
+++ b/beta/src/content/learn/tutorial-tic-tac-toe.md
@@ -1417,7 +1417,7 @@ function handleClick(i) {
   if (squares[i]) {
     return;
   }
-  let nextSquares = squares.slice();
+  const nextSquares = squares.slice();
   //...
 }
 ```


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Changed `nextSquares` variable declaration from `let` to `const` since `const` is used in other code blocks in the tutorial.