### PR TITLE
Added 'the' to make it more clear

### DIFF
--- a/src/content/reference/rsc/use-server.md
+++ b/src/content/reference/rsc/use-server.md
@@ -64,7 +64,7 @@ See [experimental_taintUniqueValue](/reference/react/experimental_taintUniqueVal
 
 Since client code calls the Server Function over the network, any arguments passed will need to be serializable.
 
-Here are supported types for Server Function arguments:
+Here are the supported types for Server Function arguments:
 
 * Primitives
 	* [string](https://developer.mozilla.org/en-US/docs/Glossary/String)


### PR DESCRIPTION
Listing a defined set, probably better to have 'the' to be more specific and clear