### PR TITLE
docs: Fix typo in ViewTransition code snippet callout

### DIFF
--- a/src/content/reference/react/ViewTransition.md
+++ b/src/content/reference/react/ViewTransition.md
@@ -2162,7 +2162,7 @@ function Item() {
 function ItemList({items}) {
   return (
     <>
-      {item.map(item => <Item key={item.id} />)}
+      {items.map(item => <Item key={item.id} />)}
     </>
   );
 }
@@ -2199,7 +2199,7 @@ function Item({id}) {
 function ItemList({items}) {
   return (
     <>
-      {item.map(item => <Item key={item.id} item={item} />)}
+      {items.map(item => <Item key={item.id} item={item} />)}
     </>
   );
 }


### PR DESCRIPTION

Fix typo in code snippet callout that is highlighting some lines of example code. It should .map through items, not item. 
