### PR TITLE
Add note on error boundary limitations

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -1275,9 +1275,9 @@ By default, if your application throws an error during rendering, React will rem
 Error boundaries do not catch errors for:
 
 - Event handlers [(learn more)](/learn/responding-to-events)
-- Asynchronous code (e.g. `setTimeout` or `requestAnimationFrame` callbacks)
 - [Server side rendering](/reference/react-dom/server) 
 - Errors thrown in the error boundary itself (rather than its children)
+- Asynchronous code (e.g. `setTimeout` or `requestAnimationFrame` callbacks); an exception is the usage of the [`startTransition`](/reference/react/useTransition#starttransition) function returned by the [`useTransition`](/reference/react/useTransition) Hook. Errors thrown inside the transition function are caught by error boundaries [(learn more)](/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)
 
 </Note>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
Issue #6991 

Adding a note about the limitations of Error Boundaries according to the legacy docs.

<img width="853" height="782" alt="Screenshot 2025-10-29 at 16 31 34" src="https://github.com/user-attachments/assets/3d3dabf1-dec2-4eb6-9255-e26aab3a6e0a" />

