### PR TITLE
Display ctrl key in search bar for non-mac browsers

### DIFF
--- a/beta/src/components/Search.tsx
+++ b/beta/src/components/Search.tsx
@@ -30,11 +30,14 @@ function Hit({hit, children}: any) {
   );
 }
 
-function Kbd(props: {children?: React.ReactNode}) {
+function Kbd(props: {children?: React.ReactNode; wide?: boolean}) {
+  const {wide, ...rest} = props;
+  const width = wide ? 'w-10' : 'w-5';
+
   return (
     <kbd
-      className="h-5 w-5 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center text-xs text-center rounded-md"
-      {...props}
+      className={`${width} h-5 border border-transparent mr-1 bg-wash dark:bg-wash-dark text-gray-30 align-middle p-0 inline-flex justify-center items-center text-xs text-center rounded-md`}
+      {...rest}
     />
   );
 }
@@ -168,7 +171,10 @@ export function Search({
         <IconSearch className="mr-3 align-middle text-gray-30 shrink-0 group-betterhover:hover:text-gray-70" />
         Search
         <span className="ml-auto hidden sm:flex item-center mr-1">
-          <Kbd>⌘</Kbd>
+          <Kbd data-platform="mac">⌘</Kbd>
+          <Kbd data-platform="win" wide>
+            Ctrl
+          </Kbd>
           <Kbd>K</Kbd>
         </span>
       </button>

--- a/beta/src/pages/_document.tsx
+++ b/beta/src/pages/_document.tsx
@@ -50,7 +50,8 @@ const MyDocument = () => {
                     }
                   });
 
-                  // Detect whether the browser is Mac to display either the ⌘ symbol or Ctrl in the search bar
+                  // Detect whether the browser is Mac to display platform specific content
+                  // An example of such content can be the keyboard shortcut displayed in the search bar
                   document.documentElement.classList.add(
                       window.navigator.platform.includes('Mac')
                       ? "platform-mac" 

--- a/beta/src/pages/_document.tsx
+++ b/beta/src/pages/_document.tsx
@@ -49,6 +49,13 @@ const MyDocument = () => {
                       setTheme(e.matches ? 'dark' : 'light');
                     }
                   });
+
+                  // Detect whether the browser is Mac to display either the ⌘ symbol or Ctrl in the search bar
+                  document.documentElement.classList.add(
+                      window.navigator.platform.includes('Mac')
+                      ? "platform-mac" 
+                      : "platform-win"
+                  );
                 })();
               `,
           }}

--- a/beta/src/styles/index.css
+++ b/beta/src/styles/index.css
@@ -97,6 +97,15 @@
     display: none;
   }
 
+  /* Hide all content that's relevant only to a specific platform */
+  html.platform-mac [data-platform='win'] {
+    display: none;
+  }
+
+  html.platform-win [data-platform='mac'] {
+    display: none;
+  }
+
   html,
   body {
     padding: 0;


### PR DESCRIPTION
PR related to https://github.com/reactjs/reactjs.org/pull/5202

Replaces the keyboard shortcut displayed within the search bar with `Ctrl K` on non-Mac platforms. 

Search bar shortcut displayed on Mac:
![image](https://user-images.githubusercontent.com/14146321/226123668-b948456f-7a09-4bcb-853b-b5fbe2b8f239.png)


Search bar shortcut displayed on Windows and Linux:
![image](https://user-images.githubusercontent.com/14146321/226123626-4fbb9fe2-052e-4293-8a6b-a4851137cb2e.png)
