### PR TITLE
Update `your-first-component.md`: Show example rendered output as `<img>` instead of `<img />`

### DIFF
--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -164,9 +164,9 @@ And `Profile` contains even more HTML: `<img />`. In the end, this is what the b
 ```html
 <section>
   <h1>Amazing scientists</h1>
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
+  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson">
+  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson">
+  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson">
 </section>
 ```
 


### PR DESCRIPTION
In HTML, `img` elements are void elements that don't have an end tag and are not self-closing. This is what you would see if you opened the DOM in any modern browser; this PR updates the [**Using a component → What the browser sees**](https://react.dev/learn/your-first-component#what-the-browser-sees) section of the docs to more accurately reflect this.

Also, in other parts of the docs, e.g. at [**Writing Markup with JSX → Converting HTML to JSX**](https://react.dev/learn/writing-markup-with-jsx#converting-html-to-jsx), the `img` tag is correctly written:
```html
<img 
  src="https://i.imgur.com/yXOvdOSs.jpg" 
  alt="Hedy Lamarr" 
  class="photo"
>
```
And an explanation is even given later on, though it's inaccurate since HTML technically does not have close-closing tags (I'll get another PR up to update that we well):
> JSX requires tags to be explicitly closed: self-closing tags like `<img>` must become `<img />` [...]
____
_**Aside (interesting read 😁):** [The case against self-closing tags in HTML](https://jakearchibald.com/2023/against-self-closing-tags-in-html/) by Jake Archibald (06 July 2023)_