### PR TITLE
Add Chen-the-Dawnstreak to Creating a React App

### DIFF
--- a/src/content/learn/creating-a-react-app.md
+++ b/src/content/learn/creating-a-react-app.md
@@ -65,6 +65,7 @@ There are other up-and-coming frameworks that are working towards our full stack
 
 - [TanStack Start (Beta)](https://tanstack.com/start/): TanStack Start is a full-stack React framework powered by TanStack Router. It provides a full-document SSR, streaming, server functions, bundling, and more using tools like Nitro and Vite.
 - [RedwoodSDK](https://rwsdk.com/): Redwood is a full stack React framework with lots of pre-installed packages and configuration that makes it easy to build full-stack web applications.
+- [Chen-the-Dawnstreak](https://www.npmjs.com/package/chen-the-dawnstreak): Chen-the-Dawnstreak is a React 19+ framework that provides typed wrappers for all 46 [MDUI](https://www.mdui.org/) (Material Design UI) Web Components, with built-in routing, data-fetching hooks, state management, SSR, a Vite plugin with file-based routing and PWA support, and a CLI scaffolding tool. To create a new project, run `npx chen-the-dawnstreak my-app` (note: the shorter alias `npx chen` may conflict with other packages).
 
 <DeepDive>
 


### PR DESCRIPTION
## Summary

- Add [Chen-the-Dawnstreak](https://www.npmjs.com/package/chen-the-dawnstreak) to the "Other frameworks" section on the Creating a React App page
- Chen-the-Dawnstreak is a React 19+ framework providing typed wrappers for all 46 [MDUI](https://www.mdui.org/) (Material Design UI) Web Components, with built-in routing, data-fetching hooks, state management, SSR support, a Vite plugin (file-based routing + PWA), and a CLI scaffolding tool
- Notes that the shorter CLI alias `npx chen` may conflict with other packages, recommending `npx chen-the-dawnstreak` instead

## Test plan

- [ ] Verify the npm link resolves to the correct package
- [ ] Verify the markdown renders correctly on the page
- [ ] Verify the MDUI link resolves to the correct site

🤖 Generated with [Claude Code](https://claude.com/claude-code)