### PR TITLE
Fix: Lower ToC breakpoint from 2xl (1536px) to xl (1280px)

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -151,7 +151,7 @@ export function Page({
       <div
         className={cn(
           hasColumns &&
-            'grid grid-cols-only-content lg:grid-cols-sidebar-content 2xl:grid-cols-sidebar-content-toc'
+            'grid grid-cols-only-content lg:grid-cols-sidebar-content xl:grid-cols-sidebar-content-toc'
         )}>
         {showSidebar && (
           <div className="lg:-mt-16 z-10">
@@ -192,7 +192,7 @@ export function Page({
             </div>
           </main>
         </Suspense>
-        <div className="hidden -mt-16 lg:max-w-custom-xs 2xl:block">
+        <div className="hidden -mt-16 lg:max-w-custom-xs xl:block">
           {showToc && toc.length > 0 && <Toc headings={toc} key={asPath} />}
         </div>
       </div>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

I was surprised to find that the Table of Contents (TOC) didn’t appear in the top-right corner on the 14-inch MacBook Pro .

In my opinion, having a TOC is almost always very useful when browsing longer technical documentation, such as react.dev.




