### PR TITLE
Remove unused useState import in StrictMode.md

### DIFF
--- a/src/content/reference/react/StrictMode.md
+++ b/src/content/reference/react/StrictMode.md
@@ -536,7 +536,7 @@ root.render(<App />);
 ```
 
 ```js
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { createConnection } from './chat.js';
 
 const serverUrl = 'https://localhost:1234';


### PR DESCRIPTION
Removed unused import of useState from React.

```javascript
import { useState, useEffect } from 'react';
import { createConnection } from './chat.js';

const serverUrl = 'https://localhost:1234';
const roomId = 'general';

export default function ChatRoom() {
  useEffect(() => {
    const connection = createConnection(serverUrl, roomId);
    connection.connect();
  }, []);
  return <h1>Welcome to the {roomId} room!</h1>;
}
```

In this part of StrictMode session, exactly after this text: `In the original example, the bug wasn’t obvious. Now let’s wrap the original (buggy) code in <StrictMode>:`

The `useState` is not necessary, so it can be removed.
