### PR TITLE
Fix/typo em dash spacing

### DIFF
--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -403,7 +403,7 @@ function LanguageList({progress}: {progress: TranslationProgress}) {
             <Link href={`https://${code}.react.dev/`}>
               {enName} ({name})
             </Link>{' '}
-            &mdash;{' '}
+            &ndash;{' '}
             <Link href={`https://github.com/reactjs/${code}.react.dev`}>
               Contribute
             </Link>

--- a/src/content/community/translations.md
+++ b/src/content/community/translations.md
@@ -12,7 +12,7 @@ React docs are translated by the global community into many languages all over t
 
 All translations are provided from the canonical source docs:
 
-- [English](https://react.dev/) &mdash; [Contribute](https://github.com/reactjs/react.dev/)
+- [English](https://react.dev/) &ndash; [Contribute](https://github.com/reactjs/react.dev/)
 
 ## Full translations {/*full-translations*/}
 

--- a/src/content/reference/rules/react-calls-components-and-hooks.md
+++ b/src/content/reference/rules/react-calls-components-and-hooks.md
@@ -97,5 +97,5 @@ function useDataWithLogging() {
 }
 ```
 
-This way, `<Button />` is much easier to understand and debug. When Hooks are used in dynamic ways, it increases the complexity of your app greatly and inhibits local reasoning, making your team less productive in the long term. It also makes it easier to accidentally break the [Rules of Hooks](/reference/rules/rules-of-hooks) that Hooks should not be called conditionally. If you find yourself needing to mock components for tests, it's better to mock the server instead to respond with canned data. If possible, it's also usually more effective to test your app with end-to-end tests.
-
+This way, `<Button />` is much easier to understand and debug. When Hooks are used in dynamic ways, it increases the complexity of your app greatly and inhibits local reasoning, making your team less productive in the long term. It also makes it easier to accidentally break the [Rules of Hooks](/reference/rules/rules-of-hooks) that Hooks should not be called conditionally.
+If you find yourself needing to mock components for tests, it's better to mock the server instead to respond with canned data. If possible, it's also usually more effective to test your app with end-to-end tests. In other words, When testing your React applications, prefer mocking [`Here Mocking is a testing technique.`] the server to simulate data responses rather than mocking individual components. This approach simplifies your tests, improves coverage and maintains the integrity of your application's behavior.


### PR DESCRIPTION
fixes: #6699

```
Let's make it consistent (and correct) by removing the spaces.
````

instead of removing spaces.. changing &mdash to &ndash

i think it looks much better:

![image](https://github.com/reactjs/react.dev/assets/103230903/5e68edb5-6c93-4a75-aa9b-09840dcdff5b)