### PR TITLE
Refactor docs-contributors to use tables and fix punctuation

### DIFF
--- a/src/content/community/docs-contributors.md
+++ b/src/content/community/docs-contributors.md
@@ -4,39 +4,45 @@ title: Docs Contributors
 
 <Intro>
 
-React documentation is written and maintained by the [React team](/community/team) and [external contributors.](https://github.com/reactjs/react.dev/graphs/contributors) On this page, we'd like to thank a few people who've made significant contributions to this site.
+React documentation is written and maintained by the [React team](/community/team) and [external contributors](https://github.com/reactjs/react.dev/graphs/contributors). On this page, we'd like to thank a few people who've made significant contributions to this site.
 
 </Intro>
 
 ## Content {/*content*/}
 
-* [Rachel Nabors](https://twitter.com/RachelNabors): editing, writing, illustrating
-* [Dan Abramov](https://bsky.app/profile/danabra.mov): writing, curriculum design
-* [Sylwia Vargas](https://twitter.com/SylwiaVargas): example code
-* [Rick Hanlon](https://twitter.com/rickhanlonii): writing
-* [David McCabe](https://twitter.com/mcc_abe): writing
-* [Sophie Alpert](https://twitter.com/sophiebits): writing
-* [Pete Hunt](https://twitter.com/floydophone): writing
-* [Andrew Clark](https://twitter.com/acdlite): writing
-* [Matt Carroll](https://twitter.com/mattcarrollcode): editing, writing
-* [Natalia Tepluhina](https://twitter.com/n_tepluhina): reviews, advice
-* [Sebastian Markbåge](https://twitter.com/sebmarkbage): feedback
+| Contributor | Contributions |
+|---|---|
+| [Rachel Nabors](https://twitter.com/RachelNabors) | editing, writing, illustrating |
+| [Dan Abramov](https://bsky.app/profile/danabra.mov) | writing, curriculum design |
+| [Sylwia Vargas](https://twitter.com/SylwiaVargas) | example code |
+| [Rick Hanlon](https://twitter.com/rickhanlonii) | writing |
+| [David McCabe](https://twitter.com/mcc_abe) | writing |
+| [Sophie Alpert](https://twitter.com/sophiebits) | writing |
+| [Pete Hunt](https://twitter.com/floydophone) | writing |
+| [Andrew Clark](https://twitter.com/acdlite) | writing |
+| [Matt Carroll](https://twitter.com/mattcarrollcode) | editing, writing |
+| [Natalia Tepluhina](https://twitter.com/n_tepluhina) | reviews, advice |
+| [Sebastian Markbåge](https://twitter.com/sebmarkbage) | feedback |
 
 ## Design {/*design*/}
 
-* [Dan Lebowitz](https://twitter.com/lebo): site design
-* [Razvan Gradinar](https://dribbble.com/GradinarRazvan): sandbox design
-* [Maggie Appleton](https://maggieappleton.com/): diagram system
-* [Sophie Alpert](https://twitter.com/sophiebits): color-coded explanations
+| Contributor | Contributions |
+|---|---|
+| [Dan Lebowitz](https://twitter.com/lebo) | site design |
+| [Razvan Gradinar](https://dribbble.com/GradinarRazvan) | sandbox design |
+| [Maggie Appleton](https://maggieappleton.com/) | diagram system |
+| [Sophie Alpert](https://twitter.com/sophiebits) | color-coded explanations |
 
 ## Development {/*development*/}
 
-* [Jared Palmer](https://twitter.com/jaredpalmer): site development
-* [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)): site development
-* [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), [Danilo Woznica](https://twitter.com/danilowoz)): sandbox integration
-* [Dan Abramov](https://bsky.app/profile/danabra.mov): site development
-* [Rick Hanlon](https://twitter.com/rickhanlonii): site development
-* [Harish Kumar](https://www.strek.in/): development and maintenance
-* [Luna Ruan](https://twitter.com/lunaruan): sandbox improvements
+| Contributor | Contributions |
+|---|---|
+| [Jared Palmer](https://twitter.com/jaredpalmer) | site development |
+| [ThisDotLabs](https://www.thisdot.co/) ([Dane Grant](https://twitter.com/danecando), [Dustin Goodman](https://twitter.com/dustinsgoodman)) | site development |
+| [CodeSandbox](https://codesandbox.io/) ([Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), [Danilo Woznica](https://twitter.com/danilowoz)) | sandbox integration |
+| [Dan Abramov](https://bsky.app/profile/danabra.mov) | site development |
+| [Rick Hanlon](https://twitter.com/rickhanlonii) | site development |
+| [Harish Kumar](https://www.strek.in/) | development and maintenance |
+| [Luna Ruan](https://twitter.com/lunaruan) | sandbox improvements |
 
 We'd also like to thank countless alpha testers and community members who gave us feedback along the way.

--- a/src/content/community/index.md
+++ b/src/content/community/index.md
@@ -10,7 +10,7 @@ React has a community of millions of developers. On this page we've listed some 
 
 ## Code of Conduct {/*code-of-conduct*/}
 
-Before participating in React's communities, [please read our Code of Conduct.](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md) We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) and we expect that all community members adhere to the guidelines within.
+Before participating in React's communities, [please read our Code of Conduct](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md). We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/) and we expect that all community members adhere to the guidelines within.
 
 ## Stack Overflow {/*stack-overflow*/}
 


### PR DESCRIPTION
## Summary
This PR significantly refactors the layout of the [docs-contributors.md](cci:7://file:///c:/Users/Dell/Desktop/react.dev/src/content/community/docs-contributors.md:0:0-0:0) page to enhance visual clarity and consistency. It moves away from simple bulleted lists to structured Markdown tables, allowing for a clearer separation between contributors and their specific contributions. Additionally, it addresses minor punctuation inconsistencies found in the community documentation to align with standard grammar usage.

## Detailed Changes

### 1. Structural Improvements to [docs-contributors.md](cci:7://file:///c:/Users/Dell/Desktop/react.dev/src/content/community/docs-contributors.md:0:0-0:0)
The main focus of this PR is transforming the "Content", "Design", and "Development" sections.
- **Before:** Contributor names and their roles were listed in a single line (e.g., `* [Name](link): role`), which could become cluttered and hard to scan, especially for entries with multiple contributors or long role descriptions.
- **After:** These lists have been converted into **Markdown tables** with two distinct columns:
    - **Contributor:** Contains the linked name(s) of the person or organization.
    - **Contributions:** clearly lists their specific roles (e.g., "writing", "sandbox design").
- **Benefit:** This tabular format improves readability, makes the data easier to scan, and provides a more professional appearance for acknowledging community contributions.

### 2. Punctuation & Grammar Fixes
- **[src/content/community/docs-contributors.md](cci:7://file:///c:/Users/Dell/Desktop/react.dev/src/content/community/docs-contributors.md:0:0-0:0)**: Corrected the placement of a closing period in the introduction paragraph. The period was previously included inside the link text (e.g., `[link.]`), and has been moved outside (e.g., `[link].`) to follow standard Markdown and grammatical conventions.
- **[src/content/community/index.md](cci:7://file:///c:/Users/Dell/Desktop/react.dev/src/content/community/index.md:0:0-0:0)**: Applied the same fix to the "Code of Conduct" link in the introduction, ensuring the period is placed correctly outside the hyperlink keyoword.

## Motivation
As the community documentation grows, maintaining a clean and structured layout is essential. The switch to tables provides a scalable way to present contributor information that is visually distinct from standard text content. Standardizing punctuation ensures a polished and consistent reading experience across the documentation site.