### PR TITLE
Add missing X in starter tic-tac-toe Square component

### DIFF
--- a/beta/src/content/learn/tutorial-tic-tac-toe.md
+++ b/beta/src/content/learn/tutorial-tic-tac-toe.md
@@ -291,7 +291,7 @@ The `App.js` file should be selected in the _Files_ section. The contents of tha
 
 ```jsx
 export default function Square() {
-  return <button className="square"></button>;
+  return <button className="square">X</button>;
 }
 ```
 


### PR DESCRIPTION
This change adds missing "X" character for starter tic-tac-toe Square component showcase in "Overview" section

![image](https://user-images.githubusercontent.com/36604233/211165431-b083e717-e34c-485f-bec9-8f9d24bc7f9e.png)
