### PR TITLE
Fix a misleading style in the example

### DIFF
--- a/beta/src/content/learn/javascript-in-jsx-with-curly-braces.md
+++ b/beta/src/content/learn/javascript-in-jsx-with-curly-braces.md
@@ -469,7 +469,7 @@ export default function TodoList() {
 ```css
 body { padding: 0; margin: 0 }
 body > div > div { padding: 20px; }
-.avatar { border-radius: 50%; height: 90px; }
+.avatar { border-radius: 50%; }
 ```
 
 </Sandpack>


### PR DESCRIPTION
The document said:

> To check that your fix worked, try changing the value of `imageSize` to `'b'`. The image should resize after your edit.

If the height is restricted, readers may be confused if they do not see any changes after adjusting the `imageSize`.

See https://beta.reactjs.org/learn/javascript-in-jsx-with-curly-braces#write-an-expression-inside-jsx-curly-braces