### PR TITLE
Add missing word

### DIFF
--- a/beta/src/content/reference/react/useMemo.md
+++ b/beta/src/content/reference/react/useMemo.md
@@ -633,7 +633,7 @@ A JSX node like `<List items={visibleTodos} />` is an object like `{ type: List,
 
 However, if React sees the same exact JSX as during the previous render, it won't try to re-render your component. This is because JSX nodes are [immutable.](https://en.wikipedia.org/wiki/Immutable_object) A JSX node object could not have changed over time, so React knows it's safe to skip a re-render. However, for this to work, the node has to *actually be the same object*, not merely look the same in code. This is what `useMemo` does in this example.
 
-Manually wrapping JSX nodes into `useMemo` is not convenient. For example, you can't do this conditionally. This is usually you would wrap components with [`memo`](/reference/react/memo) instead of wrapping JSX nodes.
+Manually wrapping JSX nodes into `useMemo` is not convenient. For example, you can't do this conditionally. This is usually why you would wrap components with [`memo`](/reference/react/memo) instead of wrapping JSX nodes.
 
 </DeepDive>
 


### PR DESCRIPTION
Copy edit 

"This is usually you would wrap components with memo instead of wrapping JSX nodes."

Changed to

"This is usually why you would wrap components with memo instead of wrapping JSX nodes."