### PR TITLE
Update logger example to account for `CompilerDiagnostic` in `CompilerError.details`

### DIFF
--- a/src/content/reference/react-compiler/logger.md
+++ b/src/content/reference/react-compiler/logger.md
@@ -102,8 +102,9 @@ Get specific information about compilation failures:
           console.error(`Details: ${event.detail.description}`);
         }
 
-        if (event.detail.loc) {
-          const { line, column } = event.detail.loc.start;
+        const loc = event.detail.primaryLocation?.() || event.detail.loc;
+        if (loc) {
+          const { line, column } = loc.start;
           console.error(`Location: Line ${line}, Column ${column}`);
         }
 


### PR DESCRIPTION
Disclaimer: I swear that this is not AI slop or any other kind of spam, but a real problem I encountered by following the current docs, which lead me to dig into the source code. 
I just want to correct the example so others have an easier time following the docs.

---

`event.detail` in the logger example could either be `CompilerErrorDetail` or `CompilerDiagnostic`, yet the example only handled the simpler (but deprecated) `CompilerErrorDetail`.
In reality, I've seen both of these show up in the `logger` function.

This adds a call to `primaryLocation` (if present) to account for the different structure of `CompilerDiagnostic` - `loc` is not present there.