### PR TITLE
fix(react-legacy-reference): normalize reference URL paths and correct render description

### DIFF
--- a/src/content/reference/react/legacy.md
+++ b/src/content/reference/react/legacy.md
@@ -19,7 +19,7 @@ These APIs are exported from the `react` package, but they are not recommended f
 * [`createRef`](/reference/react/createRef) creates a ref object which can contain arbitrary value. [See alternatives.](/reference/react/createRef#alternatives)
 * [`forwardRef`](/reference/react/forwardRef) lets your component expose a DOM node to parent component with a [ref.](/learn/manipulating-the-dom-with-refs)
 * [`isValidElement`](/reference/react/isValidElement) checks whether a value is a React element. Typically used with [`cloneElement`.](/reference/react/cloneElement)
-* [`PureComponent`](/reference/react/PureComponent) is similar to [`Component`,](/reference/react/Component) but it skip re-renders with same props. [See alternatives.](/reference/react/PureComponent#alternatives)
+* [`PureComponent`](/reference/react/PureComponent) is similar to [`Component`,](/reference/react/Component) but it skips re-renders with same props. [See alternatives.](/reference/react/PureComponent#alternatives)
 
 ---
 
@@ -28,8 +28,8 @@ These APIs are exported from the `react` package, but they are not recommended f
 These APIs were removed in React 19:
 
 * [`createFactory`](https://18.react.dev/reference/react/createFactory): use JSX instead.
-* Class Components: [`static contextTypes`](https://18.react.dev//reference/react/Component#static-contexttypes): use [`static contextType`](#static-contexttype) instead.
-* Class Components: [`static childContextTypes`](https://18.react.dev//reference/react/Component#static-childcontexttypes): use [`static contextType`](#static-contexttype) instead.
-* Class Components: [`static getChildContext`](https://18.react.dev//reference/react/Component#getchildcontext): use [`Context`](/reference/react/createContext#provider) instead.
-* Class Components: [`static propTypes`](https://18.react.dev//reference/react/Component#static-proptypes): use a type system like [TypeScript](https://www.typescriptlang.org/) instead.
-* Class Components: [`this.refs`](https://18.react.dev//reference/react/Component#refs): use [`createRef`](/reference/react/createRef) instead.
+* Class Components: [`static contextTypes`](https://18.react.dev/reference/react/Component#static-contexttypes): use [`static contextType`](#static-contexttype) instead.
+* Class Components: [`static childContextTypes`](https://18.react.dev/reference/react/Component#static-childcontexttypes): use [`static contextType`](#static-contexttype) instead.
+* Class Components: [`static getChildContext`](https://18.react.dev/reference/react/Component#getchildcontext): use [`Context`](/reference/react/createContext#provider) instead.
+* Class Components: [`static propTypes`](https://18.react.dev/reference/react/Component#static-proptypes): use a type system like [TypeScript](https://www.typescriptlang.org/) instead.
+* Class Components: [`this.refs`](https://18.react.dev/reference/react/Component#refs): use [`createRef`](/reference/react/createRef) instead.


### PR DESCRIPTION
Correct reference URL paths and render description in `legacy.md`.

## Changes

- **Normalize reference URLs**
  - Several links pointing to `18.react.dev` used a double slash in the path (e.g. `https://18.react.dev//reference/...`).
  - Updated them to the canonical form `https://18.react.dev/reference/...` to maintain consistent URL structure.

- **Correct render behavior description**
  - The sentence describing `PureComponent` behavior used `it skip re-renders`.
  - Updated it to `it skips re-renders` to correctly describe the render behavior.