### PR TITLE
docs: change MutableRef to MutableRefObject in React 19 upgrade guide

### DIFF
--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -639,7 +639,7 @@ const ref = useRef<number>(null);
 ref.current = 1;
 ```
 
-`MutableRef` is now deprecated in favor of a single `RefObject` type which `useRef` will always return:
+`MutableRefObject` is now deprecated in favor of a single `RefObject` type which `useRef` will always return:
 
 ```ts
 interface RefObject<T> {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Super minor thing, but the old deprecated type was called `MutableRefObject`, not `MutableRef`.