### PR TITLE
Fix grammatical error in ViewTransition documentation

### DIFF
--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -2124,7 +2124,7 @@ If a `startTransition` is started from the legacy popstate event, such as during
 
 ### My `<ViewTransition>` is not activating {/*my-viewtransition-is-not-activating*/}
 
-`<ViewTransition>` only activates if it is placed is before any DOM node:
+`<ViewTransition>` only activates if it is placed before any DOM node:
 
 ```js [3, 5]
 function Component() {


### PR DESCRIPTION
## What
Fixed a grammatical error in the ViewTransition component documentation.

## Changes
- **Before:** `<ViewTransition> only activates if it is placed is before any DOM node`
- **After:** `<ViewTransition> only activates if it is placed before any DOM node`

## Why
The extra "is" was grammatically incorrect and made the sentence confusing for readers.

This is a simple documentation fix that improves clarity without changing any technical meaning.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
