### PR TITLE
Fix typo in Fragment docs

### DIFF
--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -252,8 +252,8 @@ import { Fragment } from 'react';
 function ClickableFragment({ children, onClick }) {
   return (
     <Fragment ref={fragmentInstance => {
-      fragmentInstance.addEventListener('click', handleClick);
-      return () => fragmentInstance.removeEventListener('click', handleClick);
+      fragmentInstance.addEventListener('click', onClick);
+      return () => fragmentInstance.removeEventListener('click', onClick);
     }}>
       {children}
     </Fragment>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

`handleClick` does not reference anything, `onClick` was most likely the original intention.
