### PR TITLE
fix: replace imgur domains with official proxy to fix UK access issue…

### DIFF
--- a/src/content/learn/adding-interactivity.md
+++ b/src/content/learn/adding-interactivity.md
@@ -139,73 +139,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -423,7 +423,7 @@ export default function Form() {
     artwork: {
       title: 'Blue Nana',
       city: 'Hamburg',
-      image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+      image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
     }
   });
 
@@ -531,7 +531,7 @@ export default function Form() {
     artwork: {
       title: 'Blue Nana',
       city: 'Hamburg',
-      image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+      image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
     }
   });
 

--- a/src/content/learn/describing-the-ui.md
+++ b/src/content/learn/describing-the-ui.md
@@ -32,7 +32,7 @@ React applications are built from isolated pieces of UI called *components*. A R
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/MK3eW3As.jpg"
+      src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg"
       alt="Katherine Johnson"
     />
   );
@@ -98,7 +98,7 @@ export default function Gallery() {
 export default function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -131,7 +131,7 @@ export default function TodoList() {
     // This doesn't quite work!
     <h1>Hedy Lamarr's Todos</h1>
     <img
-      src="https://i.imgur.com/yXOvdOSs.jpg"
+      src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg"
       alt="Hedy Lamarr"
       class="photo"
     >
@@ -160,7 +160,7 @@ export default function TodoList() {
     <>
       <h1>Hedy Lamarr's Todos</h1>
       <img
-        src="https://i.imgur.com/yXOvdOSs.jpg"
+        src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg"
         alt="Hedy Lamarr"
         className="photo"
       />
@@ -207,7 +207,7 @@ export default function TodoList() {
       <h1>{person.name}'s Todos</h1>
       <img
         className="avatar"
-        src="https://i.imgur.com/7vQD0fPs.jpg"
+        src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
         alt="Gregorio Y. Zara"
       />
       <ul>
@@ -282,7 +282,7 @@ function Card({ children }) {
 ```js src/utils.js
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -435,7 +435,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );

--- a/src/content/learn/importing-and-exporting-components.md
+++ b/src/content/learn/importing-and-exporting-components.md
@@ -28,7 +28,7 @@ In [Your First Component](/learn/your-first-component), you made a `Profile` com
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/MK3eW3As.jpg"
+      src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg"
       alt="Katherine Johnson"
     />
   );
@@ -80,7 +80,7 @@ export default function App() {
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -198,7 +198,7 @@ export default function App() {
 export function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -286,7 +286,7 @@ export default function App() {
 export function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -354,7 +354,7 @@ export default function Gallery() {
 export function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -404,7 +404,7 @@ export default function Gallery() {
 export default function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );

--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -143,7 +143,7 @@ You can put more complex expressions inside the JSX curly braces too, for exampl
 ```js
 const user = {
   name: 'Hedy Lamarr',
-  imageUrl: 'https://i.imgur.com/yXOvdOSs.jpg',
+  imageUrl: 'https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg',
   imageSize: 90,
 };
 

--- a/src/content/learn/javascript-in-jsx-with-curly-braces.md
+++ b/src/content/learn/javascript-in-jsx-with-curly-braces.md
@@ -28,7 +28,7 @@ export default function Avatar() {
   return (
     <img
       className="avatar"
-      src="https://i.imgur.com/7vQD0fPs.jpg"
+      src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
       alt="Gregorio Y. Zara"
     />
   );
@@ -41,7 +41,7 @@ export default function Avatar() {
 
 </Sandpack>
 
-Here, `"https://i.imgur.com/7vQD0fPs.jpg"` and `"Gregorio Y. Zara"` are being passed as strings.
+Here, `"https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"` and `"Gregorio Y. Zara"` are being passed as strings.
 
 But what if you want to dynamically specify the `src` or `alt` text? You could **use a value from JavaScript by replacing `"` and `"` with `{` and `}`**:
 
@@ -49,7 +49,7 @@ But what if you want to dynamically specify the `src` or `alt` text? You could *
 
 ```js
 export default function Avatar() {
-  const avatar = 'https://i.imgur.com/7vQD0fPs.jpg';
+  const avatar = 'https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg';
   const description = 'Gregorio Y. Zara';
   return (
     <img
@@ -190,7 +190,7 @@ export default function TodoList() {
       <h1>{person.name}'s Todos</h1>
       <img
         className="avatar"
-        src="https://i.imgur.com/7vQD0fPs.jpg"
+        src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
         alt="Gregorio Y. Zara"
       />
       <ul>
@@ -266,7 +266,7 @@ export default function TodoList() {
       <h1>{person}'s Todos</h1>
       <img
         className="avatar"
-        src="https://i.imgur.com/7vQD0fPs.jpg"
+        src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
         alt="Gregorio Y. Zara"
       />
       <ul>
@@ -314,7 +314,7 @@ export default function TodoList() {
       <h1>{person.name}'s Todos</h1>
       <img
         className="avatar"
-        src="https://i.imgur.com/7vQD0fPs.jpg"
+        src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
         alt="Gregorio Y. Zara"
       />
       <ul>
@@ -358,7 +358,7 @@ export default function TodoList() {
       <h1>{person.name}'s Todos</h1>
       <img
         className="avatar"
-        src="https://i.imgur.com/7vQD0fPs.jpg"
+        src="https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg"
         alt="Gregorio Y. Zara"
       />
       <ul>
@@ -388,7 +388,7 @@ Move the image URL into a property called `person.imageUrl` and read it from the
 ```js
 const person = {
   name: 'Gregorio Y. Zara',
-  imageUrl: "https://i.imgur.com/7vQD0fPs.jpg",
+  imageUrl: "https://i.imgur.com.prx.react.dev/7vQD0fPs.jpg",
   theme: {
     backgroundColor: 'black',
     color: 'pink'
@@ -428,7 +428,7 @@ body > div > div { padding: 20px; }
 
 In the object below, the full image URL is split into four parts: base URL, `imageId`, `imageSize`, and file extension.
 
-We want the image URL to combine these attributes together: base URL (always `'https://i.imgur.com/'`), `imageId` (`'7vQD0fP'`), `imageSize` (`'s'`), and file extension (always `'.jpg'`). However, something is wrong with how the `<img>` tag specifies its `src`.
+We want the image URL to combine these attributes together: base URL (always `'https://i.imgur.com.prx.react.dev/'`), `imageId` (`'7vQD0fP'`), `imageSize` (`'s'`), and file extension (always `'.jpg'`). However, something is wrong with how the `<img>` tag specifies its `src`.
 
 Can you fix it?
 
@@ -436,7 +436,7 @@ Can you fix it?
 
 ```js
 
-const baseUrl = 'https://i.imgur.com/';
+const baseUrl = 'https://i.imgur.com.prx.react.dev/';
 const person = {
   name: 'Gregorio Y. Zara',
   imageId: '7vQD0fP',
@@ -487,7 +487,7 @@ You can write it as `src={baseUrl + person.imageId + person.imageSize + '.jpg'}`
 <Sandpack>
 
 ```js
-const baseUrl = 'https://i.imgur.com/';
+const baseUrl = 'https://i.imgur.com.prx.react.dev/';
 const person = {
   name: 'Gregorio Y. Zara',
   imageId: '7vQD0fP',
@@ -564,7 +564,7 @@ export default function TodoList() {
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     person.imageSize +
     '.jpg'

--- a/src/content/learn/keeping-components-pure.md
+++ b/src/content/learn/keeping-components-pure.md
@@ -451,7 +451,7 @@ export default function App() {
 ```js src/utils.js hidden
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -549,7 +549,7 @@ export default function App() {
 ```js src/utils.js hidden
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'

--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -998,7 +998,7 @@ export const places = [{
 ```js src/utils.js
 export function getImageUrl(place) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     place.imageId +
     'l.jpg'
   );
@@ -1137,7 +1137,7 @@ export const places = [{
 ```js src/utils.js
 export function getImageUrl(place) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     place.imageId +
     'l.jpg'
   );

--- a/src/content/learn/passing-props-to-a-component.md
+++ b/src/content/learn/passing-props-to-a-component.md
@@ -29,7 +29,7 @@ function Avatar() {
   return (
     <img
       className="avatar"
-      src="https://i.imgur.com/1bX5QH6.jpg"
+      src="https://i.imgur.com.prx.react.dev/1bX5QH6.jpg"
       alt="Lin Lanying"
       width={100}
       height={100}
@@ -153,7 +153,7 @@ export default function Profile() {
 ```js src/utils.js
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -320,7 +320,7 @@ export default function Avatar({ person, size }) {
 ```js src/utils.js
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -498,7 +498,7 @@ export default function Gallery() {
 ```js src/utils.js
 export function getImageUrl(imageId, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     imageId +
     size +
     '.jpg'
@@ -606,7 +606,7 @@ export default function Gallery() {
 ```js src/utils.js
 export function getImageUrl(imageId, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     imageId +
     size +
     '.jpg'
@@ -703,7 +703,7 @@ export default function Gallery() {
 ```js src/utils.js
 export function getImageUrl(person, size = 's') {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -770,7 +770,7 @@ export default function Profile() {
 ```js src/utils.js
 export function getImageUrl(person, size) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -834,7 +834,7 @@ export default function Profile() {
 ```js src/utils.js
 export function getImageUrl(person, size) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -905,7 +905,7 @@ export default function Profile() {
 ```js src/utils.js
 export function getImageUrl(person, size) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     size +
     '.jpg'
@@ -938,7 +938,7 @@ export default function Profile() {
           <h1>Photo</h1>
           <img
             className="avatar"
-            src="https://i.imgur.com/OKS67lhm.jpg"
+            src="https://i.imgur.com.prx.react.dev/OKS67lhm.jpg"
             alt="Aklilu Lemma"
             width={70}
             height={70}
@@ -1011,7 +1011,7 @@ export default function Profile() {
         <h1>Photo</h1>
         <img
           className="avatar"
-          src="https://i.imgur.com/OKS67lhm.jpg"
+          src="https://i.imgur.com.prx.react.dev/OKS67lhm.jpg"
           alt="Aklilu Lemma"
           width={100}
           height={100}
@@ -1073,7 +1073,7 @@ export default function Profile() {
       <Card title="Photo">
         <img
           className="avatar"
-          src="https://i.imgur.com/OKS67lhm.jpg"
+          src="https://i.imgur.com.prx.react.dev/OKS67lhm.jpg"
           alt="Aklilu Lemma"
           width={100}
           height={100}

--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -1888,25 +1888,25 @@ export default function Gallery() {
 
 let images = [{
   place: 'Penang, Malaysia',
-  src: 'https://i.imgur.com/FJeJR8M.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/FJeJR8M.jpg'
 }, {
   place: 'Lisbon, Portugal',
-  src: 'https://i.imgur.com/dB2LRbj.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/dB2LRbj.jpg'
 }, {
   place: 'Bilbao, Spain',
-  src: 'https://i.imgur.com/z08o2TS.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/z08o2TS.jpg'
 }, {
   place: 'Valparaíso, Chile',
-  src: 'https://i.imgur.com/Y3utgTi.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/Y3utgTi.jpg'
 }, {
   place: 'Schwyz, Switzerland',
-  src: 'https://i.imgur.com/JBbMpWY.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/JBbMpWY.jpg'
 }, {
   place: 'Prague, Czechia',
-  src: 'https://i.imgur.com/QwUKKmF.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/QwUKKmF.jpg'
 }, {
   place: 'Ljubljana, Slovenia',
-  src: 'https://i.imgur.com/3aIiwfm.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/3aIiwfm.jpg'
 }];
 ```
 
@@ -1956,25 +1956,25 @@ export default function Gallery() {
 
 let images = [{
   place: 'Penang, Malaysia',
-  src: 'https://i.imgur.com/FJeJR8M.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/FJeJR8M.jpg'
 }, {
   place: 'Lisbon, Portugal',
-  src: 'https://i.imgur.com/dB2LRbj.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/dB2LRbj.jpg'
 }, {
   place: 'Bilbao, Spain',
-  src: 'https://i.imgur.com/z08o2TS.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/z08o2TS.jpg'
 }, {
   place: 'Valparaíso, Chile',
-  src: 'https://i.imgur.com/Y3utgTi.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/Y3utgTi.jpg'
 }, {
   place: 'Schwyz, Switzerland',
-  src: 'https://i.imgur.com/JBbMpWY.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/JBbMpWY.jpg'
 }, {
   place: 'Prague, Czechia',
-  src: 'https://i.imgur.com/QwUKKmF.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/QwUKKmF.jpg'
 }, {
   place: 'Ljubljana, Slovenia',
-  src: 'https://i.imgur.com/3aIiwfm.jpg'
+  src: 'https://i.imgur.com.prx.react.dev/3aIiwfm.jpg'
 }];
 ```
 

--- a/src/content/learn/reacting-to-input-with-state.md
+++ b/src/content/learn/reacting-to-input-with-state.md
@@ -518,7 +518,7 @@ export default function Picture() {
       <img
         className="picture"
         alt="Rainbow houses in Kampung Pelangi, Indonesia"
-        src="https://i.imgur.com/5qwVYb1.jpeg"
+        src="https://i.imgur.com.prx.react.dev/5qwVYb1.jpeg"
       />
     </div>
   );
@@ -594,7 +594,7 @@ export default function Picture() {
         }}
         className={pictureClassName}
         alt="Rainbow houses in Kampung Pelangi, Indonesia"
-        src="https://i.imgur.com/5qwVYb1.jpeg"
+        src="https://i.imgur.com.prx.react.dev/5qwVYb1.jpeg"
       />
     </div>
   );
@@ -649,7 +649,7 @@ export default function Picture() {
         <img
           className="picture picture--active"
           alt="Rainbow houses in Kampung Pelangi, Indonesia"
-          src="https://i.imgur.com/5qwVYb1.jpeg"
+          src="https://i.imgur.com.prx.react.dev/5qwVYb1.jpeg"
           onClick={e => e.stopPropagation()}
         />
       </div>
@@ -660,7 +660,7 @@ export default function Picture() {
       <img
         className="picture"
         alt="Rainbow houses in Kampung Pelangi, Indonesia"
-        src="https://i.imgur.com/5qwVYb1.jpeg"
+        src="https://i.imgur.com.prx.react.dev/5qwVYb1.jpeg"
         onClick={() => setIsActive(true)}
       />
     </div>

--- a/src/content/learn/render-and-commit.md
+++ b/src/content/learn/render-and-commit.md
@@ -54,7 +54,7 @@ root.render(<Image />);
 export default function Image() {
   return (
     <img
-      src="https://i.imgur.com/ZF6s192.jpg"
+      src="https://i.imgur.com.prx.react.dev/ZF6s192.jpg"
       alt="'Floralis Genérica' by Eduardo Catalano: a gigantic metallic flower sculpture with reflective petals"
     />
   );
@@ -103,7 +103,7 @@ export default function Gallery() {
 function Image() {
   return (
     <img
-      src="https://i.imgur.com/ZF6s192.jpg"
+      src="https://i.imgur.com.prx.react.dev/ZF6s192.jpg"
       alt="'Floralis Genérica' by Eduardo Catalano: a gigantic metallic flower sculpture with reflective petals"
     />
   );

--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -223,7 +223,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );
@@ -353,7 +353,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );
@@ -514,7 +514,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );
@@ -629,7 +629,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );
@@ -743,7 +743,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );
@@ -861,7 +861,7 @@ export const people = [{
 ```js src/utils.js
 export function getImageUrl(person) {
   return (
-    'https://i.imgur.com/' +
+    'https://i.imgur.com.prx.react.dev/' +
     person.imageId +
     's.jpg'
   );

--- a/src/content/learn/state-a-components-memory.md
+++ b/src/content/learn/state-a-components-memory.md
@@ -63,73 +63,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -243,73 +243,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -432,73 +432,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -628,73 +628,73 @@ let sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 
@@ -797,73 +797,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -968,73 +968,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```
@@ -1130,73 +1130,73 @@ export const sculptureList = [{
   name: 'Homenaje a la Neurocirugía',
   artist: 'Marta Colvin Andrade',
   description: 'Although Colvin is predominantly known for abstract themes that allude to pre-Hispanic symbols, this gigantic sculpture, an homage to neurosurgery, is one of her most recognizable public art pieces.',
-  url: 'https://i.imgur.com/Mx7dA2Y.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Mx7dA2Y.jpg',
   alt: 'A bronze statue of two crossed hands delicately holding a human brain in their fingertips.'  
 }, {
   name: 'Floralis Genérica',
   artist: 'Eduardo Catalano',
   description: 'This enormous (75 ft. or 23m) silver flower is located in Buenos Aires. It is designed to move, closing its petals in the evening or when strong winds blow and opening them in the morning.',
-  url: 'https://i.imgur.com/ZF6s192m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/ZF6s192m.jpg',
   alt: 'A gigantic metallic flower sculpture with reflective mirror-like petals and strong stamens.'
 }, {
   name: 'Eternal Presence',
   artist: 'John Woodrow Wilson',
   description: 'Wilson was known for his preoccupation with equality, social justice, as well as the essential and spiritual qualities of humankind. This massive (7ft. or 2,13m) bronze represents what he described as "a symbolic Black presence infused with a sense of universal humanity."',
-  url: 'https://i.imgur.com/aTtVpES.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/aTtVpES.jpg',
   alt: 'The sculpture depicting a human head seems ever-present and solemn. It radiates calm and serenity.'
 }, {
   name: 'Moai',
   artist: 'Unknown Artist',
   description: 'Located on the Easter Island, there are 1,000 moai, or extant monumental statues, created by the early Rapa Nui people, which some believe represented deified ancestors.',
-  url: 'https://i.imgur.com/RCwLEoQm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/RCwLEoQm.jpg',
   alt: 'Three monumental stone busts with the heads that are disproportionately large with somber faces.'
 }, {
   name: 'Blue Nana',
   artist: 'Niki de Saint Phalle',
   description: 'The Nanas are triumphant creatures, symbols of femininity and maternity. Initially, Saint Phalle used fabric and found objects for the Nanas, and later on introduced polyester to achieve a more vibrant effect.',
-  url: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   alt: 'A large mosaic sculpture of a whimsical dancing female figure in a colorful costume emanating joy.'
 }, {
   name: 'Ultimate Form',
   artist: 'Barbara Hepworth',
   description: 'This abstract bronze sculpture is a part of The Family of Man series located at Yorkshire Sculpture Park. Hepworth chose not to create literal representations of the world but developed abstract forms inspired by people and landscapes.',
-  url: 'https://i.imgur.com/2heNQDcm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/2heNQDcm.jpg',
   alt: 'A tall sculpture made of three elements stacked on each other reminding of a human figure.'
 }, {
   name: 'Cavaliere',
   artist: 'Lamidi Olonade Fakeye',
   description: "Descended from four generations of woodcarvers, Fakeye's work blended traditional and contemporary Yoruba themes.",
-  url: 'https://i.imgur.com/wIdGuZwm.png',
+  url: 'https://i.imgur.com.prx.react.dev/wIdGuZwm.png',
   alt: 'An intricate wood sculpture of a warrior with a focused face on a horse adorned with patterns.'
 }, {
   name: 'Big Bellies',
   artist: 'Alina Szapocznikow',
   description: "Szapocznikow is known for her sculptures of the fragmented body as a metaphor for the fragility and impermanence of youth and beauty. This sculpture depicts two very realistic large bellies stacked on top of each other, each around five feet (1,5m) tall.",
-  url: 'https://i.imgur.com/AlHTAdDm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/AlHTAdDm.jpg',
   alt: 'The sculpture reminds a cascade of folds, quite different from bellies in classical sculptures.'
 }, {
   name: 'Terracotta Army',
   artist: 'Unknown Artist',
   description: 'The Terracotta Army is a collection of terracotta sculptures depicting the armies of Qin Shi Huang, the first Emperor of China. The army consisted of more than 8,000 soldiers, 130 chariots with 520 horses, and 150 cavalry horses.',
-  url: 'https://i.imgur.com/HMFmH6m.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/HMFmH6m.jpg',
   alt: '12 terracotta sculptures of solemn warriors, each with a unique facial expression and armor.'
 }, {
   name: 'Lunar Landscape',
   artist: 'Louise Nevelson',
   description: 'Nevelson was known for scavenging objects from New York City debris, which she would later assemble into monumental constructions. In this one, she used disparate parts like a bedpost, juggling pin, and seat fragment, nailing and gluing them into boxes that reflect the influence of Cubism’s geometric abstraction of space and form.',
-  url: 'https://i.imgur.com/rN7hY6om.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/rN7hY6om.jpg',
   alt: 'A black matte sculpture where the individual elements are initially indistinguishable.'
 }, {
   name: 'Aureole',
   artist: 'Ranjani Shettar',
   description: 'Shettar merges the traditional and the modern, the natural and the industrial. Her art focuses on the relationship between man and nature. Her work was described as compelling both abstractly and figuratively, gravity defying, and a "fine synthesis of unlikely materials."',
-  url: 'https://i.imgur.com/okTpbHhm.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/okTpbHhm.jpg',
   alt: 'A pale wire-like sculpture mounted on concrete wall and descending on the floor. It appears light.'
 }, {
   name: 'Hippos',
   artist: 'Taipei Zoo',
   description: 'The Taipei Zoo commissioned a Hippo Square featuring submerged hippos at play.',
-  url: 'https://i.imgur.com/6o5Vuyu.jpg',
+  url: 'https://i.imgur.com.prx.react.dev/6o5Vuyu.jpg',
   alt: 'A group of bronze hippo sculptures emerging from the sett sidewalk as if they were swimming.'
 }];
 ```

--- a/src/content/learn/updating-objects-in-state.md
+++ b/src/content/learn/updating-objects-in-state.md
@@ -457,7 +457,7 @@ const [person, setPerson] = useState({
   artwork: {
     title: 'Blue Nana',
     city: 'Hamburg',
-    image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+    image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   }
 });
 ```
@@ -501,7 +501,7 @@ export default function Form() {
     artwork: {
       title: 'Blue Nana',
       city: 'Hamburg',
-      image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+      image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
     }
   });
 
@@ -608,7 +608,7 @@ let obj = {
   artwork: {
     title: 'Blue Nana',
     city: 'Hamburg',
-    image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+    image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
   }
 };
 ```
@@ -619,7 +619,7 @@ However, "nesting" is an inaccurate way to think about how objects behave. When 
 let obj1 = {
   title: 'Blue Nana',
   city: 'Hamburg',
-  image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
 };
 
 let obj2 = {
@@ -634,7 +634,7 @@ The `obj1` object is not "inside" `obj2`. For example, `obj3` could "point" at `
 let obj1 = {
   title: 'Blue Nana',
   city: 'Hamburg',
-  image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+  image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
 };
 
 let obj2 = {
@@ -690,7 +690,7 @@ export default function Form() {
     artwork: {
       title: 'Blue Nana',
       city: 'Hamburg',
-      image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+      image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
     }
   });
 

--- a/src/content/learn/writing-markup-with-jsx.md
+++ b/src/content/learn/writing-markup-with-jsx.md
@@ -71,7 +71,7 @@ Suppose that you have some (perfectly valid) HTML:
 ```html
 <h1>Hedy Lamarr's Todos</h1>
 <img 
-  src="https://i.imgur.com/yXOvdOSs.jpg" 
+  src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
   alt="Hedy Lamarr" 
   class="photo"
 >
@@ -103,7 +103,7 @@ export default function TodoList() {
     // This doesn't quite work!
     <h1>Hedy Lamarr's Todos</h1>
     <img 
-      src="https://i.imgur.com/yXOvdOSs.jpg" 
+      src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
       alt="Hedy Lamarr" 
       class="photo"
     >
@@ -142,7 +142,7 @@ For example, you can use a `<div>`:
 <div>
   <h1>Hedy Lamarr's Todos</h1>
   <img 
-    src="https://i.imgur.com/yXOvdOSs.jpg" 
+    src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
     alt="Hedy Lamarr" 
     class="photo"
   >
@@ -159,7 +159,7 @@ If you don't want to add an extra `<div>` to your markup, you can write `<>` and
 <>
   <h1>Hedy Lamarr's Todos</h1>
   <img 
-    src="https://i.imgur.com/yXOvdOSs.jpg" 
+    src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
     alt="Hedy Lamarr" 
     class="photo"
   >
@@ -188,7 +188,7 @@ This is how Hedy Lamarr's image and list items look closed:
 ```js {2-6,8-10}
 <>
   <img 
-    src="https://i.imgur.com/yXOvdOSs.jpg" 
+    src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
     alt="Hedy Lamarr" 
     class="photo"
    />
@@ -208,7 +208,7 @@ This is why, in React, many HTML and SVG attributes are written in camelCase. Fo
 
 ```js {4}
 <img 
-  src="https://i.imgur.com/yXOvdOSs.jpg" 
+  src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
   alt="Hedy Lamarr" 
   className="photo"
 />
@@ -236,7 +236,7 @@ export default function TodoList() {
     <>
       <h1>Hedy Lamarr's Todos</h1>
       <img 
-        src="https://i.imgur.com/yXOvdOSs.jpg" 
+        src="https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg" 
         alt="Hedy Lamarr" 
         className="photo" 
       />

--- a/src/content/learn/your-first-component.md
+++ b/src/content/learn/your-first-component.md
@@ -63,7 +63,7 @@ Traditionally when creating web pages, web developers marked up their content an
 export default function Profile() {
   return (
     <img
-      src="https://i.imgur.com/MK3eW3Am.jpg"
+      src="https://i.imgur.com.prx.react.dev/MK3eW3Am.jpg"
       alt="Katherine Johnson"
     />
   )
@@ -99,7 +99,7 @@ The component returns an `<img />` tag with `src` and `alt` attributes. `<img />
 Return statements can be written all on one line, as in this component:
 
 ```js
-return <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />;
+return <img src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg" alt="Katherine Johnson" />;
 ```
 
 But if your markup isn't all on the same line as the `return` keyword, you must wrap it in a pair of parentheses:
@@ -107,7 +107,7 @@ But if your markup isn't all on the same line as the `return` keyword, you must 
 ```js
 return (
   <div>
-    <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
+    <img src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg" alt="Katherine Johnson" />
   </div>
 );
 ```
@@ -128,7 +128,7 @@ Now that you've defined your `Profile` component, you can nest it inside other c
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/MK3eW3As.jpg"
+      src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg"
       alt="Katherine Johnson"
     />
   );
@@ -164,9 +164,9 @@ And `Profile` contains even more HTML: `<img />`. In the end, this is what the b
 ```html
 <section>
   <h1>Amazing scientists</h1>
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
-  <img src="https://i.imgur.com/MK3eW3As.jpg" alt="Katherine Johnson" />
+  <img src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg" alt="Katherine Johnson" />
+  <img src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg" alt="Katherine Johnson" />
+  <img src="https://i.imgur.com.prx.react.dev/MK3eW3As.jpg" alt="Katherine Johnson" />
 </section>
 ```
 
@@ -248,7 +248,7 @@ This sandbox doesn't work because the root component is not exported:
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/lICfvbD.jpg"
+      src="https://i.imgur.com.prx.react.dev/lICfvbD.jpg"
       alt="Aklilu Lemma"
     />
   );
@@ -273,7 +273,7 @@ Add `export default` before the function definition like so:
 export default function Profile() {
   return (
     <img
-      src="https://i.imgur.com/lICfvbD.jpg"
+      src="https://i.imgur.com.prx.react.dev/lICfvbD.jpg"
       alt="Aklilu Lemma"
     />
   );
@@ -306,7 +306,7 @@ You may get an "Unexpected token" error while trying to fix this. In that case, 
 ```js
 export default function Profile() {
   return
-    <img src="https://i.imgur.com/jA8hHMpm.jpg" alt="Katsuko Saruhashi" />;
+    <img src="https://i.imgur.com.prx.react.dev/jA8hHMpm.jpg" alt="Katsuko Saruhashi" />;
 }
 ```
 
@@ -324,7 +324,7 @@ You can fix this component by moving the return statement to one line like so:
 
 ```js
 export default function Profile() {
-  return <img src="https://i.imgur.com/jA8hHMpm.jpg" alt="Katsuko Saruhashi" />;
+  return <img src="https://i.imgur.com.prx.react.dev/jA8hHMpm.jpg" alt="Katsuko Saruhashi" />;
 }
 ```
 
@@ -342,7 +342,7 @@ Or by wrapping the returned JSX markup in parentheses that open right after `ret
 export default function Profile() {
   return (
     <img 
-      src="https://i.imgur.com/jA8hHMpm.jpg" 
+      src="https://i.imgur.com.prx.react.dev/jA8hHMpm.jpg" 
       alt="Katsuko Saruhashi" 
     />
   );
@@ -367,7 +367,7 @@ Something's wrong with how the `Profile` component is declared and used. Can you
 function profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );
@@ -403,7 +403,7 @@ Change `function profile()` to `function Profile()`, and then change every `<pro
 function Profile() {
   return (
     <img
-      src="https://i.imgur.com/QIrZWGIs.jpg"
+      src="https://i.imgur.com.prx.react.dev/QIrZWGIs.jpg"
       alt="Alan L. Hart"
     />
   );

--- a/src/content/reference/react-dom/components/common.md
+++ b/src/content/reference/react-dom/components/common.md
@@ -795,7 +795,7 @@ import Avatar from './Avatar.js';
 
 const user = {
   name: 'Hedy Lamarr',
-  imageUrl: 'https://i.imgur.com/yXOvdOSs.jpg',
+  imageUrl: 'https://i.imgur.com.prx.react.dev/yXOvdOSs.jpg',
   imageSize: 90,
 };
 

--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -529,7 +529,7 @@ export default function Form() {
     artwork: {
       title: 'Blue Nana',
       city: 'Hamburg',
-      image: 'https://i.imgur.com/Sd1AgUOm.jpg',
+      image: 'https://i.imgur.com.prx.react.dev/Sd1AgUOm.jpg',
     }
   });
 


### PR DESCRIPTION
This PR redirects all Imgur-hosted assets to the official React documentation proxy: i.imgur.com.prx.react.dev.

Using this proxy ensures:
1.Reliability: Images are served through a domain managed for the documentation, bypassing regional blocks on the primary Imgur domain.
2.Zero-Change to Content: We do not need to manually re-host thousands of assets. The proxy handles the routing while keeping the original image IDs intact.
3.Consistency: This fix covers all 18 major tutorial and reference files, updating both helper functions like getImageUrl() and any hardcoded <img> tags.

Changes:
Updated i.imgur.com to i.imgur.com.prx.react.dev in all MDX files under src/content/learn/ and src/content/reference/.
Fixed helper utility functions in Sandpack interactive examples to use the proxy URL.
Verified that thumbnail size logic (e.g., s.jpg, b.jpg) remains functional through the proxy.