### PR TITLE
Documentation: Clarifying described behavior for ref callbacks

### DIFF
--- a/src/content/reference/react-dom/components/common.md
+++ b/src/content/reference/react-dom/components/common.md
@@ -259,7 +259,13 @@ Instead of a ref object (like the one returned by [`useRef`](/reference/react/us
 
 When the `<div>` DOM node is added to the screen, React will call your `ref` callback with the DOM `node` as the argument. When that `<div>` DOM node is removed, React will call your the cleanup function returned from the callback.
 
-React will also call your `ref` callback whenever you pass a *different* `ref` callback. In the above example, `(node) => { ... }` is a different function on every render. When your component re-renders, the *previous* function will be called with `null` as the argument, and the *next* function will be called with the DOM node.
+React will also call your `ref` callback whenever you pass a *different* `ref` callback. In the above example, `(node) => { ... }` is a different function on every render. When your component re-renders, React will call the cleanup function returned by the *previous* callback (if any), and then call the *next* function with the DOM node.
+
+<Note>
+
+If your ref callback doesn't return a cleanup function, React will call the previous callback with `null` as the argument for legacy compatibility.
+
+</Note>
 
 #### Parameters {/*ref-callback-parameters*/}
 


### PR DESCRIPTION
**Existing Issue:**[ #7811](https://github.com/reactjs/react.dev/issues/7811)

**Page**
[Common components](https://react.dev/reference/react-dom/components/common#ref-callback)

**Changes**
_Old_
<img width="1440" alt="Screenshot 2025-06-03 at 5 28 34 PM" src="https://github.com/user-attachments/assets/d332907d-7f7c-408d-a7de-575f62c5e6bb" />

_New_
<img width="1427" alt="Screenshot 2025-06-03 at 5 22 18 PM" src="https://github.com/user-attachments/assets/ad040c2d-fae2-4ba7-b07b-84729b7b0bf0" />

These changes:
1. Emphasize the modern cleanup pattern (which matches the code example)
2. Clarify that cleanup functions are called instead of passing null
3. Note the legacy behavior as secondary information