### PR TITLE
Improve anchor link

### DIFF
--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -239,7 +239,7 @@ html.dark .code-step * {
 }
 
 .mdx-heading {
-  scroll-margin-top: 3em;
+  scroll-margin-top: calc(4rem + 20px);
   /* Space for the anchor */
   padding-right: 1em;
 }


### PR DESCRIPTION
The current value is broken, the header has the `.h-16` class name which equals to 4rem.

https://react.dev/reference/react/useDeferredValue#showing-stale-content-while-fresh-content-is-loading

**Before**
<img width="904" alt="Screenshot 2023-03-18 at 00 46 41" src="https://user-images.githubusercontent.com/3165635/226070549-f4ea74ed-28c1-4e87-adba-f1ed363916b2.png">

**After**
<img width="823" alt="Screenshot 2023-03-18 at 00 46 53" src="https://user-images.githubusercontent.com/3165635/226070572-d97df55e-286a-4a4c-8b5f-1656a5677327.png">

---

For this test, I used:

<img width="752" alt="Screenshot 2023-03-18 at 00 48 03" src="https://user-images.githubusercontent.com/3165635/226070712-4b7a59d4-c3a4-492c-a580-a015f90f1b2b.png">

but it equally improve the experience with the default value (16px for the default font size)