### PR TITLE
fix(a11y): add aria-label to icon-only Sandpack toolbar links

### DIFF
--- a/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
+++ b/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
@@ -16,7 +16,8 @@ export const OpenInCodeSandboxButton = () => {
   return (
     <UnstyledOpenInCodeSandboxButton
       className="text-sm text-primary dark:text-primary-dark inline-flex items-center hover:text-link duration-100 ease-in transition mx-1 ms-2 md:ms-1"
-      title="Open in CodeSandbox">
+      title="Open in CodeSandbox"
+      aria-label="Open in CodeSandbox">
       <IconNewPage
         className="inline mx-1 relative top-[1px]"
         width="1em"

--- a/src/components/MDX/Sandpack/OpenInTypeScriptPlayground.tsx
+++ b/src/components/MDX/Sandpack/OpenInTypeScriptPlayground.tsx
@@ -20,6 +20,7 @@ export const OpenInTypeScriptPlaygroundButton = (props: {content: string}) => {
         contentWithReactImport
       )}`}
       title="Open in TypeScript Playground"
+      aria-label="Open in TypeScript Playground"
       target="_blank"
       rel="noreferrer">
       <IconNewPage


### PR DESCRIPTION
## Summary

Add `aria-label` to `OpenInTypeScriptPlayground` and `OpenInCodeSandboxButton` components to fix a WCAG 2.4.4 (Link Purpose) violation.

Both components hide their text labels on mobile using `hidden md:block`, leaving only an icon visible. Without `aria-label`, screen readers cannot determine the link purpose on smaller viewports since `title` alone is insufficient per WCAG.

## Changes

- `OpenInTypeScriptPlayground.tsx`: Add `aria-label="Open in TypeScript Playground"`
- `OpenInCodeSandboxButton.tsx`: Add `aria-label="Open in CodeSandbox"`

## What this does NOT address

This PR addresses part of the report in #8366 (the icon-only links). The other reported items (skip navigation link and heading hierarchy) would benefit from separate PRs.

Partially fixes #8366