### PR TITLE
fix: Remove reliance on accidental behavior

### DIFF
--- a/src/content/learn/reusing-logic-with-custom-hooks.md
+++ b/src/content/learn/reusing-logic-with-custom-hooks.md
@@ -1691,7 +1691,7 @@ function useAnimationLoop(isRunning, drawFrame) {
       frameId = requestAnimationFrame(tick);
     }
 
-    tick();
+    tick(startTime);
     return () => cancelAnimationFrame(frameId);
   }, [isRunning]);
 }


### PR DESCRIPTION
The initial call of `tick` ought to have a value for the 'now' argument' passed into it here. Currently, the code does work incidentally, but it passes `undefined` into `tick`, with the result that `ref.current.style.opacity` gets set equal to `NaN`. The browser just ignores this, so nothing bad happens but it's fragile and could be confusing to readers. I suggest we pass `startTime` to `tick` when it's first called, so that `ref.current.style.opacity` just gets set equal to 0 instead.
