### PR TITLE
Fix typos in Suspense.md, useDeferredValue.md & useTransition.md

### DIFF
--- a/beta/src/content/reference/react/Suspense.md
+++ b/beta/src/content/reference/react/Suspense.md
@@ -163,7 +163,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -452,7 +452,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -789,7 +789,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1018,7 +1018,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1247,7 +1247,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1581,7 +1581,7 @@ export default function Panel({ children }) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1968,7 +1968,7 @@ export default function Panel({ children }) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -2354,7 +2354,7 @@ export default function Panel({ children }) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 

--- a/beta/src/content/reference/react/useDeferredValue.md
+++ b/beta/src/content/reference/react/useDeferredValue.md
@@ -186,7 +186,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -401,7 +401,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -630,7 +630,7 @@ function use(promise) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 

--- a/beta/src/content/reference/react/useTransition.md
+++ b/beta/src/content/reference/react/useTransition.md
@@ -848,7 +848,7 @@ export default function ContactTab() {
 
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1042,7 +1042,7 @@ export default function ContactTab() {
 
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 
@@ -1350,7 +1350,7 @@ export default function Panel({ children }) {
 ```
 
 ```js data.js hidden
-// Note: the way you would do data fething depends on
+// Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
 // Normally, the caching logic would be inside a framework.
 


### PR DESCRIPTION
Fixed typos: `fething` -> `fetching`

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
