### PR TITLE
docs: fix StrictMode cat scrolling example

### DIFF
--- a/src/content/reference/react/StrictMode.md
+++ b/src/content/reference/react/StrictMode.md
@@ -1170,7 +1170,7 @@ export default function CatFriends() {
                   console.log('❌ Too many cats in the list!');
                 }
                 return () => {
-                  list.splice(list.indexOf(item));
+                  list.splice(list.indexOf(item), 1);
                   console.log(`❌ Removing cat from the map. Total cats: ${itemsRef.current.length}`);
                 }
               }}


### PR DESCRIPTION
### Steps to Reproduce

In the correct example in [StrictMode](./src/content/reference/react/StrictMode.md) _Fixing bugs found by re-running ref callbacks in development_ section, click on Millie to change cats, then click any number that is not 0.

### Expected

Should scroll to relevant `<li>`.

### Actual

Runtime error :crying_cat_face: 