### PR TITLE
docs: Update head change to <head> in /reference/react-dom/components/index.md

### DIFF
--- a/src/content/reference/react-dom/components/index.md
+++ b/src/content/reference/react-dom/components/index.md
@@ -42,7 +42,7 @@ These built-in browser components let you load external resources or annotate th
 * [`<style>`](/reference/react-dom/components/style)
 * [`<title>`](/reference/react-dom/components/title)
 
-They are special in React because React can render them into the document head, suspend while resources are loading, and enact other behaviors that are described on the reference page for each specific component.
+They are special in React because React can render them into the document `<head>`, suspend while resources are loading, and enact other behaviors that are described on the reference page for each specific component.
 
 ---
 


### PR DESCRIPTION
[change here](https://react.dev/reference/react-dom/components#resource-and-metadata-components)

I think this provides more clarity:

## before 
They are special in React because React can render them into the document head,

## after
They are special in React because React can render them into the document `<head>`,

## becase
<img width="912" height="227" alt="image" src="https://github.com/user-attachments/assets/e08abf15-d47b-4e4d-8bbd-5c29a16de222" />

this into `<head>`

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
