### PR TITLE
docs: clarify React Compiler 🧠 emoji usage in React Dev Tools

### DIFF
--- a/src/content/learn/react-compiler.md
+++ b/src/content/learn/react-compiler.md
@@ -353,5 +353,3 @@ When you make the error go away, confirm that removing the opt out directive mak
 ### Other issues {/*other-issues*/}
 
 Please see https://github.com/reactwg/react-compiler/discussions/7.
-
-


### PR DESCRIPTION
React Dev Tools displays a brain (🧠) emoji when highlighting 3rd party library components (not explicitly developed in a user's codebase, but imported from another one and used in that user's codebase) that have been explicitly wrapped in a `memo()` callback. There is currently no explanation of what this emoji does. I've taken the time to read the RC source code and noticed that this is how the brain emoji is used.