### PR TITLE
docs: add missing 'Static APIs' link to React DOM reference page

### DIFF
--- a/src/content/reference/react/index.md
+++ b/src/content/reference/react/index.md
@@ -28,6 +28,7 @@ React-dom contains features that are only supported for web applications (which 
 * [APIs](/reference/react-dom) - The `react-dom` package contains methods supported only in web applications.
 * [Client APIs](/reference/react-dom/client) - The `react-dom/client` APIs let you render React components on the client (in the browser).
 * [Server APIs](/reference/react-dom/server) - The `react-dom/server` APIs let you render React components to HTML on the server.
+* [Static APIs](/reference/react-dom/static) - The `react-dom/static` APIs let you generate static HTML for React components.
 
 ## React Compiler {/*react-compiler*/}
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
# Fix issue #8126 
[Typo]: Missing Static APIs on the React Overview Page #8126 

## 📝 Description

This PR adds a missing link to the **Static APIs** section under the **React DOM** category on the [React Reference Overview page](https://react.dev/reference/react).

The page [https://react.dev/reference/react-dom/static](https://react.dev/reference/react-dom/static) exists and is accessible directly, but was not discoverable from the reference index, potentially making it harder for users to find the static rendering APIs introduced in React 19.

**✅ Changes**

- Added **Static APIs** entry in the React DOM section of the reference index

**📚 Motivation**
  
Adding this link ensures users can easily find and navigate to the `react-dom/static` section alongside Client and Server APIs.

## 📎 Before
<img width="2217" height="1365" alt="Capture-2025-11-05-090403" src="https://github.com/user-attachments/assets/df3d3170-7971-4b54-932e-5c3f5bbd2413" />

## 📎 After
<img width="2133" height="1464" alt="Capture-after-2025-11-05-092922" src="https://github.com/user-attachments/assets/738dbf67-2294-4352-9d0e-d7e8d0b34515" />

---

## 🙏 Notes

Let me know if this should be placed in a different order, section, or if there are any copy edits needed.
Thanks for maintaining a great developer experience with the docs!