### PR TITLE
Clarify that JSX braces require expressions (Fixes #8247)

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -197,6 +197,8 @@ return (
 );
 ```
 
+JSX curly braces expect **expressions**, not statements. This is why `if` runs in regular JavaScript *before* the returned JSX, while the result of that `if` (like `content`) is placed inside `{ }`. When you need to branch inline inside JSX, use an expression form such as the conditional (`? :`) operator.
+
 If you prefer more compact code, you can use the [conditional `?` operator.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) Unlike `if`, it works inside JSX:
 
 ```js


### PR DESCRIPTION
## Summary

Clarifies a potentially misleading explanation on `/learn` about conditionals in JSX.

JSX curly braces (`{}`) accept expressions, not statements. This can confuse beginners into thinking `if` "doesn't work in JSX", when the real issue is that `if` is a statement and must be used in regular JavaScript before returning JSX.

Fixes #8247

## What changed

- Updated `src/content/learn/index.md` in the Conditional rendering section.
- Added a short note explaining:
  - `{}` in JSX expects an expression
  - `if` is a statement, so it should run before `return` (e.g. assign JSX to a variable)
  - for inline branching inside JSX, use an expression form like `? :`

## Verification

- Checked `/learn` locally and confirmed the clarification reads naturally between the `if...else` example and the `? :` example.