### PR TITLE
Fix runtime error in a broken clock challenge caused by missing element check

### DIFF
--- a/src/content/learn/keeping-components-pure.md
+++ b/src/content/learn/keeping-components-pure.md
@@ -246,11 +246,12 @@ Rendering is a *calculation*, it shouldn't try to "do" things. Can you express t
 ```js src/Clock.js active
 export default function Clock({ time }) {
   const hours = time.getHours();
-  if (hours >= 0 && hours <= 6) {
-    document.getElementById('time').className = 'night';
-  } else {
-    document.getElementById('time').className = 'day';
+  const timeElement = document.getElementById('time');
+
+  if (timeElement) {
+    timeElement.className = hours >= 0 && hours <= 6 ? 'night' : 'day';
   }
+
   return (
     <h1 id="time">
       {time.toLocaleTimeString()}


### PR DESCRIPTION
### **What’s the issue?**
The Clock challenge component throws a runtime error because it tries to set the className on an element that does not yet exist in the DOM. Specifically, document.getElementById('time') returns null during the initial render, causing this error:

<img width="1066" height="467" alt="image" src="https://github.com/user-attachments/assets/92a68f3e-87b2-44c7-9d7e-98e739088906" />

_This PR adds a simple existence check before accessing the element’s className, preventing the runtime error while preserving the original logic_