### PR TITLE
Important note about `set` functions missing from new `useState` docs #5950

### DIFF
--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -70,7 +70,7 @@ function handleClick() {
 
 <Note>
 
-React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list.
+React guarantees that `setState` function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the `useEffect` or `useCallback` dependency list.
 
 </Note>
 


### PR DESCRIPTION
Added the note that `setState` wont change on re-renders.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

closes issue number #5950 
