### PR TITLE
fix: remove height in CSS to make avatar resizable

### DIFF
--- a/beta/src/content/learn/javascript-in-jsx-with-curly-braces.md
+++ b/beta/src/content/learn/javascript-in-jsx-with-curly-braces.md
@@ -469,7 +469,7 @@ export default function TodoList() {
 ```css
 body { padding: 0; margin: 0 }
 body > div > div { padding: 20px; }
-.avatar { border-radius: 50%; height: 90px; }
+.avatar { border-radius: 50%; }
 ```
 
 </Sandpack>
@@ -520,7 +520,7 @@ export default function TodoList() {
 ```css
 body { padding: 0; margin: 0 }
 body > div > div { padding: 20px; }
-.avatar { border-radius: 50%; height: 90px; }
+.avatar { border-radius: 50%; }
 ```
 
 </Sandpack>
@@ -575,7 +575,7 @@ export function getImageUrl(person) {
 ```css
 body { padding: 0; margin: 0 }
 body > div > div { padding: 20px; }
-.avatar { border-radius: 50%; height: 90px; }
+.avatar { border-radius: 50%; }
 ```
 
 </Sandpack>


### PR DESCRIPTION
In the page "Learn" / "JavaScript in JSX with Curly Braces" in the last challenge, we're told to check if our fix worked by "changing the value of imageSize to 'b'. The image should resize after your edit.". However, the height of the avatar is fixed to 90px in the CSS, so changing the size of the base image doesn't make any visual difference.

I removed the `height` CSS attribute so that the exemple works as intended.