### PR TITLE
Fix optimization link pointing to legacy docs

### DIFF
--- a/src/content/learn/render-and-commit.md
+++ b/src/content/learn/render-and-commit.md
@@ -142,7 +142,7 @@ Otherwise, you can encounter confusing bugs and unpredictable behavior as your c
 
 #### Optimizing performance {/*optimizing-performance*/}
 
-The default behavior of rendering all components nested within the updated component is not optimal for performance if the updated component is very high in the tree. If you run into a performance issue, there are several opt-in ways to solve it described in the [Performance](https://react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged) section. **Don't optimize prematurely!**
+The default behavior of rendering all components nested within the updated component is not optimal for performance if the updated component is very high in the tree. If you run into a performance issue, there are several opt-in ways to solve it described in the [Performance](/reference/react/memo#skipping-re-rendering-when-props-are-unchanged) section. **Don't optimize prematurely!**
 
 </DeepDive>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fixes #8089 

Before inside the ["Optimizing performance" deep dive](https://react.dev/learn/render-and-commit#optimizing-performance), the link with text "Performance" would send us to the legacy React docs.

<img width="981" height="630" alt="image" src="https://github.com/user-attachments/assets/6fe92728-9ec2-4e5b-baca-639a31374e8a" />


Clicking on "Performance" above would send us here: 

<img width="1027" height="997" alt="image" src="https://github.com/user-attachments/assets/397b237c-5627-430c-a34f-355864a3db43" />


The link on this legacy page for "[memo: Skipping re-rendering when props are unchanged](https://react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged)" points to the new docs.  This is the same link used in this PR.

Now clicking on "Performance" navigates to here:

<img width="1350" height="961" alt="image" src="https://github.com/user-attachments/assets/dce8ebc3-4daa-4461-a7c5-1202e8dfd5d0" />


### Additional Considerations

Despite the old docs linking to https://react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged, this new page is in the Reference section for `memo`.  There doesn't seem to be a comprehensive Learn section for performance.  

The closest I could find is https://react.dev/learn/react-compiler/introduction#optimizing-re-renders, which may be more appropriate considering the React Compiler is now stable.  https://react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged still does mention the React Compiler, though only does so later down.


#### Topics in legacy link that are not covered in the new link

- Using the production build
- Profiling (probably needs an update with the release of the new Profiler Panel)
- Virtualization (mentioning Activity is probably related)


#### Topics not mentioned in either related to reducing the frequency of re-renders

["Lift content up" ](https://overreacted.io/before-you-memo/)


