### PR TITLE
docs: Update one of `You Might Not Need an Effect` examples

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -231,9 +231,9 @@ function List({ items }) {
   const [selection, setSelection] = useState(null);
 
   // Better: Adjust the state while rendering
-  const [prevItems, setPrevItems] = useState(items);
-  if (items !== prevItems) {
-    setPrevItems(items);
+  const prevItems = useRef(items);
+  if (items !== prevItems.current) {
+    prevItems.current = items;
     setSelection(null);
   }
   // ...


### PR DESCRIPTION
Using setState inherently causes another re-render on change, even if according to the value nothing changed. 
I think `useRef` would be more accurate.

I see the lint error on the changed example - but it might be overzealous, as we indeed don't want to re-render on its change.