### PR TITLE
docs: remove unsupported topic from React Compiler introduction

### DIFF
--- a/src/content/learn/react-compiler/introduction.md
+++ b/src/content/learn/react-compiler/introduction.md
@@ -12,7 +12,6 @@ React Compiler is a new build-time tool that automatically optimizes your React 
 * Getting started with the compiler
 * Incremental adoption strategies
 * Debugging and troubleshooting when things go wrong
-* Using the compiler on your React library
 
 </YouWillLearn>
 


### PR DESCRIPTION
Fixes #8387

Removes “Using the compiler on your React library” from the “You will learn” section on the React Compiler Introduction page because this topic is not actually covered on the page.

This fixes the mismatch between the page summary and the documented content.