### PR TITLE
fix: correct typos and improve clarity in useOptimistic.md

### DIFF
--- a/src/content/reference/react/useOptimistic.md
+++ b/src/content/reference/react/useOptimistic.md
@@ -110,7 +110,7 @@ This state is called the "optimistic" because it is used to immediately present 
 
 4. **(Optional) wait for Suspense**: If `newValue` suspends, React continues showing `'b'`.
 
-5. **Single render commit**: Finally, the `newValue` is commits for `value` and `optimistic`.
+5. **Single render commit**: Finally, the `newValue` commits for `value` and `optimistic`.
 
 There's no extra render to "clear" the optimistic state. The optimistic and real state converge in the same render when the Transition completes.
 
@@ -118,7 +118,7 @@ There's no extra render to "clear" the optimistic state. The optimistic and real
 
 #### Optimistic state is temporary {/*optimistic-state-is-temporary*/}
 
-Optimistic state is only renders while an Action is in progress, otherwise `value` is rendered.
+Optimistic state only renders while an Action is in progress, otherwise `value` is rendered.
 
 If `saveChanges` returned `'c'`, then both `value` and `optimistic` will be `'c'`, not `'b'`.
 
@@ -403,7 +403,7 @@ export default function App() {
   }
 
   if (optimisticIsLiked !== isLiked) {
-    console.log('✅ rendering optmistic state: ' + optimisticIsLiked);  
+    console.log('✅ rendering optimistic state: ' + optimisticIsLiked);  
   } else {
     console.log('✅ rendering real value: ' + optimisticIsLiked);
   }
@@ -1071,7 +1071,7 @@ startTransition(() => {
 })
 ```
 
-Since `useTransition` uses `useOptimsitic` for `isPending` under the hood, this is equivalent to option 1.
+Since `useTransition` uses `useOptimistic` for `isPending` under the hood, this is equivalent to option 1.
 
 3. **Add a `pending` flag in your reducer**
 


### PR DESCRIPTION
I found a formatting typo in the `useOptimistic`docs, in the [troubleshooting](https://react.dev/reference/react/useOptimistic#i-dont-know-if-my-optimistic-update-is-pending) section. While fixing it, I noticed also that there was no explanatory sentence below example 3 of "I don’t know if my optimistic update is pending", so I added one, following the pattern of examples 1 and 2.

This sort of typo could have been caught by an AI PR reviewer like GH Copilot - might be worth using in the future. Claude found some more typos, actually, I pushed those too.