### PR TITLE
docs(blog): Add 'React 19.2' to blog sidebar

### DIFF
--- a/src/sidebarBlog.json
+++ b/src/sidebarBlog.json
@@ -33,6 +33,13 @@
           "path": "/blog/2025/10/07/introducing-the-react-foundation"
         },
         {
+          "title": "React 19.2",
+          "titleForHomepage": "React 19.2",
+          "icon": "blog",
+          "date": "October 1, 2025",
+          "path": "/blog/2025/10/01/react-19-2"
+        },
+        {
           "title": "React Labs: View Transitions, Activity, and more",
           "titleForHomepage": "View Transitions and Activity",
           "icon": "blog",


### PR DESCRIPTION
PR Fixes #8095

This PR adds the "React 19.2" blog post entry to `src/sidebarBlog.json`, as it was previously missing.

The entry has been added in the correct chronological (descending) order to ensure it appears in the responsive blog sidebar, as discussed in the issue.

**Added Entry**
```json
    {
      "title": "React 19.2",
      "titleForHomepage": "React 19.2",
      "icon": "blog",
      "date": "October 1, 2025",
      "path": "/blog/2025/10/01/react-19-2"
    }
```
**Result**
<img width="879" height="546" alt="1" src="https://github.com/user-attachments/assets/f9502a2e-c945-445a-a04c-06d2efff4e9e" />


