### PR TITLE
docs: Add hyperlink to experimental_taintObjectReference

### DIFF
--- a/src/content/reference/react/experimental_taintObjectReference.md
+++ b/src/content/reference/react/experimental_taintObjectReference.md
@@ -15,7 +15,7 @@ You can try it by upgrading React packages to the most recent experimental versi
 
 Experimental versions of React may contain bugs. Don't use them in production.
 
-This API is only available inside React Server Components.
+This API is only available inside [React Server Components](/reference/rsc/use-client).
 
 </Experimental>
 


### PR DESCRIPTION
### Description

Aligns experimental_taintObjectReference.md with experimental_taintUniqueValue.mdby adding a missing hyperlink to the React Server Components documentation.

### Changes

Added link to /reference/rsc/use-client in the experimental notice of experimental_taintObjectReference.md