### PR TITLE
fix: correct comment unit from 500s to 500ms in Preview bundler listener

### DIFF
--- a/src/components/MDX/Sandpack/Preview.tsx
+++ b/src/components/MDX/Sandpack/Preview.tsx
@@ -121,7 +121,7 @@ export function Preview({
           /**
            * The spinner component transition might be longer than
            * the bundler loading, so we only show the spinner if
-           * it takes more than 500s to load the bundler.
+           * it takes more than 500ms to load the bundler.
            */
           timeout = setTimeout(() => {
             setShowLoading(true);


### PR DESCRIPTION
## Summary

Fix a factual error in an inline comment inside `Preview.tsx`.

### Changes

The comment described the spinner delay as `"500s"` (seconds), but the
actual `setTimeout` delay is `500` milliseconds. The `setTimeout` Web API
always receives its delay in milliseconds, so `500` equals 0.5 seconds —
not 500 seconds.

\```diff
- * it takes more than 500s to load the bundler.
+ * it takes more than 500ms to load the bundler.
\```

## Validation

- Docs-only change (comment inside source file).
- No runtime behavior changed.
- `yarn tsc` passes.