### PR TITLE
fix: remove unused useState

### DIFF
--- a/src/content/reference/react/useEffect.md
+++ b/src/content/reference/react/useEffect.md
@@ -670,7 +670,7 @@ export default function App() {
 ```
 
 ```js useWindowListener.js
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export function useWindowListener(eventType, listener) {
   useEffect(() => {


### PR DESCRIPTION
Removed unused useState.
![useEffect – React](https://user-images.githubusercontent.com/71954454/227889549-c7b8c30a-7e1e-4ab6-bac8-cafd6a8ed862.png)
ref: https://react.dev/reference/react/useEffect#examples-custom-hooks