### PR TITLE
docs: migrate ReactDOM.render to createRoot for React 18+

### DIFF
--- a/public/html/single-file-example.html
+++ b/public/html/single-file-example.html
@@ -11,14 +11,12 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="text/babel">
-
-      ReactDOM.render(
-        <h1>Hello, world!</h1>,
-        document.getElementById('root')
-      );
-
-    </script>
+    <script type="text/javascript">
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(
+    <h1>Hello, world!</h1>
+  );
+</script>
     <!--
       Note: this page is a great way to try React but it's not suitable for production.
       It slowly compiles JSX with Babel in the browser and uses a large development build of React.


### PR DESCRIPTION
This PR updates the example in `single-file-example.html` to use React 18+ `createRoot` API instead of the deprecated `ReactDOM.render`. 

- Replaced:
  ReactDOM.render(<h1>Hello, world!</h1>, document.getElementById('root'));
- With:
  const root = ReactDOM.createRoot(document.getElementById('root'));
  root.render(<h1>Hello, world!</h1>);

This ensures compatibility with React 18 and follows current best practices.
