### PR TITLE
docs: Update hooks link to /reference/react/hooks in /reference/react/api

### DIFF
--- a/src/content/reference/react/apis.md
+++ b/src/content/reference/react/apis.md
@@ -4,7 +4,7 @@ title: "Built-in React APIs"
 
 <Intro>
 
-In addition to [Hooks](/reference/react) and [Components](/reference/react/components), the `react` package exports a few other APIs that are useful for defining components. This page lists all the remaining modern React APIs.
+In addition to [Hooks](/reference/react/hooks) and [Components](/reference/react/components), the `react` package exports a few other APIs that are useful for defining components. This page lists all the remaining modern React APIs.
 
 </Intro>
 


### PR DESCRIPTION

Because components link to /reference/react/components, I think hooks should link to /reference/react/hooks.
<img width="884" height="330" alt="image" src="https://github.com/user-attachments/assets/8ccf4ad3-3f67-405f-966f-9528b805f696" />




<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
