### PR TITLE
chore: fix footer "Community" link

### DIFF
--- a/beta/src/components/Layout/Footer.tsx
+++ b/beta/src/components/Layout/Footer.tsx
@@ -353,7 +353,7 @@ export function Footer({hideSurvey = false, hideBorder = false}: FooterProps) {
               </FooterLink>
             </div>
             <div className="md:col-start-2 xl:col-start-4 flex flex-col">
-              <FooterLink href="/" isHeader={true}>
+              <FooterLink href="/community" isHeader={true}>
                 Community
               </FooterLink>
               <FooterLink href="https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md">


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

The link was previously pointing to the homepage, not the community page.