### PR TITLE
docs: fix incorrect startTransition usage in server-functions example

### DIFF
--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -126,14 +126,15 @@ function UpdateName() {
   const submitAction = async () => {
     startTransition(async () => {
       const {error} = await updateName(name);
-      if (error) {
-        setError(error);
-      } else {
-        setName('');
-      }
-    })
-  }
-  
+      startTransition(() => {
+        if (error) {
+          setError(error);
+        } else {
+          setName('');
+        }
+      });
+    });
+  };
   return (
     <form action={submitAction}>
       <input type="text" name="name" disabled={isPending}/>


### PR DESCRIPTION
Closes #8158

Fix incorrect startTransition usage in docs

The example in the Server Functions page calls a server action inside startTransition, but the state updates after the await aren’t wrapped in a new transition. React’s docs mention that post-await state updates aren’t included automatically, so this updates the snippet to wrap them in another startTransition for correctness.

This brings the example in line with the recommended behavior.