### PR TITLE
Remove non-existent meetup group (Edinburgh, Scotland)

### DIFF
--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -137,9 +137,6 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 ## Portugal {/*portugal*/}
 * [Lisbon](https://www.meetup.com/JavaScript-Lisbon/)
 
-## Scotland (UK) {/*scotland-uk*/}
-* [Edinburgh](https://www.meetup.com/React-Scotland/)
-
 ## Spain {/*spain*/}
 * [Barcelona](https://www.meetup.com/ReactJS-Barcelona/)
 


### PR DESCRIPTION
The Edinburgh meetup group no longer exists, and I have been unable to find any other Scottish React groups
