### PR TITLE
docs: Remove extra double quotes

### DIFF
--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -152,7 +152,7 @@ Don’t forget that dispatching DOM events only works when the DOM container is 
 
 ## Troubleshooting {/*troubleshooting*/}
 
-### I'm getting an error: "The current testing environment is not configured to support act"(...)" {/*error-the-current-testing-environment-is-not-configured-to-support-act*/}
+### I'm getting an error: "The current testing environment is not configured to support act(...)" {/*error-the-current-testing-environment-is-not-configured-to-support-act*/}
 
 Using `act` requires setting `global.IS_REACT_ACT_ENVIRONMENT=true` in your test environment. This is to ensure that `act` is only used in the correct environment.
 


### PR DESCRIPTION
[this link](https://react.dev/reference/react/act#error-the-current-testing-environment-is-not-configured-to-support-act)

<img width="959" height="128" alt="image" src="https://github.com/user-attachments/assets/5da467a9-ad70-4840-9c5b-3423cabe9e69" />


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
