### PR TITLE
Docs: use const for useRef click counter example

### DIFF
--- a/src/content/reference/react/useRef.md
+++ b/src/content/reference/react/useRef.md
@@ -112,7 +112,7 @@ This component uses a ref to keep track of how many times the button was clicked
 import { useRef } from 'react';
 
 export default function Counter() {
-  let ref = useRef(0);
+  const ref = useRef(0);
 
   function handleClick() {
     ref.current = ref.current + 1;


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!
Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Summary:
- Updated the useRef click counter example to use `const` instead of `let` for the ref variable.
- The ref object itself is never reassigned; only its `.current` property is mutated, which aligns better with JavaScript and React documentation best practices.
- This makes the example clearer and consistent with the guideline to prefer `const` when a binding does not change.

Test Plan:
- yarn dev

