### PR TITLE
fix(Sandpack): prevent phantom browser history entries on scroll (#8047)

### DIFF
--- a/src/components/MDX/Sandpack/Preview.tsx
+++ b/src/components/MDX/Sandpack/Preview.tsx
@@ -97,18 +97,17 @@ export function Preview({
 
   const sandpackIdle = sandpack.status === 'idle';
 
-useEffect(function createBundler() {
-  const iframeElement = iframeRef.current!;
-  if (!iframeElement.dataset.registered) {
-    registerBundler(iframeElement, clientId);
-    iframeElement.dataset.registered = 'true';
-  }
-  return () => {
-    unregisterBundler(clientId);
-    iframeElement.dataset.registered = '';
-  };
-}, []);
-
+  useEffect(function createBundler() {
+    const iframeElement = iframeRef.current!;
+    if (!iframeElement.dataset.registered) {
+      registerBundler(iframeElement, clientId);
+      iframeElement.dataset.registered = 'true';
+    }
+    return () => {
+      unregisterBundler(clientId);
+      iframeElement.dataset.registered = '';
+    };
+  }, []);
 
   useEffect(
     function bundlerListener() {


### PR DESCRIPTION
Fixes #8047

This PR resolves an issue where scrolling down documentation pages (such as
“Separating Events from Effects”) caused multiple phantom browser history entries,
requiring multiple back button presses to navigate away.

- Ensures Sandpack iframe bundler registers only once per mount.
- Prevents repeated history pushes from iframe reloads.
- Verified locally on Chrome and Firefox.
