### PR TITLE
docs: fix incorrect article usage (a/an)

### DIFF
--- a/src/content/reference/react-dom/components/index.md
+++ b/src/content/reference/react-dom/components/index.md
@@ -186,7 +186,7 @@ Non-string JavaScript values passed to custom elements will be serialized by def
 <my-element value={[1,2,3]}></my-element>
 ```
 
-React will, however, recognize an custom element's property as one that it may pass arbitrary values to if the property name shows up on the class during construction:
+React will, however, recognize a custom element's property as one that it may pass arbitrary values to if the property name shows up on the class during construction:
 
 <Sandpack>
 

--- a/src/content/reference/react/experimental_taintUniqueValue.md
+++ b/src/content/reference/react/experimental_taintUniqueValue.md
@@ -91,7 +91,7 @@ experimental_taintUniqueValue(
 );
 ```
 
-If the tainted value's lifespan is tied to a object, the `lifetime` should be the object that encapsulates the value. This ensures the tainted value remains protected for the lifetime of the encapsulating object.
+If the tainted value's lifespan is tied to an object, the `lifetime` should be the object that encapsulates the value. This ensures the tainted value remains protected for the lifetime of the encapsulating object.
 
 ```js
 import {experimental_taintUniqueValue} from 'react';


### PR DESCRIPTION
## Summary

Fix incorrect indefinite article usage in two documentation files:

- **`components/index.md`**: "an custom" → "a custom" (consonant sound requires "a")
- **`experimental_taintUniqueValue.md`**: "a object" → "an object" (vowel sound requires "an")

No functional or structural changes.