### PR TITLE
docs(forwardRef.md): Explain Hooks support in render function

### DIFF
--- a/beta/src/content/reference/react/forwardRef.md
+++ b/beta/src/content/reference/react/forwardRef.md
@@ -49,7 +49,7 @@ const MyInput = forwardRef(function MyInput(props, ref) {
 
 ### `render` function {/*render-function*/}
 
-`forwardRef` accepts a render function as an argument. React calls this function with `props` and `ref`:
+`forwardRef` accepts a render function as an argument. React calls this function with `props` and `ref`. Also, Hooks can be used in this render function.
 
 ```js
 const MyInput = forwardRef(function MyInput(props, ref) {


### PR DESCRIPTION
Adds a little bit of explanation to the new `forwardRef` documentation page to clarify that the render function argument supports the use of Hooks.