### PR TITLE
add: Nagpur to the list of React meetups

### DIFF
--- a/src/content/community/meetups.md
+++ b/src/content/community/meetups.md
@@ -90,7 +90,7 @@ Do you have a local React.js meetup? Add it here! (Please keep the list alphabet
 * [Mumbai](https://reactmumbai.dev)
 * [Pune](https://www.meetup.com/ReactJS-and-Friends/)
 * [Rajasthan](https://reactrajasthan.com)
-* [Nagpur](https://bit.ly/react-nagpur)
+* [Nagpur](https://reactnagpur.live)
 
 
 ## Indonesia {/*indonesia*/}


### PR DESCRIPTION
Adding the React Community for Nagpur, India. Updated the link now to [`reactnagpur.live`](https://reactnagpur.live)
Previously, PR was closed due to a bitly link. #8001 