### PR TITLE
Forgotten import statement for `createElement`

### DIFF
--- a/beta/src/content/reference/react/isValidElement.md
+++ b/beta/src/content/reference/react/isValidElement.md
@@ -23,7 +23,7 @@ const isElement = isValidElement(value)
 Call `isValidElement(value)` to check whether `value` is a React element.
 
 ```js
-import { isValidElement } from 'react';
+import { isValidElement, createElement } from 'react';
 
 // ✅ React elements
 console.log(isValidElement(<p />)); // true


### PR DESCRIPTION
Added `createElement` in the import statement since it was used within the code snippet but was not imported in the API Reference for `isValidElement`.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
