### PR TITLE
fix(styles): change sidebar width in Firefox to avoid overlapping on

### DIFF
--- a/beta/src/components/Layout/Nav/Nav.tsx
+++ b/beta/src/components/Layout/Nav/Nav.tsx
@@ -101,10 +101,17 @@ export default function Nav({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
+  const [isFirefox, setIsFirefox] = useState(false);
   const scrollParentRef = useRef<HTMLDivElement>(null);
   const feedbackAutohideRef = useRef<any>(null);
   const {asPath} = useRouter();
   const feedbackPopupRef = useRef<null | HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof window !== undefined) {
+      setIsFirefox(window.navigator.userAgent.indexOf('Firefox') > -1);
+    }
+  }, []);
 
   // In mobile mode, let the user switch tabs there and back without navigating.
   // Seed the tab state from the router, but keep it independent.
@@ -330,7 +337,10 @@ export default function Nav({
 
       <div
         ref={scrollParentRef}
-        className="overflow-y-scroll no-bg-scrollbar lg:w-[336px] grow bg-wash dark:bg-wash-dark">
+        className={cn(
+          `overflow-y-scroll no-bg-scrollbar grow bg-wash dark:bg-wash-dark`,
+          isFirefox ? 'lg-w[310px]' : 'lg-w[336px]'
+        )}>
         <aside
           className={cn(
             `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-xs z-10`,


### PR DESCRIPTION
#5588 

In beta docs, the sidebar overlaps the content when min-width of screen is 1024px. This happens on Firefox only. 

Added a conditional media query depending on browser.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
