### PR TITLE
docs: fix lazy() sandbox buttons (Reset -> Reload or Clear)

### DIFF
--- a/src/content/reference/react/lazy.md
+++ b/src/content/reference/react/lazy.md
@@ -175,7 +175,7 @@ body {
 
 </Sandpack>
 
-This demo loads with an artificial delay. The next time you untick and tick the checkbox, `Preview` will be cached, so there will be no loading state. To see the loading state again, click "Reset" on the sandbox.
+This demo loads with an artificial delay. The next time you untick and tick the checkbox, `Preview` will be cached, so there will be no loading state. To see the loading state again, click "Reload" or "Clear" on the sandbox.
 
 [Learn more about managing loading states with Suspense.](/reference/react/Suspense)
 


### PR DESCRIPTION
Changes:

Before: To see the loading state again, click “Reset” on the sandbox.
After: To see the loading state again, click "Reload" or "Clear" on the sandbox.

Details: 
- File: `src/content/reference/react/lazy.md`
- Page: https://react.dev/reference/react/lazy.md
- Verified the sandbox actually shows "Reload" and "Clear" buttons
