### PR TITLE
Docs async react hooks

### DIFF
--- a/src/content/reference/react/hooks.md
+++ b/src/content/reference/react/hooks.md
@@ -112,17 +112,11 @@ To prioritize rendering, use one of these Hooks:
 
 Async React lets you build responsive apps by running asynchronous work inside Actions. These hooks help manage UI updates during asynchronous operations and allow React to keep the interface responsive while work is being processed.
 
-### useTransition {/*usetransition*/}
+To manage asynchronous updates, use one of these Hooks:
 
-Lets you mark state updates as non-blocking so the UI stays responsive while they run.
-
-### useActionState {/*useactionstate*/}
-
-Lets you update state from an Action, commonly used for form submissions or async reducers.
-
-### useOptimistic {/*useoptimistic*/}
-
-Lets you show a temporary UI state while an Action is running.
+- [`useTransition`](/reference/react/useTransition) lets you mark state updates as non-blocking so the UI stays responsive while they run.
+- [`useActionState`](/reference/react/useActionState) lets you update state from an Action, commonly used for form submissions or async reducers.
+- [`useOptimistic`](/reference/react/useOptimistic) lets you show a temporary UI state while an Action is running.
 
 ---
 


### PR DESCRIPTION
**Description**:

Update the Hooks reference page to introduce a new **Async React Hooks** section.

This groups together async-related hooks to better reflect React 19 patterns around Actions and improve discoverability of related APIs.

Changes:
* Add a new **Async React Hooks** section on the Hooks reference page
* Group `useTransition`, `useActionState`, and `useOptimistic` under this section
* Remove `useActionState` from the **Other Hooks** section to avoid duplication
* Follow the existing hooks index format using bullet links and short descriptions

**Related issue(s)**:

Fixes #8316 

**Notes for reviewer**:

The change is localized to the Hooks reference page and follows the existing documentation structure.  
No hook behavior or API documentation was modified—only the organization of the hooks index page.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)