### PR TITLE
[Beta]: Added Absolute Paths

### DIFF
--- a/beta/tsconfig.json
+++ b/beta/tsconfig.json
@@ -22,7 +22,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": "src",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
I have added [absolute paths](https://nextjs.org/docs/advanced-features/module-path-aliases).

Now every paths can be written like : 
`import Button from "@/components/Button.tsx"`
instead of :
`import Button from "../../components/Button.tsx"`