### PR TITLE
docs: Fix typo in Oceania childIds array in Choosing State Structure docs

### DIFF
--- a/src/content/learn/choosing-the-state-structure.md
+++ b/src/content/learn/choosing-the-state-structure.md
@@ -1716,7 +1716,7 @@ export const initialTravelPlan = {
   34: {
     id: 34,
     title: 'Oceania',
-    childIds: [35, 36, 37, 38, 39, 40,, 41],   
+    childIds: [35, 36, 37, 38, 39, 40, 41],   
   },
   35: {
     id: 35,


### PR DESCRIPTION
This PR fixes #8111.

Fixes a minor typo in the documentation article "Choosing the State Structure", under the section "Improving memory usage", by removing a double comma in the initialTravelPlan object in places.js.
