### PR TITLE
Fix broken internal link in Component reference (anchor)

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -1009,7 +1009,7 @@ Deriving state leads to verbose code and makes your components difficult to thin
 
 #### Caveats {/*static-getderivedstatefromprops-caveats*/}
 
-- This method is fired on *every* render, regardless of the cause. This is different from [`UNSAFE_componentWillReceiveProps`](#unsafe_cmoponentwillreceiveprops), which only fires when the parent causes a re-render and not as a result of a local `setState`.
+- This method is fired on *every* render, regardless of the cause. This is different from [`UNSAFE_componentWillReceiveProps`](#unsafe_componentwillreceiveprops), which only fires when the parent causes a re-render and not as a result of a local `setState`.
 
 - This method doesn't have access to the component instance. If you'd like, you can reuse some code between `static getDerivedStateFromProps` and the other class methods by extracting pure functions of the component props and state outside the class definition.
 


### PR DESCRIPTION
Fix incorrect anchor reference in Component API section.

- The internal link targeting the UNSAFE_componentWillReceiveProps section in Component.md referenced an incorrect anchor: #unsafe_cmoponentwillreceiveprops, which prevented the link from resolving to the intended heading.
- This change updates the anchor to #unsafe_componentwillreceiveprops, aligning it with the heading slug generated by the markdown renderer and restoring proper in-page navigation.