### PR TITLE
Add getDerivedStateFromProps documentation for createClass (#1214)

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -1019,6 +1019,12 @@ Implementing `static getDerivedStateFromProps` in a class component is equivalen
 
 </Note>
 
+<Note>
+
+**Note:** The `static getDerivedStateFromProps` method can also be used with components created via the `createClass` API (using the [`create-react-class`](https://www.npmjs.com/package/create-react-class) package). This allows legacy codebases to adopt the newer lifecycle pattern.
+
+</Note>
+
 ---
 
 ## Usage {/*usage*/}


### PR DESCRIPTION
This PR adds documentation for using `getDerivedStateFromProps` with components created via the `createClass` API. This helps legacy codebases using the `create-react-class` package understand that they can adopt the newer lifecycle pattern.

The note has been added to the `static getDerivedStateFromProps` section in Component.md, explaining that this method can also be used with `createClass` components.

Closes #1214