### PR TITLE
Fragment refs - Remove unused ref from focus fragment example

### DIFF
--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -317,8 +317,6 @@ Fragment refs provide focus management methods that work across all DOM nodes wi
 import { Fragment, useRef } from 'react';
 
 function FocusFragment({ children }) {
-  const fragmentRef = useRef(null);
-
   return (
     <Fragment ref={(fragmentInstance) => fragmentInstance?.focus()}>
       {children}


### PR DESCRIPTION
Fragment refs - Remove unused ref from focus fragment example

It looks like a copy/paste typo from the previous code snippet