### PR TITLE
Update act() usage to be async in examples

### DIFF
--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -98,7 +98,7 @@ it('can render and update a counter', async () => {
   document.body.appendChild(container);
   
   // ✅ Render the component inside act().
-  await act(() => {
+  await act(async () => {
     ReactDOMClient.createRoot(container).render(<Counter />);
   });
   
@@ -126,7 +126,7 @@ it.only('can render and update a counter', async () => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   
-  await act( async () => {
+  await act(async () => {
     ReactDOMClient.createRoot(container).render(<Counter />);
   });
   


### PR DESCRIPTION
This 🐣 PR updates the second example on [react.dev/reference/react/act](https://react.dev/reference/react/act) to use an async callback with `act()` + fix an alignment issue with another sample

Although the example currently uses a synchronous callback, the documentation below it explicitly recommends always using the async form:

> **“We recommend using `act` with `await` and an async function.
> Although the sync version works in many cases, it doesn’t work in all cases…
> We will deprecate and remove the sync version in the future.”**

Updating the example to use an async callback makes it consistent with:

* The guidance above
* Other examples on the page
* The future direction of the API (nobody should do a double-take when the 1st example uses a sync callback)

This change does not alter the behavior of the example, but aligns it with the recommended best practice and helps avoid confusion for readers.