### PR TITLE
Update docs with info about onError

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -406,6 +406,8 @@ Event names:
 onLoad onError
 ```
 
+Note: When using onError with the `<picture>` element, onError can be used on either `<picture>` or `<img>` (not `<source>`).
+
 * * *
 
 ### Animation Events {#animation-events}


### PR DESCRIPTION
Closes: https://github.com/facebook/react/issues/25961

onError for the picture element works differently in React to Vanilla HTML

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
