### PR TITLE
Capitalize "Actions" as a React concept in documentation

### DIFF
--- a/src/content/reference/react/hooks.md
+++ b/src/content/reference/react/hooks.md
@@ -116,7 +116,7 @@ These Hooks are mostly useful to library authors and aren't commonly used in the
 - [`useDebugValue`](/reference/react/useDebugValue) lets you customize the label React DevTools displays for your custom Hook.
 - [`useId`](/reference/react/useId) lets a component associate a unique ID with itself. Typically used with accessibility APIs.
 - [`useSyncExternalStore`](/reference/react/useSyncExternalStore) lets a component subscribe to an external store.
-* [`useActionState`](/reference/react/useActionState) allows you to manage state of actions.
+* [`useActionState`](/reference/react/useActionState) allows you to manage state of Actions.
 
 ---
 

--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -6,7 +6,7 @@ title: Server Functions
 
 Server Functions are for use in [React Server Components](/reference/rsc/server-components).
 
-**Note:** Until September 2024, we referred to all Server Functions as "Server Actions". If a Server Function is passed to an action prop or called from inside an action then it is a Server Action, but not all Server Functions are Server Actions. The naming in this documentation has been updated to reflect that Server Functions can be used for multiple purposes.
+**Note:** Until September 2024, we referred to all Server Functions as "Server Actions". If a Server Function is passed to an action prop or called from inside an Action then it is a Server Action, but not all Server Functions are Server Actions. The naming in this documentation has been updated to reflect that Server Functions can be used for multiple purposes.
 
 </RSC>
 


### PR DESCRIPTION
## Summary
Capitalizes "Actions" where it refers to the React Actions concept, as tracked in #6713.

### Changes
1. **`hooks.md`**: "manage state of actions" → "manage state of Actions" (in the `useActionState` description)
2. **`server-functions.md`**: "called from inside an action then it is a Server Action" → "called from inside an Action then it is a Server Action" (consistency with the capitalized concept)

These are the remaining instances in the reference docs where the React concept "Actions" was lowercase. Blog posts were intentionally left unchanged as they are historical content.