### PR TITLE
Remove unnecessary prop in ContactList component

### DIFF
--- a/src/content/learn/managing-state.md
+++ b/src/content/learn/managing-state.md
@@ -319,7 +319,6 @@ export default function Messenger() {
     <div>
       <ContactList
         contacts={contacts}
-        selectedContact={to}
         onSelect={contact => setTo(contact)}
       />
       <Chat contact={to} />
@@ -336,7 +335,6 @@ const contacts = [
 
 ```js src/ContactList.js
 export default function ContactList({
-  selectedContact,
   contacts,
   onSelect
 }) {
@@ -414,7 +412,6 @@ export default function Messenger() {
     <div>
       <ContactList
         contacts={contacts}
-        selectedContact={to}
         onSelect={contact => setTo(contact)}
       />
       <Chat key={to.email} contact={to} />
@@ -431,7 +428,6 @@ const contacts = [
 
 ```js src/ContactList.js
 export default function ContactList({
-  selectedContact,
   contacts,
   onSelect
 }) {

--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -1036,7 +1036,6 @@ export default function Messenger() {
     <div>
       <ContactList
         contacts={contacts}
-        selectedContact={to}
         onSelect={contact => setTo(contact)}
       />
       <Chat contact={to} />
@@ -1053,7 +1052,6 @@ const contacts = [
 
 ```js src/ContactList.js
 export default function ContactList({
-  selectedContact,
   contacts,
   onSelect
 }) {
@@ -1141,7 +1139,6 @@ export default function Messenger() {
     <div>
       <ContactList
         contacts={contacts}
-        selectedContact={to}
         onSelect={contact => setTo(contact)}
       />
       <Chat key={to.id} contact={to} />
@@ -1158,7 +1155,6 @@ const contacts = [
 
 ```js src/ContactList.js
 export default function ContactList({
-  selectedContact,
   contacts,
   onSelect
 }) {


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below
-->
This PR removes an unused prop passed to the `ContactList` component, used in the examples for Preserving and Resetting state. 

- [x] Component still renders. When selecting a different contact, the message gets reset, as intended.

![image](https://github.com/reactjs/react.dev/assets/22248849/e76114b9-a9b5-436b-88a6-f0fe17180a18)



