### PR TITLE
fix: spacing in responsive site navigation

### DIFF
--- a/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -148,12 +148,12 @@ export function SidebarRouteTree({
                 {index !== 0 && (
                   <li
                     role="separator"
-                    className="mt-4 mb-2 ml-5 xs:mx-5 border-b border-border dark:border-border-dark"
+                    className="mt-4 mb-2 mx-5 sm:mr-0 border-b border-border dark:border-border-dark"
                   />
                 )}
                 <h3
                   className={cn(
-                    'mb-1 text-sm font-bold ml-5 xs:mx-5 text-tertiary dark:text-tertiary-dark',
+                    'mb-1 text-sm font-bold mx-5 sm:mr-0 text-tertiary dark:text-tertiary-dark',
                     index !== 0 && 'mt-2'
                   )}>
                   {sectionHeader}

--- a/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -148,12 +148,12 @@ export function SidebarRouteTree({
                 {index !== 0 && (
                   <li
                     role="separator"
-                    className="mt-4 mb-2 mx-5 sm:mr-0 border-b border-border dark:border-border-dark"
+                    className="mt-4 mb-2 mx-5 lg:mr-0 border-b border-border dark:border-border-dark"
                   />
                 )}
                 <h3
                   className={cn(
-                    'mb-1 text-sm font-bold mx-5 sm:mr-0 text-tertiary dark:text-tertiary-dark',
+                    'mb-1 text-sm font-bold mx-5 lg:mr-0 text-tertiary dark:text-tertiary-dark',
                     index !== 0 && 'mt-2'
                   )}>
                   {sectionHeader}

--- a/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/beta/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -148,12 +148,12 @@ export function SidebarRouteTree({
                 {index !== 0 && (
                   <li
                     role="separator"
-                    className="mt-4 mb-2 ml-5 border-b border-border dark:border-border-dark"
+                    className="mt-4 mb-2 ml-5 xs:mx-5 border-b border-border dark:border-border-dark"
                   />
                 )}
                 <h3
                   className={cn(
-                    'mb-1 text-sm font-bold ml-5 text-tertiary dark:text-tertiary-dark',
+                    'mb-1 text-sm font-bold ml-5 xs:mx-5 text-tertiary dark:text-tertiary-dark',
                     index !== 0 && 'mt-2'
                   )}>
                   {sectionHeader}

--- a/beta/src/components/Layout/SidebarNav/SidebarNav.tsx
+++ b/beta/src/components/Layout/SidebarNav/SidebarNav.tsx
@@ -31,7 +31,7 @@ export default function SidebarNav({
 
   return (
     <div className={cn('sticky top-0 lg:bottom-0 lg:h-screen flex flex-col')}>
-      <div className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
+      <div className="overflow-y-overlay no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
         <aside
           className={cn(
             `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-xs z-10 hidden lg:block`

--- a/beta/src/components/Layout/TopNav/TopNav.tsx
+++ b/beta/src/components/Layout/TopNav/TopNav.tsx
@@ -290,7 +290,7 @@ export default function TopNav({
         {isOpen && (
           <div
             ref={scrollParentRef}
-            className="overflow-y-scroll no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
+            className="overflow-y-overlay no-bg-scrollbar lg:w-[342px] grow bg-wash dark:bg-wash-dark">
             <aside
               className={cn(
                 `lg:grow lg:flex flex-col w-full pb-8 lg:pb-0 lg:max-w-xs z-50`,
@@ -302,7 +302,7 @@ export default function TopNav({
                 className="w-full lg:h-auto grow pr-0 lg:pr-5 pt-4 lg:py-6 md:pt-4 lg:pt-4 scrolling-touch scrolling-gpu">
                 {/* No fallback UI so need to be careful not to suspend directly inside. */}
                 <Suspense fallback={null}>
-                  <div className="pl-3 xs:px-5 xs:gap-0.5 xs:text-base flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
+                  <div className="px-5 sm:pl-3 sm:pr-0 xs:gap-0.5 xs:text-base flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
                     <NavItem isActive={section === 'learn'} url="/learn">
                       Learn
                     </NavItem>
@@ -322,7 +322,7 @@ export default function TopNav({
                   </div>
                   <div
                     role="separator"
-                    className="ml-5 xs:mx-5 mt-4 mb-2 border-b border-border dark:border-border-dark"
+                    className="mx-5 sm:mr-0 mt-4 mb-2 border-b border-border dark:border-border-dark"
                   />
                   <SidebarRouteTree
                     // Don't share state between the desktop and mobile versions.

--- a/beta/src/components/Layout/TopNav/TopNav.tsx
+++ b/beta/src/components/Layout/TopNav/TopNav.tsx
@@ -302,7 +302,7 @@ export default function TopNav({
                 className="w-full lg:h-auto grow pr-0 lg:pr-5 pt-4 lg:py-6 md:pt-4 lg:pt-4 scrolling-touch scrolling-gpu">
                 {/* No fallback UI so need to be careful not to suspend directly inside. */}
                 <Suspense fallback={null}>
-                  <div className="px-5 sm:pl-3 sm:pr-0 xs:gap-0.5 xs:text-base flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
+                  <div className="px-5 lg:pl-3 lg:pr-0 xs:gap-0.5 xs:text-base flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
                     <NavItem isActive={section === 'learn'} url="/learn">
                       Learn
                     </NavItem>
@@ -322,7 +322,7 @@ export default function TopNav({
                   </div>
                   <div
                     role="separator"
-                    className="mx-5 sm:mr-0 mt-4 mb-2 border-b border-border dark:border-border-dark"
+                    className="mx-5 lg:mr-0 mt-4 mb-2 border-b border-border dark:border-border-dark"
                   />
                   <SidebarRouteTree
                     // Don't share state between the desktop and mobile versions.

--- a/beta/src/components/Layout/TopNav/TopNav.tsx
+++ b/beta/src/components/Layout/TopNav/TopNav.tsx
@@ -302,7 +302,7 @@ export default function TopNav({
                 className="w-full lg:h-auto grow pr-0 lg:pr-5 pt-4 lg:py-6 md:pt-4 lg:pt-4 scrolling-touch scrolling-gpu">
                 {/* No fallback UI so need to be careful not to suspend directly inside. */}
                 <Suspense fallback={null}>
-                  <div className="pl-3 xs:pl-5 xs:gap-0.5 xs:text-base overflow-x-scroll flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
+                  <div className="pl-3 xs:px-5 xs:gap-0.5 xs:text-base flex flex-row lg:hidden text-base font-bold text-secondary dark:text-secondary-dark">
                     <NavItem isActive={section === 'learn'} url="/learn">
                       Learn
                     </NavItem>
@@ -322,7 +322,7 @@ export default function TopNav({
                   </div>
                   <div
                     role="separator"
-                    className="ml-5 mt-4 mb-2 border-b border-border dark:border-border-dark"
+                    className="ml-5 xs:mx-5 mt-4 mb-2 border-b border-border dark:border-border-dark"
                   />
                   <SidebarRouteTree
                     // Don't share state between the desktop and mobile versions.

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -224,6 +224,16 @@
   html.dark .no-bg-scrollbar::-webkit-scrollbar-thumb:active {
     background-color: rgba(255, 255, 255, 0.35) !important;
   }
+
+  /*
+  * 'overlay' is a deprecated value, but works with the .no-bg-scrollbar solution
+  * so the scrollbar width doesn't offset the containing element's width.
+  * We can go back to using 'scroll' when .no-bg-scrollbar is no longer needed.
+  */
+  html .overflow-y-overlay {
+    overflow-y: scroll; /* For Firefox. */
+    overflow-y: overlay; /* For WebKit-based browsers. */
+  }
 }
 
 .code-step * {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

This fixes the following issue: https://github.com/reactjs/reactjs.org/issues/5725
`::-webkit-scrollbar` offsets its containing element's width in browsers that support it.
This PR overlays the scrollbar so the containing element's width is not affected (and adds the appropriate padding/margin to even out the spacing in mobile).

Chrome (before):
<img width="1624" alt="Screenshot 2023-03-19 at 12 33 04 am" src="https://user-images.githubusercontent.com/18243433/226109684-d2389573-82c3-4cb9-a75c-0cc6182813d7.png">

Chrome (after):
<img width="1624" alt="Screenshot 2023-03-19 at 12 33 15 am" src="https://user-images.githubusercontent.com/18243433/226109693-5c1106f0-6d54-41ad-911b-08c915cc829a.png">

Firefox (before):
<img width="1624" alt="Screenshot 2023-03-19 at 12 32 24 am" src="https://user-images.githubusercontent.com/18243433/226109700-6cd686ee-b2f0-4d2a-8d9d-edd58b737bc5.png">

Firefox (after):
<img width="1624" alt="Screenshot 2023-03-19 at 12 32 27 am" src="https://user-images.githubusercontent.com/18243433/226109712-89a649a9-7d35-49bb-a15c-ca639a4b78d4.png">

