### PR TITLE
Vary accept header for markdown

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,14 @@ const nextConfig = {
     scrollRestoration: true,
     reactCompiler: true,
   },
+  async headers() {
+    return [
+      {
+        source: '/:path((?!llms.txt).*)',
+        headers: [{key: 'Vary', value: 'Accept'}],
+      },
+    ];
+  },
   async rewrites() {
     return {
       beforeFiles: [


### PR DESCRIPTION
Since this site is deployed to Vercel then:

- https://vercel.com/docs/cdn-cache#use-cases

> Vercel's CDN already includes the Accept and Accept-Encoding headers as part of the cache key by default. You do not need to explicitly include these headers in your Vary header.

However, if you go to https://react.dev/reference/react and do:

```js
fetch(window.location.href, {headers: {
    accept:'text/markdown'
}}).then(res=>res.text()).then(console.log)
```

And follow that with:

```js
fetch(window.location.href).then(res=>res.text()).then(console.log)
```

You'll see that both return markdown. The network tab shows that the latter is read from disk. Reloading the page fetches fresh. This PR fixes that edge case, but in general, I think it is a good idea to be explicit about the Accept header being part of the cache key.

Deployment with this addition: https://react-dev-plum.vercel.app/learn - compare to what happens on react.dev 

@rickhanlonii 🙏