### PR TITLE
docs: fix `react-hooks/exhaustive-dependencies` typo

### DIFF
--- a/beta/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/beta/src/content/learn/lifecycle-of-reactive-effects.md
@@ -748,7 +748,7 @@ If you have an existing codebase, you might have some Effects that suppress the 
 useEffect(() => {
   // ...
   // 🔴 Avoid suppressing the linter like this:
-  // eslint-ignore-next-line react-hooks/exhaustive-dependencies
+  // eslint-ignore-next-line react-hooks/exhaustive-deps
 }, []);
 ```
 

--- a/beta/src/content/learn/removing-effect-dependencies.md
+++ b/beta/src/content/learn/removing-effect-dependencies.md
@@ -285,7 +285,7 @@ If you have an existing codebase, you might have some Effects that suppress the 
 useEffect(() => {
   // ...
   // 🔴 Avoid suppressing the linter like this:
-  // eslint-ignore-next-line react-hooks/exhaustive-dependencies
+  // eslint-ignore-next-line react-hooks/exhaustive-deps
 }, []);
 ```
 

--- a/beta/src/content/reference/react/useEffect.md
+++ b/beta/src/content/reference/react/useEffect.md
@@ -1130,7 +1130,7 @@ If you have an existing codebase, you might have some Effects that suppress the 
 useEffect(() => {
   // ...
   // 🔴 Avoid suppressing the linter like this:
-  // eslint-ignore-next-line react-hooks/exhaustive-dependencies
+  // eslint-ignore-next-line react-hooks/exhaustive-deps
 }, []);
 ```
 


### PR DESCRIPTION
The rule is `exhaustive-deps`, not `exhaustive-dependencies`.