### PR TITLE
Add React Norway 2026 conference to community page

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -67,6 +67,11 @@ April 14-17,  2026. In-person in London
 
 [Website](https://india.cityjsconf.org/) - [Twitter](https://x.com/cityjsconf) - [Bluesky](https://bsky.app/profile/cityjsconf.bsky.social)
 
+### React Norway 2026 {/*react-norway-2026*/}
+June 5, 2026. Rockefeller, Oslo, Norway.
+
+[Website](https://reactnorway.com/) - [Twitter](https://x.com/ReactNorway)
+
 
 ## Past Conferences {/*past-conferences*/}
 


### PR DESCRIPTION
Hello team,

Just adding the amazing React Norway 2026 that is coming up on June 5th, 2026, at the Rockefeller in Oslo.

Thanks!
