### PR TITLE
docs: Update caveats for React cache documentation

### DIFF
--- a/src/content/reference/react/cache.md
+++ b/src/content/reference/react/cache.md
@@ -64,6 +64,7 @@ The optimization of caching return values based on inputs is known as [_memoizat
 
 - React will invalidate the cache for all memoized functions for each server request.
 - Each call to `cache` creates a new function. This means that calling `cache` with the same function multiple times will return different memoized functions that do not share the same cache.
+- React uses shallow comparison (`Object.is`) for arguments. Passing a new object or array on every call will bypass the cache.
 - `cachedFn` will also cache errors. If `fn` throws an error for certain arguments, it will be cached, and the same error is re-thrown when `cachedFn` is called with those same arguments.
 - `cache` is for use in [Server Components](/reference/rsc/server-components) only.
 


### PR DESCRIPTION
_TLDR:_ This MR adds a brief mention of the behavior of `cache` function right at the top of the documentation, in the "Caveats" section, which feels like the right place for such "heads up, confirm you're using it right" piece of information.

---

> "Explicit is better than implicit." — The Zen of Python (Tim Peters)

Recently we were working on enhancing reliability for our website, specifically revisiting what and how efficiently we are caching.

After a bunch of investigations and trying things out, we found out that we were not using the `cache` function correctly. It was added some time ago and we were passing objects in params instead of primitives. But since the documentation doesn't really directly mentions it anywhere _(only deep down in the troubleshooting section, where it mentions `Object.is` comparison briefly without explaining it too much)_, we didn't even know we are using it wrong until we started targeted debugging.

This whole investigation and debugging flow sparked some ideas and we wanted to help future engineers like ourselves to not end up in a similar situation by misreading/misunderstanding the documentation. So this MR adds a brief mention of the behavior of `cache` function right at the top of the documentation, in the "Caveats" section, which feels like the right place for such "heads up, confirm you're using it right" piece of information.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
