### PR TITLE
fix: use correct function name for addTransitionType

### DIFF
--- a/src/content/reference/react/addTransitionType.md
+++ b/src/content/reference/react/addTransitionType.md
@@ -39,7 +39,7 @@ startTransition(() => {
 
 #### Returns {/*returns*/}
 
-`startTransition` does not return anything.
+`addTransitionType` does not return anything.
 
 #### Caveats {/*caveats*/}
 


### PR DESCRIPTION
The docs for [addTransitionType](https://react.dev/reference/react/addTransitionType) say that:

Reference
`addTransitionType `
...
Returns
`startTransition` does not return anything

but it should say

`addTransitionType ` does not return anything