### PR TITLE
Update conferences: move past events (Sep 2025 – Feb 2026) to Past section

### DIFF
--- a/src/content/community/conferences.md
+++ b/src/content/community/conferences.md
@@ -15,7 +15,6 @@ March 26 - 27, 2026. In-person in Paris, France (hybrid event)
 
 [Website](https://react.paris/) - [Twitter](https://x.com/BeJS_)
 
-
 ### CityJS London 2026 {/*cityjs-london-2026*/}
 April 14-17,  2026. In-person in London
 


### PR DESCRIPTION
Update conferences list for March 2026
Moves conferences that have already occurred from "Upcoming" to "Past":

<img width="1258" height="764" alt="image" src="https://github.com/user-attachments/assets/af425c3f-9e30-4b25-be2f-fb61850604f8" />

No content was added or removed — only moved between sections. Past conferences are listed in reverse chronological order.

@rickhanlonii 