### PR TITLE
clarify SRP definition

### DIFF
--- a/src/content/learn/thinking-in-react.md
+++ b/src/content/learn/thinking-in-react.md
@@ -37,7 +37,7 @@ Start by drawing boxes around every component and subcomponent in the mockup and
 
 Depending on your background, you can think about splitting up a design into components in different ways:
 
-* **Programming**--use the same techniques for deciding if you should create a new function or object. One such technique is the [single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle), that is, a component should ideally only have one reason to change. If it ends up growing, it should be decomposed into smaller subcomponents. 
+* **Programming**--use the same techniques for deciding if you should create a new function or object. One such technique is the [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns), that is, a component should ideally only be concerned with one thing. If it ends up growing, it should be decomposed into smaller subcomponents. 
 * **CSS**--consider what you would make class selectors for. (However, components are a bit less granular.)
 * **Design**--consider how you would organize the design's layers.
 


### PR DESCRIPTION
The SRP states that a "module should have one and only one reason to change", which differs from only doing one thing.
Uncle Bob explains this difference in _Clean Architecture_ and mentions that it is a common mistake due to the principle not being properly named.

> Of all the SOLID principles, the Single Responsibility Principle (SRP) might
> be the least well understood. That’s likely because it has a particularly
> inappropriate name. It is too easy for programmers to hear the name and
> then assume that it means that every module should do just one thing.

https://blog.cleancoder.com/uncle-bob/2014/05/08/SingleReponsibilityPrinciple.html