### PR TITLE
fix(learn): Clear form error on new input in City Quiz examples

### DIFF
--- a/src/content/learn/managing-state.md
+++ b/src/content/learn/managing-state.md
@@ -35,6 +35,7 @@ export default function Form() {
   const [answer, setAnswer] = useState('');
   const [error, setError] = useState(null);
   const [status, setStatus] = useState('typing');
+  const showError = status === 'typing' && error && answer === error.failedAnswer;
 
   if (status === 'success') {
     return <h1>That's right!</h1>
@@ -49,6 +50,7 @@ export default function Form() {
     } catch (err) {
       setStatus('typing');
       setError(err);
+      setError({ message: err.message, failedAnswer: answer });
     }
   }
 
@@ -75,7 +77,7 @@ export default function Form() {
         }>
           Submit
         </button>
-        {error !== null &&
+        {showError &&
           <p className="Error">
             {error.message}
           </p>

--- a/src/content/learn/reacting-to-input-with-state.md
+++ b/src/content/learn/reacting-to-input-with-state.md
@@ -57,6 +57,7 @@ async function handleFormSubmit(e) {
 }
 
 function handleTextareaChange() {
+  hide(errorMessage);
   if (textarea.value.length === 0) {
     disable(button);
   } else {
@@ -414,6 +415,7 @@ export default function Form() {
   const [answer, setAnswer] = useState('');
   const [error, setError] = useState(null);
   const [status, setStatus] = useState('typing');
+  const showError = status === 'typing' && error && answer === error.failedAnswer;
 
   if (status === 'success') {
     return <h1>That's right!</h1>
@@ -427,7 +429,7 @@ export default function Form() {
       setStatus('success');
     } catch (err) {
       setStatus('typing');
-      setError(err);
+      setError({ message: err.message, failedAnswer: answer });
     }
   }
 
@@ -454,7 +456,7 @@ export default function Form() {
         }>
           Submit
         </button>
-        {error !== null &&
+        {showError &&
           <p className="Error">
             {error.message}
           </p>


### PR DESCRIPTION
**What is the current behavior?**

In the "City quiz" examples found on both the `learn/managing-state` and `learn/reacting-to-input-with-state` pages, submitting a wrong answer causes an error message to appear. This error message then persists indefinitely, even when the user starts typing a new answer or resubmits the form, creating a confusing user experience.

![Current_behavior](https://github.com/user-attachments/assets/157c3717-ecbe-452d-84b5-7805a701a784)

**What is the new behavior?**

This PR fixes the UX bug in both examples by clearing the `error` state whenever a new user action (`onChange` or `onSubmit`) is initiated. This ensures the UI provides timely and relevant feedback, which better reflects modern form handling best practices.

![new_behavior](https://github.com/user-attachments/assets/c4455caf-462b-4961-addf-099eafc56567)

**How to test:**

1.  Navigate to the "City quiz" example on the `learn/managing-state` page.
2.  Submit an incorrect answer (e.g., "test"). The error message appears.
3.  Start typing a new answer in the text area.
4.  **Expected:** The error message immediately disappears.
5.  Repeat the test on the `learn/reacting-to-input-with-state` page to confirm the fix in both locations.