### PR TITLE
docs: add WebdriverIO as recommended alternative

### DIFF
--- a/content/docs/testing.md
+++ b/content/docs/testing.md
@@ -32,6 +32,8 @@ Different answers may work for different teams and products.
 
 **[React Testing Library](https://testing-library.com/react)** is a set of helpers that let you test React components without relying on their implementation details. This approach makes refactoring a breeze and also nudges you towards best practices for accessibility. Although it doesn't provide a way to "shallowly" render a component without its children, a test runner like Jest lets you do this by [mocking](/docs/testing-recipes.html#mocking-modules).
 
+**[WebdriverIO](https://webdriver.io/docs/component-testing/react)** is a JavaScript test framework for unit, component and e2e testing in the browser. It is an alternative runner that lets you render the component in a real browser and __not__ JSDOM. Interacting with React components can happen through [WebDriver](https://w3c.github.io/webdriver/) which mimics user behavior much closer than e.g. JavaScript based clicks. Similar to Jest it provides powerful features such as mocking of [modules and dependencies](https://webdriver.io/docs/component-testing/mocking#modules).
+
 ### Learn More {#learn-more}
 
 This section is divided in two pages:


### PR DESCRIPTION
I suggest to add WebdriverIO as recommended alternative as it allows the same features as Jest but offers users to run their tests in an actual browser.

Using JSDOM and JavaScript click events do not seem like a viable approach for testing component these days as they don't mimic user behavior at all. For example, clicks through `fireEvent` of `@testing-library/react` do not recognise whether another element is blocking the access to an element. I've done a [whole set of experiments](https://github.com/webdriverio/component-testing-examples/tree/main/framework-comparisons) showing that using WebDriver as automation protocol to mimic user behavior prevents stupid errors to pass through and also offers much more capabilities, e.g. user gestures.

Full disclosure: I am maintaining WebdriverIO. Things mentioned above have always been bothering me, which is why I introduced component testing into the framework. Yes I know there is Cypress, Puppeteer and Playwright and they also deserve to be on this page. I advocate for this tool though as it promotes usage of web standards (WebDriver) and tools that are open governed and not owned by a company.