### PR TITLE
increased height of menu

### DIFF
--- a/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
+++ b/src/components/StickyResponsiveSidebar/StickyResponsiveSidebar.js
@@ -91,7 +91,6 @@ class StickyResponsiveSidebar extends Component<Props, State> {
             [media.greaterThan('small')]: {
               position: 'fixed',
               zIndex: 2,
-              height: 'calc(100vh - 60px)',
               overflowY: 'auto',
               WebkitOverflowScrolling: 'touch',
               marginRight: -999,
@@ -101,11 +100,15 @@ class StickyResponsiveSidebar extends Component<Props, State> {
             },
 
             [media.size('small')]: {
-              height: 'calc(100vh - 40px)',
+              height: 'calc(100vh - 60px - var(--social-banner-height-normal))',
             },
 
             [media.between('medium', 'large')]: {
-              height: 'calc(100vh - 50px)',
+              height: 'calc(100vh - 50px - var(--social-banner-height-normal))',
+            },
+
+            [media.greaterThan('large')]: {
+              height: 'calc(100vh - 60px - var(--social-banner-height-normal))',
             },
 
             [media.greaterThan('sidebarFixed')]: {


### PR DESCRIPTION
PR for #5582

- increased height of menu to account for the height of the beta.react.js banner

Small Screen (~650px)
![Screen Shot 2023-02-14 at 9 52 57 PM](https://user-images.githubusercontent.com/84363010/218915152-6beaa496-1ef9-43d6-ae71-9bad69a069e1.png)

Medium Screen (~850px)
![Screen Shot 2023-02-14 at 9 53 29 PM](https://user-images.githubusercontent.com/84363010/218915210-318e7925-b2e9-4612-8bd8-546bb036b4ec.png)

Large Screen (~1100px)
![Screen Shot 2023-02-14 at 9 54 00 PM](https://user-images.githubusercontent.com/84363010/218915272-84b824e0-7aee-4e96-907f-c9ab8025db28.png)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
