### PR TITLE
Fix incorrect condition in "Chains of computations" example

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -437,7 +437,7 @@ function Game() {
     // ✅ Calculate all the next state in the event handler
     setCard(nextCard);
     if (nextCard.gold) {
-      if (goldCardCount <= 3) {
+      if (goldCardCount < 3) {
         setGoldCardCount(goldCardCount + 1);
       } else {
         setGoldCardCount(0);


### PR DESCRIPTION
Fixes #8097

## Problem

In the "Chains of computations" section, the refactored example uses an incorrect condition that changes the game logic from the original:

```js
// Current (incorrect)
if (goldCardCount <= 3) {
  setGoldCardCount(goldCardCount + 1);
} else {
  // advance round
}
```

This allows **5 gold cards** before advancing the round, which differs from the original Effect-based example that advances after **4 gold cards**.

## Solution

Changed the condition from `<=` to `<`:

```js
// Fixed
if (goldCardCount < 3) {
  setGoldCardCount(goldCardCount + 1);
} else {
  // advance round
}
```

## Why This Fix is Correct

The original "bad" example increments first, then checks:
```js
useEffect(() => {
  setGoldCardCount(c => c + 1);  // 0→1, 1→2, 2→3, 3→4
}, [card]);

useEffect(() => {
  if (goldCardCount > 3) {  // Triggers when count reaches 4
    setRound(r => r + 1);
    setGoldCardCount(0);
  }
}, [goldCardCount]);
```

This advances after 4 cards (when count reaches 4).

The fixed example checks before incrementing:
- With `<= 3`: Allows counts 0,1,2,3 to increment → 4 values → advances on 5th card ❌
- With `< 3`: Allows counts 0,1,2 to increment → 3 values → advances on 4th card ✅

## Testing

Verified the fix by:
1. Tracing execution logic step-by-step
2. Building the docs site locally and confirming correct rendering
3. Checking that only the intended line was modified

## Changes

- File: `src/content/learn/you-might-not-need-an-effect.md`
- Line: 440
- Change: `goldCardCount <= 3` → `goldCardCount < 3`