### PR TITLE
fix: correct example link to minified error on /errors index page

### DIFF
--- a/src/content/errors/index.md
+++ b/src/content/errors/index.md
@@ -7,4 +7,4 @@ In the minified production build of React, we avoid sending down full error mess
 
 We highly recommend using the development build locally when debugging your app since it tracks additional debug info and provides helpful warnings about potential problems in your apps, but if you encounter an exception while using the production build, the error message will include just a link to the docs for the error.
 
-For an example, see: [https://react.dev/errors/149](/errors/421).
+For an example, see: [https://react.dev/errors/149](/errors/149).


### PR DESCRIPTION
This PR corrects a link on the /errors index page. It was pointing to error ID 421 instead of the intended ID 149.