### PR TITLE
docs: fix typo in useContext reference

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -1366,7 +1366,7 @@ You might have a provider without a `value` in the tree:
 
 If you forget to specify `value`, it's like passing `value={undefined}`.
 
-You may have also mistakingly used a different prop name by mistake:
+You may have also mistakenly used a different prop name by mistake:
 
 ```js {1,2}
 // 🚩 Doesn't work: prop should be called "value"


### PR DESCRIPTION
## Summary\n- Fix a spelling typo in the useContext reference.\n\n## Related issue\n- N/A\n\n## Guideline alignment\n- https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md\n\n## Validation/testing\n- Not run (docs-only).