### PR TITLE
Fix:-Updated setIndex logic

### DIFF
--- a/beta/src/content/learn/adding-interactivity.md
+++ b/beta/src/content/learn/adding-interactivity.md
@@ -96,7 +96,7 @@ export default function Gallery() {
   const [showMore, setShowMore] = useState(false);
 
   function handleNextClick() {
-    setIndex(index + 1);
+    setIndex ((index + 1) % sculptureList.length);
   }
 
   function handleMoreClick() {


### PR DESCRIPTION
The ImageGallery example's updatingIndex logic has a small flaw, as we are not keeping tracking of the index with the total number of images in the `sculptorList` , it gives an error as we are getting out of the total image count.  running the modulus operator over the setIndex with the sculptorsList length solves the issue

cc @gaearon 

Before the changes:-

https://user-images.githubusercontent.com/72331432/211250125-dbbb7606-47e3-4051-84cb-95ac061dbd48.mp4

After the changes:-


https://user-images.githubusercontent.com/72331432/211250174-229b5ed1-720b-43f8-8ec8-4329593c47c2.mp4



 