### PR TITLE
docs: add `<Activity>` bullet to built-in components section

### DIFF
--- a/src/content/reference/react/components.md
+++ b/src/content/reference/react/components.md
@@ -16,6 +16,7 @@ React exposes a few built-in components that you can use in your JSX.
 * [`<Profiler>`](/reference/react/Profiler) lets you measure rendering performance of a React tree programmatically.
 * [`<Suspense>`](/reference/react/Suspense) lets you display a fallback while the child components are loading.
 * [`<StrictMode>`](/reference/react/StrictMode) enables extra development-only checks that help you find bugs early.
+* [`<Activity>`](/reference/react/Activity) lets you hide and restore the UI and internal state of its children.
 
 ---
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
### Overview
Per title. I noticed that `<Activity>` is missing from the [built-in components section](https://react.dev/reference/react/components). This PR adds it. It's worth calling out that `useEffectEvent` is missing from the [built-in hooks page](https://react.dev/reference/react/hooks) too (**update**: added in https://github.com/reactjs/react.dev/pull/8088).
