### PR TITLE
remove useless parameter

### DIFF
--- a/plugins/gatsby-transformer-authors-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-authors-yaml/gatsby-node.js
@@ -12,7 +12,7 @@ const safeLoad = require('js-yaml').safeLoad;
 
 // Reads authors.yml data into GraphQL.
 // This is auto-linked by gatsby-config.js to blog posts.
-exports.sourceNodes = ({graphql, actions}) => {
+exports.sourceNodes = ({actions}) => {
   const {createNode} = actions;
 
   const path = resolve(__dirname, '../../content/authors.yml');


### PR DESCRIPTION
I've noticed that we didn't rly use that parameter and decided to remove it
