### PR TITLE
Fix date of CVE-2026-23864 (2025 => 2026)

### DIFF
--- a/src/content/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components.md
+++ b/src/content/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components.md
@@ -106,7 +106,7 @@ See [this issue](https://github.com/facebook/react-native/issues/54772#issuecomm
 
 **CVEs:** [CVE-2026-23864](https://www.cve.org/CVERecord?id=CVE-2026-23864)
 **Base Score:** 7.5 (High)
-**Date**: January 26, 2025
+**Date**: January 26, 2026
 
 Security researchers discovered additional DoS vulnerabilities still exist in React Server Components.
 


### PR DESCRIPTION
This PR fixes the release date of CVE-2026-23864 in the latest blog post.

❌: January 26, 202**5**
✅: January 26, 202**6**

CC @rickhanlonii 