### PR TITLE
[Typo]: Update "two caveats" to "three caveats" in Style precedence section

### DIFF
--- a/src/content/reference/react-dom/components/style.md
+++ b/src/content/reference/react-dom/components/style.md
@@ -49,7 +49,7 @@ React can move `<style>` components to the document's `<head>`, de-duplicate ide
 
 To opt into this behavior, provide the `href` and `precedence` props. React will de-duplicate styles if they have the same `href`. The precedence prop tells React where to rank the `<style>` DOM node relative to others in the document `<head>`, which determines which stylesheet can override the other.
 
-This special treatment comes with two caveats:
+This special treatment comes with three caveats:
 
 * React will ignore changes to props after the style has been rendered. (React will issue a warning in development if this happens.)
 * React will drop all extraneous props when using the `precedence` prop (beyond `href` and `precedence`).


### PR DESCRIPTION

<img width="900" height="201" alt="image" src="https://github.com/user-attachments/assets/67ce8384-ddd3-4bb3-b1df-dc99b3b2e4b5" />


### Summary
The documentation currently states:

> This special treatment comes with two caveats:

But there are actually three caveats listed:

1. React will ignore changes to props after the style has been rendered.  
2. React will drop all extraneous props when using the precedence prop (beyond href and precedence).  
3. React may leave the style in the DOM even after the component that rendered it has been unmounted.  

This PR updates "two caveats" → "three caveats" to match the actual number of listed caveats.

### Page
https://react.dev/reference/react-dom/components/style#special-rendering-behavior

### Notes
- This is a small typo fix in the documentation.
- No code changes included.