### PR TITLE
fix: horizontal sidebar in sandpack

### DIFF
--- a/src/styles/sandpack.css
+++ b/src/styles/sandpack.css
@@ -199,21 +199,11 @@ html.dark .sp-wrapper {
   background: var(--sp-colors-surface1);
 }
 
-.sandpack .sp-code-editor .cm-editor,
-.sandpack .sp-code-editor .cm-editor .cm-gutters {
-  background-color: transparent;
-}
-
 .sandpack .sp-code-editor .cm-content,
 .sandpack .sp-code-editor .cm-gutters,
 .sandpack .sp-code-editor .cm-gutterElement {
   padding: 0;
   -webkit-font-smoothing: auto; /* Improve the legibility */
-}
-
-.sandpack .sp-code-editor .cm-content {
-  overflow-x: auto;
-  padding-bottom: 18px;
 }
 
 .sandpack--playground .sp-code-editor .cm-line {
@@ -262,9 +252,9 @@ html.dark .sp-wrapper {
 }
 
 .sp-code-editor .sp-cm .cm-scroller {
-  overflow-x: hidden;
+  overflow-x: auto;
   overflow-y: auto;
-  padding-top: 18px;
+  padding: 18px 0;
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Issue number: [#5749](https://github.com/reactjs/react.dev/issues/5749)

Fixed the horizontal scrollbar in code snippets. Also had to remove the transparency from the gutters and the editor since they create a problem with the horizontal scrolling. Since webkit doesn't have scrollbar position properties the previous scrollbar wasn't going to work. If this is still an issue and we need transparency in editor then we can instead pass wrapContent prop to the SandpackCodeEditor component.

Old
![old](https://user-images.githubusercontent.com/101188157/226648407-ecc36c3b-8599-4ede-bd85-15596cfe8211.png)

New
![new](https://user-images.githubusercontent.com/101188157/226648447-49848672-cf0e-4753-8bc0-5fdaf696ee0c.png)
