### PR TITLE
fix: add sourceMaps: true to vite-plugin-babel config examples

### DIFF
--- a/src/content/learn/react-compiler/installation.md
+++ b/src/content/learn/react-compiler/installation.md
@@ -88,7 +88,7 @@ Alternatively, if you prefer a separate Babel plugin for Vite:
 npm install -D vite-plugin-babel
 </TerminalBlock>
 
-```js {2,11}
+```js {2,11-12}
 // vite.config.js
 import babel from 'vite-plugin-babel';
 import { defineConfig } from 'vite';
@@ -99,6 +99,7 @@ export default defineConfig({
     react(),
     babel({
       babelConfig: {
+        sourceMaps: true,
         plugins: ['babel-plugin-react-compiler'],
       },
     }),
@@ -117,7 +118,7 @@ Install `vite-plugin-babel`, and add the compiler's Babel plugin to it:
 npm install vite-plugin-babel
 </TerminalBlock>
 
-```js {3-4,16}
+```js {3-4,14,16}
 // vite.config.js
 import { defineConfig } from "vite";
 import babel from "vite-plugin-babel";
@@ -131,6 +132,7 @@ export default defineConfig({
     babel({
       filter: /\.[jt]sx?$/,
       babelConfig: {
+        sourceMaps: true,
         presets: ["@babel/preset-typescript"], // if you use TypeScript
         plugins: [
           ["babel-plugin-react-compiler", ReactCompilerConfig],


### PR DESCRIPTION
Fixes #8215

The vite-plugin-babel configuration examples were missing sourceMaps: true in babelConfig, causing broken sourcemaps when debugging React Compiler-optimized components.

Updated both the Vite alternative setup and React Router sections to include the missing option.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Summary

Adds `sourceMaps: true` to the `babelConfig` in both the Vite
alternative setup and React Router installation examples.

## Problem

When using `vite-plugin-babel` with React Compiler, the current
docs omit `sourceMaps: true` from the Babel configuration. This
causes sourcemaps to include React Compiler-optimized code paths
instead of the original source, making debugging significantly
harder.

Reproduction: https://github.com/andrew-locklair-fs/react-vite-compiler-repro

## Fix

Added `sourceMaps: true` to `babelConfig` in:
1. **Vite** section — alternative `vite-plugin-babel` example
2. **React Router** section — `vite-plugin-babel` example

Fixes #8215