### PR TITLE
Clarify distinction between local and internal state references

### DIFF
--- a/src/content/learn/state-as-a-snapshot.md
+++ b/src/content/learn/state-as-a-snapshot.md
@@ -64,8 +64,10 @@ label, textarea { margin-bottom: 10px; display: block; }
 Here's what happens when you click the button:
 
 1. The `onSubmit` event handler executes.
-2. `setIsSent(true)` sets `isSent` to `true` and queues a new render.
+2. `setIsSent(true)` sets `isSent`<sup>*</sup> to `true` and queues a new render.
 3. React re-renders the component according to the new `isSent` value.
+
+<sup>*</sup> Note that only the `isSent` value stored within React's state manager is updated. The local component variable `isSent` does not change as it is a _copy of_ not a _reference to_ the internal state
 
 Let's take a closer look at the relationship between state and rendering.
 


### PR DESCRIPTION
## Motivation

Ambiguity in the docs. It says it updates `isSent`, but in the code example `isSent` is a local variable, and the local variable is not in fact updated. I'm not sure if my mental model accurately describes what's really going on, or if this is quite the right place for this suggestion, but I feel it's helpful to be clear that the local variable is not updated, and that React's internal, persistent `isSent` "variable" is what gets updated
