### PR TITLE
doc: fix typo

### DIFF
--- a/src/content/reference/react/createContext.md
+++ b/src/content/reference/react/createContext.md
@@ -84,7 +84,7 @@ function Button() {
 }
 ```
 
-Although this older way still works, but **newly written code should read context with [`useContext()`](/reference/react/useContext) instead:**
+Although this older way still works, **newly written code should read context with [`useContext()`](/reference/react/useContext) instead:**
 
 ```js
 function Button() {


### PR DESCRIPTION
This fixes a minor typo in the createContext documentation. Alternatively, the sentence could be changed to:

> This older way still works, but **newly written code should read context with [`useContext()`](/reference/react/useContext) instead:
