### PR TITLE
Fix effect event name on useEffectEvent reference docs

### DIFF
--- a/src/content/reference/react/useEffectEvent.md
+++ b/src/content/reference/react/useEffectEvent.md
@@ -105,7 +105,7 @@ useEffect(() => {
 }, [roomId]);
 ```
 
-Since `onConnected` is an <CodeStep step={1}>Effect Event</CodeStep>, `muted` and `onConnect` are not in the Effect dependencies.
+Since `onConnected` is an <CodeStep step={1}>Effect Event</CodeStep>, `muted` and `onConnected` are not in the Effect dependencies.
 
 <Pitfall>
 


### PR DESCRIPTION
Yesterday, I was going through the reference docs of 'useEffectEvent' hook and found that there is a misspelling in the name of one of the effect event functions. I have done the correction and I'm providing the screenshots below, please let me know if I'm missing something here. Thanks!

Before:
 
<img width="1792" height="813" alt="Screenshot 2026-02-12 at 10 49 09 AM" src="https://github.com/user-attachments/assets/be905be1-49ed-4b4a-bbb8-14d6555b1989" />

.
.
.

After:

<img width="1792" height="813" alt="Screenshot 2026-02-12 at 10 53 38 AM" src="https://github.com/user-attachments/assets/2037dc60-799d-4f48-a832-4f5b8a13a718" />

