### PR TITLE
add `the` before yarn website

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains the source code and documentation powering [react.dev](https:
 
 1. Git
 1. Node: any version starting with v16.8.0 or greater
-1. Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
+1. Yarn: See the [ Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
 1. A fork of the repo (for any contributions)
 1. A clone of the [react.dev repo](https://github.com/reactjs/react.dev) on your local machine
 


### PR DESCRIPTION
### Summary
Fixed typos and formatting issues in the contributing guide (README.md) for clarity and readability.