### PR TITLE
Fix: Added react/jsv-dev-runtime to fakeRequire in compileMDX

### DIFF
--- a/src/utils/compileMDX.ts
+++ b/src/utils/compileMDX.ts
@@ -106,6 +106,8 @@ export default async function compileMDX(
   const fakeRequire = (name: string) => {
     if (name === 'react/jsx-runtime') {
       return require('react/jsx-runtime');
+    } else if (name === 'react/jsx-dev-runtime') {
+      return require('react/jsx-dev-runtime');
     } else {
       // For each fake MDX import, give back the string component name.
       // It will get serialized later.


### PR DESCRIPTION
Before the fix the compileMDX function was only handing 'react/jsx-runtime' imports but in dev mode Next.js use 'react/jsx-dev-runtime' which exports jsxDEV. This was causing a 'jsxDEV is not a function' error when running yarn dev. This fix adds handling for 'react/jsx-dev-runtime' to the fakeRequire function, resolving the development mode compilation error.
