### PR TITLE
Fix typo in useCallback example

### DIFF
--- a/beta/src/content/reference/react/useCallback.md
+++ b/beta/src/content/reference/react/useCallback.md
@@ -247,7 +247,7 @@ In this example, the `ShippingForm` component is **artificially slowed down** so
 
 Incrementing the counter feels slow because it forces the slowed down `ShippingForm` to re-render. That's expected because the counter has changed, and so you need to reflect the user's new choice on the screen.
 
-Next, try toggling the theme. **Thanks to `useCallback` together with [`memo`](/reference/react/memo), it’s fast despite the artificial slowdown!** `ShippingForm` skipped re-rendering because the `handleSubmit` function has not changed. The `handleSubmit` function has not changed because both `productId` and `referral` (your `useCallback` dependencies) haven't changed since last render.
+Next, try toggling the theme. **Thanks to `useCallback` together with [`memo`](/reference/react/memo), it’s fast despite the artificial slowdown!** `ShippingForm` skipped re-rendering because the `handleSubmit` function has not changed. The `handleSubmit` function has not changed because both `productId` and `referrer` (your `useCallback` dependencies) haven't changed since last render.
 
 <Sandpack>
 


### PR DESCRIPTION
Fix typo in `useCallback` example. The code example (and every other mention in this file) is `referrer`, not `referral`.