### PR TITLE
[docs] [Typo]: The code example on the "useContext" page includes an unused import `useContext`

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -826,7 +826,7 @@ const initialTasks = [
 ```
 
 ```js src/AddTask.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasksDispatch } from './TasksContext.js';
 
 export default function AddTask() {
@@ -855,7 +855,7 @@ let nextId = 3;
 ```
 
 ```js src/TaskList.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasks, useTasksDispatch } from './TasksContext.js';
 
 export default function TaskList() {


### PR DESCRIPTION
Fix: remove unused `useContext` import in the "Scaling up with context and a reducer" example on the useContext docs page.

This is a small docs-only cleanup (no behavior changes).

Closes #8186.