### PR TITLE
docs(reference): remove unused useContext import from examples

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -826,7 +826,7 @@ const initialTasks = [
 ```
 
 ```js src/AddTask.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasksDispatch } from './TasksContext.js';
 
 export default function AddTask() {
@@ -855,7 +855,7 @@ let nextId = 3;
 ```
 
 ```js src/TaskList.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasks, useTasksDispatch } from './TasksContext.js';
 
 export default function TaskList() {


### PR DESCRIPTION
This PR removes the unused `useContext` import from the `AddTask` and `TaskList` examples on the **useContext reference page**.

These examples use custom hooks (`useTasks`, `useTasksDispatch`) and no longer call `useContext` directly, so the import is unnecessary.

This aligns the examples with the actual code usage and fixes a small typo reported in the issue.

Closes #8186.