### PR TITLE
Accept header negotiation beforeFiles

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,26 +20,28 @@ const nextConfig = {
     reactCompiler: true,
   },
   async rewrites() {
-    return [
-      // Serve markdown when Accept header prefers text/markdown
-      // Useful for LLM agents - https://www.skeptrune.com/posts/use-the-accept-header-to-serve-markdown-instead-of-html-to-llms/
-      {
-        source: '/:path*',
-        has: [
-          {
-            type: 'header',
-            key: 'accept',
-            value: '(.*text/markdown.*)',
-          },
-        ],
-        destination: '/api/md/:path*',
-      },
-      // Explicit .md extension also serves markdown
-      {
-        source: '/:path*.md',
-        destination: '/api/md/:path*',
-      },
-    ];
+    return {
+      beforeFiles: [
+        // Serve markdown when Accept header prefers text/markdown
+        // Useful for LLM agents - https://www.skeptrune.com/posts/use-the-accept-header-to-serve-markdown-instead-of-html-to-llms/
+        {
+          source: '/:path((?!llms.txt).*)',
+          has: [
+            {
+              type: 'header',
+              key: 'accept',
+              value: '(.*text/markdown.*)',
+            },
+          ],
+          destination: '/api/md/:path*',
+        },
+        // Explicit .md extension also serves markdown
+        {
+          source: '/:path*.md',
+          destination: '/api/md/:path*',
+        },
+      ],
+    };
   },
   env: {},
   webpack: (config, {dev, isServer, ...options}) => {


### PR DESCRIPTION
On the deployed version, the rewrite has to be declared to happen `beforeFiles`. 

You can try this the fix out here: https://react-dev-sepia.vercel.app/ - I'll tear the link/project down after this lands.

```
# 1. Normal page request (should return HTML)
curl -s https://react-dev-sepia.vercel.app/learn/thinking-in-react | head -5

# 2. With Accept: text/markdown (should return markdown)
curl -s -L -H "Accept: text/markdown" https://react-dev-sepia.vercel.app/learn/thinking-in-react | head -15

# 3. Explicit .md extension (should return markdown)
curl -s https://react-dev-sepia.vercel.app/learn/thinking-in-react.md | head -15

# 4. /llms.txt normal (should return sitemap)
curl -s https://react-dev-sepia.vercel.app/llms.txt | head -10

# 5. /llms.txt with Accept: text/markdown (should still return sitemap)
curl -s -L -H "Accept: text/markdown" https://react-dev-sepia.vercel.app/llms.txt | head -10
```