### PR TITLE
docs: add note about use preference over useContext

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -16,6 +16,14 @@ const value = useContext(SomeContext)
 
 ---
 
+<Note>
+
+[`use`](/reference/react/use) is preferred over `useContext` because it is more flexible. Unlike `useContext`, `use` can be called inside conditionals and loops.
+
+</Note>
+
+---
+
 ## Reference {/*reference*/}
 
 ### `useContext(SomeContext)` {/*usecontext*/}


### PR DESCRIPTION
## Summary

Adds a note to the `useContext` documentation page informing developers that `use` is preferred over `useContext` because it is more flexible.

## Details

This change addresses issue #7723 by adding a prominent note at the beginning of the `useContext` reference page, similar to what is already mentioned in the `use` documentation.

The note explains that:
- `use` is preferred over `useContext`
- `use` is more flexible because it can be called inside conditionals and loops
- Includes a link to the `use` API documentation

## Test plan

Documentation change only - no code changes required.

Closes #7723