### PR TITLE
Update .gitignore to include claude related artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ public/fonts/**/Optimistic_*.woff2
 
 # rss
 public/rss.xml
+
+# ai
+.claude
+CLAUDE.md


### PR DESCRIPTION

I am trying out Claude for writing docs and to do so effectively it needs to create some markdown files and other local settings. I would like to start filtering out these artifacts in our .gitignore settings as AI usage becomes more commonplace for contributing.

Optionally we could also commit the [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices) file to aid other developers contributing with the assistance of AI to help improve the quality of any PRs. But I'm omitting that for now since I think that may be contentious.
