### PR TITLE
Remove ReactConf notes in blogs

### DIFF
--- a/src/content/blog/2024/02/15/react-labs-what-we-have-been-working-on-february-2024.md
+++ b/src/content/blog/2024/02/15/react-labs-what-we-have-been-working-on-february-2024.md
@@ -15,14 +15,6 @@ In React Labs posts, we write about projects in active research and development.
 
 </Intro>
 
-<Note>
-
-React Conf 2024 is scheduled for May 15–16 in Henderson, Nevada! If you’re interested in attending React Conf in person, you can [sign up for the ticket lottery](https://forms.reform.app/bLaLeE/react-conf-2024-ticket-lottery/1aRQLK) until February 28th. 
-
-For more info on tickets, free streaming, sponsoring, and more, see [the React Conf website](https://conf.react.dev).
-
-</Note>
-
 ---
 
 ## React Compiler {/*react-compiler*/}

--- a/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
+++ b/src/content/blog/2025/04/23/react-labs-view-transitions-activity-and-more.md
@@ -16,14 +16,6 @@ In React Labs posts, we write about projects in active research and development.
 </Intro>
 
 
-<Note>
-
-React Conf 2025 is scheduled for October 7–8 in Henderson, Nevada!
-
-Watch the livestream on [the React Conf website](https://conf.react.dev).
-
-</Note>
-
 Today, we're excited to release documentation for two new experimental features that are ready for testing:
 
 - [View Transitions](#view-transitions)
@@ -39,6 +31,14 @@ We're also sharing updates on new features currently in development:
 ---
 
 # New Experimental Features {/*new-experimental-features*/}
+
+<Note>
+
+`<Activity />` has shipped in `react@19.2`.
+
+`<ViewTransition />` and `addTransitionType` are now available in `react@canary`.
+
+</Note>
 
 View Transitions and Activity are now ready for testing in `react@experimental`. These features have been tested in production and are stable, but the final API may still change as we incorporate feedback.
 


### PR DESCRIPTION
These don't make sense any more, the conferences are over.