### PR TITLE
Conditionally deriving state is allowed

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/lints/set-state-in-render.md
+++ b/src/content/reference/eslint-plugin-react-hooks/lints/set-state-in-render.md
@@ -5,7 +5,7 @@ version: rc
 
 <Intro>
 
-Validates against setting state during render, which can trigger additional renders and potential infinite render loops.
+Validates against unconditionally setting state during render, which can trigger additional renders and potential infinite render loops.
 
 </Intro>
 
@@ -19,14 +19,14 @@ You can try it by upgrading the lint plugin [to the most recent RC version](/lea
 
 ## Rule Details {/*rule-details*/}
 
-Calling `setState` during render triggers another render before the current one finishes. This creates an infinite loop that crashes your app.
+Calling `setState` during render unconditionally triggers another render before the current one finishes. This creates an infinite loop that crashes your app.
 
 ## Common Violations {/*common-violations*/}
 
 ### Invalid {/*invalid*/}
 
 ```js {expectedErrors: {'react-compiler': [4]}}
-// ❌ setState directly in render
+// ❌ Unconditional setState directly in render
 function Component({value}) {
   const [count, setCount] = useState(0);
   setCount(value); // Infinite loop!
@@ -58,6 +58,19 @@ function Component({user}) {
   const name = user?.name || '';
   const email = user?.email || '';
   return <div>{name}</div>;
+}
+
+// ✅ Conditionally derive state from props and state from previous renders
+function Component({ items }) {
+  const [isReverse, setIsReverse] = useState(false);
+  const [selection, setSelection] = useState(null);
+
+  const [prevItems, setPrevItems] = useState(items);
+  if (items !== prevItems) { // This condition makes it valid
+    setPrevItems(items);
+    setSelection(null);
+  }
+  // ...
 }
 ```
 
@@ -102,3 +115,5 @@ function Counter({max}) {
 ```
 
 Now the setter only runs in response to the click, React finishes the render normally, and `count` never crosses `max`.
+
+In rare cases, you may need to adjust state based on information from previous renders. For those, follow [this pattern](https://react.dev/reference/react/useState#storing-information-from-previous-renders) of setting state conditionally.


### PR DESCRIPTION
These docs are misleading. We [do have an official API](https://react.dev/reference/react/useState#storing-information-from-previous-renders) that relies on setting state in render. If we don't like it, we should come up with a more first-class API for this occasionally legit pattern. But the API is legit and supported.

This clarifies the docs to resolve the contradiction. Only unconditional setState in render is definitely disallowed. Conditional is more nuanced, as noted.