### PR TITLE
docs: clarify conditional operator usage in JSX

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -197,7 +197,7 @@ return (
 );
 ```
 
-If you prefer more compact code, you can use the [conditional `?` operator.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) Unlike `if`, it works inside JSX:
+If you prefer more compact code, you can use the [conditional `?` operator.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator) Unlike `if`, it works inline inside JSX:
 
 ```js
 <div>


### PR DESCRIPTION
This PR improves the wording in the Learn > Quick Start section of the docs to clarify how conditional rendering works in JSX.

The previous text could be interpreted to mean that `if` cannot be used with JSX at all. This change clarifies that the conditional (`? :`) operator can be used *inline* inside JSX, which more accurately reflects how JSX expressions work.

Fixes #8247

