### PR TITLE
docs: changed useEffect example

### DIFF
--- a/beta/src/content/learn/synchronizing-with-effects.md
+++ b/beta/src/content/learn/synchronizing-with-effects.md
@@ -630,7 +630,7 @@ If your Effect subscribes to something, the cleanup function should unsubscribe:
 ```js {6}
 useEffect(() => {
   function handleScroll(e) {
-    console.log(e.clientX, e.clientY);
+    console.log(window.scrollX, window.scrollY);
   }
   window.addEventListener('scroll', handleScroll);
   return () => window.removeEventListener('scroll', handleScroll);


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The useEffect example in "Synchronizing with Effects" gives undefined as a MouseEvent is being logged for a scroll event trigger .
This is in the section [Subscribing to events](https://react.dev/learn/synchronizing-with-effects#subscribing-to-events)

I have changed it to window.scrollX and window.scrollY, so they output some value instead of undefined.

This is for the issue - [#5710 ](https://github.com/reactjs/reactjs.org/issues/5710)

![image](https://user-images.githubusercontent.com/34810623/225860583-289714e2-1b82-4aa9-902b-07003061407d.png)

