### PR TITLE
fix: prevent wrapping in uwu mode footer links

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -746,10 +746,14 @@ ol.mdx-illustration-block {
 }
 .uwu-hidden {
   display: flex;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .uwu .uwu-visible {
   display: flex;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .uwu .uwu-hidden {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
