### PR TITLE
Refactor to adhere to React best practices

### DIFF
--- a/beta/src/content/learn/you-might-not-need-an-effect.md
+++ b/beta/src/content/learn/you-might-not-need-an-effect.md
@@ -597,13 +597,18 @@ function Parent() {
 }
 
 function Child({ onFetched }) {
-  const data = useSomeAPI();
   // 🔴 Avoid: Passing data to the parent in an Effect
   useEffect(() => {
-    if (data) {
-      onFetched(data);
+    async function fetchData() {
+      const data = await useSomeAPI();
+      if (data) {
+        onFetched(data);
+      }
     }
-  }, [onFetched, data]);
+    
+    fetchData();
+  }, [onFetched]);
+  
   // ...
 }
 ```
@@ -612,7 +617,17 @@ In React, data flows from the parent components to their children. When you see 
 
 ```js {4-5}
 function Parent() {
-  const data = useSomeAPI();
+  const [data, setData] = useState(null);
+  
+  useEffect(() => {
+    async function fetchData() {
+      const fetchedData = await useSomeAPI();
+      setData(fetchedData);
+    }
+
+    fetchData();
+  }, []);
+  
   // ...
   // ✅ Good: Passing data down to the child
   return <Child data={data} />;


### PR DESCRIPTION
In this section, the words "fetched," "fetching," and "onFetched" are used frequently. so, including `useSomeAPI()` without any clarification in the example may cause confusion as it could be interpreted as a side effect. To clarify, it should be noted that `useSomeAPI()` is a side effect and should be wrapped in an `useEffect()` hook or an event handler to avoid potential issues.

To eliminate any confusion, either the wording used in the example can be modified, or it can be explicitly mentioned that `useSomeAPI()` should be wrapped in an `useEffect()` hook or an event handler. By doing so, it will ensure that the example follows React's best practices, which suggest that data should flow from parent components to their children, and updates to parent component state should not be made in child component effects.

**Overall, making this clarification will improve the clarity of the example and prevent potential confusion for readers.**