### PR TITLE
Fix reversed blog navigation links

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -96,8 +96,10 @@ export function Page({
           {!isBlogIndex && (
             <DocsPageFooter
               route={route}
-              nextRoute={nextRoute}
-              prevRoute={prevRoute}
+              // For blog posts, swap prev/next since they're ordered newest->oldest
+              // but "Previous" should go to older posts and "Next" to newer posts
+              nextRoute={section === 'blog' ? prevRoute : nextRoute}
+              prevRoute={section === 'blog' ? nextRoute : prevRoute}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
Fixes the reversed "Previous" and "Next" navigation links on blog posts.

## Problem
- "Previous" was pointing to newer posts
- "Next" was pointing to older posts

This behavior is counter-intuitive for blog navigation, where users expect "Previous" to go to older posts and "Next" to go to newer posts.

## Solution
Swapped `prevRoute` and `nextRoute` specifically for blog posts in the Page component, since blog posts are ordered newest-to-oldest in the route tree.

## Test Plan
- Navigate to any blog post (e.g., https://react.dev/blog/2025/04/23/react-labs-view-transitions-activity-and-more)
- Verify "Previous" now links to an older post
- Verify "Next" now links to a newer post

ISSUE: #7844
