### PR TITLE
[Beta] Simplify Immer installation guide

### DIFF
--- a/beta/src/content/learn/updating-objects-in-state.md
+++ b/beta/src/content/learn/updating-objects-in-state.md
@@ -672,9 +672,8 @@ The `draft` provided by Immer is a special type of object, called a [Proxy](http
 
 To try Immer:
 
-1. Add `use-immer` to your `package.json` as a dependency
-2. Run `npm install`
-3. Then replace `import { useState } from 'react'` with `import { useImmer } from 'use-immer'`
+1. Run `npm install use-immer` to add Immer as a dependency
+2. Then replace `import { useState } from 'react'` with `import { useImmer } from 'use-immer'`
 
 Here is the above example converted to Immer:
 


### PR DESCRIPTION
To slightly reduce the overhead of versioning and `package.json` semantics for people who are new to the Node ecosystem, I would like to suggest simplifying the guide by simply using `npm install use-immer` rather than:
1. Looking for the latest version of immer
2. Manually add the dependency in the `package.json`
3. Running `npm install` afterward

P.S: thanks for the incredible new documentation website, it is a great pleasure reading it!