### PR TITLE
chore: update text color of console text in console block

### DIFF
--- a/beta/src/components/MDX/ConsoleBlock.tsx
+++ b/beta/src/components/MDX/ConsoleBlock.tsx
@@ -44,7 +44,7 @@ function ConsoleBlock({level = 'error', children}: ConsoleBlockProps) {
           <Box className="bg-gray-300 dark:bg-gray-90" width="15px" />
         </div>
         <div className="flex text-sm px-4">
-          <div className="border-b-2 border-gray-300 dark:border-gray-90">
+          <div className="border-b-2 border-gray-300 dark:border-gray-90 dark:text-gray-30 text-gray-50">
             Console
           </div>
           <div className="px-4 py-2 flex">


### PR DESCRIPTION
The text is not properly visible at all. used colors from the `homepage` branch
Before: 
<img width="909" alt="Screenshot 2023-03-11 at 2 02 20 AM" src="https://user-images.githubusercontent.com/32865581/224422697-a5603ff6-dd2f-4220-ab37-a4927aa1d1a1.png">
After:
<img width="883" alt="Screenshot 2023-03-11 at 2 03 01 AM" src="https://user-images.githubusercontent.com/32865581/224422807-c82d12c1-1351-4194-9ca4-5f460d9074e9.png">
