### PR TITLE
feat: Introduce `SidebarItem` component to manage sidebar entry colla…

### DIFF
--- a/src/components/Layout/Sidebar/SidebarLink.tsx
+++ b/src/components/Layout/Sidebar/SidebarLink.tsx
@@ -29,6 +29,7 @@ interface SidebarLinkProps {
   isExpanded?: boolean;
   hideArrow?: boolean;
   isPending: boolean;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export function SidebarLink({
@@ -40,6 +41,7 @@ export function SidebarLink({
   isExpanded,
   hideArrow,
   isPending,
+  onClick,
 }: SidebarLinkProps) {
   const ref = useRef<HTMLAnchorElement>(null);
 
@@ -64,6 +66,7 @@ export function SidebarLink({
       title={title}
       target={target}
       passHref
+      onClick={onClick}
       aria-current={selected ? 'page' : undefined}
       className={cn(
         'p-2 pe-2 w-full rounded-none lg:rounded-e-2xl text-start hover:bg-gray-5 dark:hover:bg-gray-80 relative flex items-center justify-between',

--- a/src/components/Layout/Sidebar/SidebarRouteTree.tsx
+++ b/src/components/Layout/Sidebar/SidebarRouteTree.tsx
@@ -9,7 +9,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  */
 
-import {useRef, useLayoutEffect, Fragment} from 'react';
+import {useRef, useLayoutEffect, useState, useEffect, Fragment} from 'react';
 
 import cn from 'classnames';
 import {useRouter} from 'next/router';
@@ -78,6 +78,95 @@ function CollapseWrapper({
   );
 }
 
+interface SidebarItemProps {
+  item: RouteItem;
+  level: number;
+  isForceExpanded: boolean;
+  breadcrumbs: RouteItem[];
+  slug: string;
+  pendingRoute: string | null;
+}
+
+function SidebarItem({
+  item,
+  level,
+  isForceExpanded,
+  breadcrumbs,
+  slug,
+  pendingRoute,
+}: SidebarItemProps) {
+  const {path, title, routes, version, heading} = item;
+  const selected = slug === path;
+  const isBreadcrumb =
+    breadcrumbs.length > 1 && breadcrumbs[breadcrumbs.length - 1].path === path;
+
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const shouldBeExpanded = isForceExpanded || isBreadcrumb || selected;
+  const isExpanded = shouldBeExpanded && !isCollapsed;
+
+  useEffect(() => {
+    if (!selected) {
+      setIsCollapsed(false);
+    }
+  }, [selected]);
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (selected) {
+      event.preventDefault();
+      setIsCollapsed((prev) => !prev);
+    }
+  };
+
+  if (!path || heading) {
+    return (
+      <SidebarRouteTree
+        level={level + 1}
+        isForceExpanded={isForceExpanded}
+        routeTree={{title, routes}}
+        breadcrumbs={[]}
+      />
+    );
+  } else if (routes) {
+    return (
+      <li>
+        <SidebarLink
+          href={path}
+          isPending={pendingRoute === path}
+          selected={selected}
+          level={level}
+          title={title}
+          version={version}
+          isExpanded={isExpanded}
+          hideArrow={isForceExpanded}
+          onClick={handleClick}
+        />
+        <CollapseWrapper duration={250} isExpanded={isExpanded}>
+          <SidebarRouteTree
+            isForceExpanded={isForceExpanded}
+            routeTree={{title, routes}}
+            breadcrumbs={breadcrumbs}
+            level={level + 1}
+          />
+        </CollapseWrapper>
+      </li>
+    );
+  } else {
+    return (
+      <li>
+        <SidebarLink
+          isPending={pendingRoute === path}
+          href={path}
+          selected={selected}
+          level={level}
+          title={title}
+          version={version}
+        />
+      </li>
+    );
+  }
+}
+
 export function SidebarRouteTree({
   isForceExpanded,
   breadcrumbs,
@@ -89,102 +178,44 @@ export function SidebarRouteTree({
   const currentRoutes = routeTree.routes as RouteItem[];
   return (
     <ul>
-      {currentRoutes.map(
-        (
-          {
-            path,
-            title,
-            routes,
-            version,
-            heading,
-            hasSectionHeader,
-            sectionHeader,
-          },
-          index
-        ) => {
-          const selected = slug === path;
-          let listItem = null;
-          if (!path || heading) {
-            // if current route item has no path and children treat it as an API sidebar heading
-            listItem = (
-              <SidebarRouteTree
-                level={level + 1}
-                isForceExpanded={isForceExpanded}
-                routeTree={{title, routes}}
-                breadcrumbs={[]}
-              />
-            );
-          } else if (routes) {
-            // if route has a path and child routes, treat it as an expandable sidebar item
-            const isBreadcrumb =
-              breadcrumbs.length > 1 &&
-              breadcrumbs[breadcrumbs.length - 1].path === path;
-            const isExpanded = isForceExpanded || isBreadcrumb || selected;
-            listItem = (
-              <li key={`${title}-${path}-${level}-heading`}>
-                <SidebarLink
-                  key={`${title}-${path}-${level}-link`}
-                  href={path}
-                  isPending={pendingRoute === path}
-                  selected={selected}
-                  level={level}
-                  title={title}
-                  version={version}
-                  isExpanded={isExpanded}
-                  hideArrow={isForceExpanded}
+      {currentRoutes.map((item, index) => {
+        const {path, title, hasSectionHeader, sectionHeader} = item;
+        if (hasSectionHeader) {
+          let sectionHeaderText =
+            sectionHeader != null
+              ? sectionHeader.replace('{{version}}', siteConfig.version)
+              : '';
+          return (
+            <Fragment key={`${sectionHeaderText}-${level}-separator`}>
+              {index !== 0 && (
+                <li
+                  role="separator"
+                  className="mt-4 mb-2 ms-5 border-b border-border dark:border-border-dark"
                 />
-                <CollapseWrapper duration={250} isExpanded={isExpanded}>
-                  <SidebarRouteTree
-                    isForceExpanded={isForceExpanded}
-                    routeTree={{title, routes}}
-                    breadcrumbs={breadcrumbs}
-                    level={level + 1}
-                  />
-                </CollapseWrapper>
-              </li>
-            );
-          } else {
-            // if route has a path and no child routes, treat it as a sidebar link
-            listItem = (
-              <li key={`${title}-${path}-${level}-link`}>
-                <SidebarLink
-                  isPending={pendingRoute === path}
-                  href={path}
-                  selected={selected}
-                  level={level}
-                  title={title}
-                  version={version}
-                />
-              </li>
-            );
-          }
-          if (hasSectionHeader) {
-            let sectionHeaderText =
-              sectionHeader != null
-                ? sectionHeader.replace('{{version}}', siteConfig.version)
-                : '';
-            return (
-              <Fragment key={`${sectionHeaderText}-${level}-separator`}>
-                {index !== 0 && (
-                  <li
-                    role="separator"
-                    className="mt-4 mb-2 ms-5 border-b border-border dark:border-border-dark"
-                  />
-                )}
-                <h3
-                  className={cn(
-                    'mb-1 text-sm font-bold ms-5 text-tertiary dark:text-tertiary-dark',
-                    index !== 0 && 'mt-2'
-                  )}>
-                  {sectionHeaderText}
-                </h3>
-              </Fragment>
-            );
-          } else {
-            return listItem;
-          }
+              )}
+              <h3
+                className={cn(
+                  'mb-1 text-sm font-bold ms-5 text-tertiary dark:text-tertiary-dark',
+                  index !== 0 && 'mt-2'
+                )}>
+                {sectionHeaderText}
+              </h3>
+            </Fragment>
+          );
+        } else {
+          return (
+            <SidebarItem
+              key={`${title}-${path}-${level}-item`}
+              item={item}
+              level={level}
+              isForceExpanded={isForceExpanded}
+              breadcrumbs={breadcrumbs}
+              slug={slug}
+              pendingRoute={pendingRoute}
+            />
+          );
         }
-      )}
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/fced4544-f701-43d3-b011-3b4e74620106

## **Overview**

This PR enhances the React documentation website's sidebar navigation by allowing users to toggle dropdowns when clicking an already-selected item. This improves overall navigation usability and aligns the behavior with common UI expectations.

---

## **Problem Statement**

Previously, clicking on an active/selected sidebar item that had a dropdown produced no action.
Users naturally expect that clicking the same selected item again should collapse the dropdown—similar to accordion-style navigation patterns.

This mismatch resulted in:

* Reduced control over expanded sections
* Unnecessary vertical scrolling
* A navigation flow that felt less intuitive

---

## **Solution**

A toggle mechanism has been implemented to allow collapsing an expanded dropdown by clicking the currently selected item a second time.

---

## **Technical Changes**

### **Modified Files**

#### `src/components/Layout/Sidebar/SidebarLink.tsx`

* Added optional `onClick` prop to support custom click behavior
* Passed `onClick` handler down to the underlying `Link` component

#### `src/components/Layout/Sidebar/SidebarRouteTree.tsx`

* Imported `useState` and `useEffect`
* Extracted a new `SidebarItem` component to encapsulate item-level logic
* Added local `isCollapsed` state to manage manual expand/collapse
* Implemented click handler to toggle `isCollapsed` when clicking on a selected item
* Added `useEffect` to reset `isCollapsed` when the item becomes deselected
* Refactored main component to use `SidebarItem` for cleaner structure

---

## **Key Logic**

```tsx
// Determine if item should be expanded
const shouldBeExpanded = isForceExpanded || isBreadcrumb || selected;
const isExpanded = shouldBeExpanded && !isCollapsed;

// Toggle on click when selected
const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
  if (selected) {
    event.preventDefault();
    setIsCollapsed((prev) => !prev);
  }
};

// Reset collapsed state when navigating away
useEffect(() => {
  if (!selected) {
    setIsCollapsed(false);
  }
}, [selected]);
```

---

## **Behavior**

### **Before**

* Clicking an active sidebar item with children: **No action**
* Navigation to another page: Dropdown expanded/collapsed strictly by breadcrumb logic

### **After**

* 1st click on item: Navigates & expands dropdown (if applicable)
* 2nd click on same selected item: **Collapses** dropdown
* 3rd click: **Expands** again
* Navigating away: Resets collapse state for correct default behavior

---

## **Benefits**

* **Improved UX:** Matches intuitive accordion-like patterns
* **Enhanced Control:** Users can collapse sections they're done with
* **Backwards Compatible:** Navigation behavior remains unchanged
* **No Regressions:** Collapsed state resets on navigation to avoid stale UI

---

## **Testing**

* ✅ `npm run tsc` (TypeScript compilation)
* ✅ `npm run lint` (ESLint validation)



* All existing warnings were unrelated to this change
  #8149
