### PR TITLE
Prevent MovingDot scroll expansion in Updating Objects in State

### DIFF
--- a/src/content/learn/updating-objects-in-state.md
+++ b/src/content/learn/updating-objects-in-state.md
@@ -73,6 +73,7 @@ export default function MovingDot() {
         position: 'relative',
         width: '100vw',
         height: '100vh',
+        overflow: 'hidden',
       }}>
       <div style={{
         position: 'absolute',
@@ -146,6 +147,7 @@ export default function MovingDot() {
         position: 'relative',
         width: '100vw',
         height: '100vh',
+        overflow: 'hidden',
       }}>
       <div style={{
         position: 'absolute',


### PR DESCRIPTION
## Summary

The MovingDot example on Updating Objects in State causes the white box to “grow” as the dot moves toward the bottom edge. It is the second codebox here: https://react.dev/learn/updating-objects-in-state#treat-state-as-read-only.

### Current:
![current](https://github.com/user-attachments/assets/8fedfeab-bd9f-4bbb-9221-266b613133fb)

### After:
![after](https://github.com/user-attachments/assets/34ddcad8-9e63-41ad-8a0e-536d83a127f7)


