### PR TITLE
Update render-props.md

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -271,7 +271,7 @@ Mouse.propTypes = {
 
 ### Be careful when using Render Props with React.PureComponent {#be-careful-when-using-render-props-with-reactpurecomponent}
 
-Using a render prop can negate the advantage that comes from using [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) if you create the function inside a `render` method. This is because the shallow prop comparison will always return `false` for new props, and each `render` in this case will generate a new value for the render prop.
+Using a render prop can negate the advantage that comes from using [`React.PureComponent`](/docs/react-api.html#reactpurecomponent) if you create the function inside a `render` method. This is because the shallow prop comparison will always return `true` for new props, and each `render` in this case will generate a new value for the render prop.
 
 For example, continuing with our `<Mouse>` component from above, if `Mouse` were to extend `React.PureComponent` instead of `React.Component`, our example would look like this:
 


### PR DESCRIPTION
'This is because the shallow prop comparison will always return `false` for new props, and each `render` in this case will generate a new value for the render prop. `false` is supposed to be `true`

I think the description above is supposed to be `true`. Because the advantage from React.PureComponent is "Less render More performance" referred to https://reactjs.org/docs/shallow-compare.html

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
