### PR TITLE
docs: Update Vite React Compiler setup for @vitejs/plugin-react@6.0.0

### DIFF
--- a/src/content/learn/react-compiler/installation.md
+++ b/src/content/learn/react-compiler/installation.md
@@ -64,9 +64,32 @@ module.exports = {
 
 ### Vite {/*vite*/}
 
-If you use Vite, you can add the plugin to vite-plugin-react:
+If you use Vite with version 6.0.0 or later of `@vitejs/plugin-react`, you can use the `reactCompilerPreset`:
 
-```js {3,9}
+<TerminalBlock>
+npm install -D @rolldown/plugin-babel
+</TerminalBlock>
+
+```js {3-4,9-11}
+// vite.config.js
+import { defineConfig } from 'vite';
+import react, { reactCompilerPreset } from '@vitejs/plugin-react';
+import babel from '@rolldown/plugin-babel';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    babel({
+      presets: [reactCompilerPreset()]
+    }),
+  ],
+});
+```
+
+<Note>
+In `@vitejs/plugin-react@6.0.0`, the inline Babel option was removed. If you're using an older version, you can use:
+
+```js
 // vite.config.js
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -81,26 +104,21 @@ export default defineConfig({
   ],
 });
 ```
+</Note>
 
-Alternatively, if you prefer a separate Babel plugin for Vite:
+Alternatively, you can use the Babel plugin directly with `@rolldown/plugin-babel`:
 
-<TerminalBlock>
-npm install -D vite-plugin-babel
-</TerminalBlock>
-
-```js {2,11}
+```js {3,9}
 // vite.config.js
-import babel from 'vite-plugin-babel';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import babel from '@rolldown/plugin-babel';
 
 export default defineConfig({
   plugins: [
     react(),
     babel({
-      babelConfig: {
-        plugins: ['babel-plugin-react-compiler'],
-      },
+      plugins: ['babel-plugin-react-compiler'],
     }),
   ],
 });

--- a/src/content/reference/react/useOptimistic.md
+++ b/src/content/reference/react/useOptimistic.md
@@ -83,7 +83,7 @@ function handleClick() {
 
 #### How optimistic state works {/*how-optimistic-state-works*/}
 
-`useOptimistic` lets you show a temporary value while a Action is in progress:
+`useOptimistic` lets you show a temporary value while an Action is in progress:
 
 ```js
 const [value, setValue] = useState('a');


### PR DESCRIPTION
## Summary

This PR updates the Vite React Compiler setup instructions to work with `@vitejs/plugin-react@6.0.0`, which removed the inline Babel option.

## Changes

- Add instructions for using `reactCompilerPreset` with `@rolldown/plugin-babel`
- Document that the inline babel option was removed in version 6.0.0
- Keep backward compatibility note for users with older versions
- Provide alternative approach using Babel plugin directly
- Remove outdated `vite-plugin-babel` reference

## Testing

Documentation only change.

## Related Issue

Fixes #8353

## References

- [Vite Plugin React@6.0.0 changelog](https://github.com/vitejs/vite-plugin-react/releases/tag/plugin-react%406.0.0)
- [Vite Plugin React README - React Compiler](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#react-compiler)
