### PR TITLE
Fix inaccurate description of Challenge 4

### DIFF
--- a/beta/src/content/learn/state-a-components-memory.md
+++ b/beta/src/content/learn/state-a-components-memory.md
@@ -1448,7 +1448,7 @@ If your linter is [configured for React](/learn/editor-setup#linting), you shoul
 
 #### Remove unnecessary state {/*remove-unnecessary-state*/}
 
-When the button is clicked, this example should ask for the user's name and then display an alert greeting them. You tried to use state to keep the name, but for some reason it always shows "Hello, !".
+When the button is clicked, this example should ask for the user's name and then display an alert greeting them. You tried to use state to keep the name, but for some reason it shows only "Hello, !" the first time you enter a name, and then subsequently, it also shows whatever name you entered just before that time.
 
 To fix this code, remove the unnecessary state variable. (We will discuss about [why this didn't work](/learn/state-as-a-snapshot) later.)
 


### PR DESCRIPTION
In Challenge 4 (Remove unnecessary state), the last sentence of the first paragraph says that the alert always shows "Hello, !". It doesn't. What actually happens is that "Hello, !" is alerted the first time you enter a name, but subsequently, the name you entered just before that time is shown.

Example:

1. Say you enter John the first time. Alert: "Hello, !"

3. Next, you entered Jane. Alert: "Hello, John!"

4. Finally, you entered Jack. Alert: "Hello, Jane!"

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
