### PR TITLE
docs: fix mistakenly wording in useContext reference

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -1366,7 +1366,7 @@ You might have a provider without a `value` in the tree:
 
 If you forget to specify `value`, it's like passing `value={undefined}`.
 
-You may have also mistakingly used a different prop name by mistake:
+You may have also mistakenly used a different prop name by mistake:
 
 ```js {1,2}
 // 🚩 Doesn't work: prop should be called "value"


### PR DESCRIPTION
## Summary
- fix `mistakingly` -> `mistakenly` in the `useContext` reference docs

## Related issue
- N/A (trivial docs fix)

## Guideline alignment
- Reviewed https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md and kept this to one documentation file with no behavior change.

## Validation/testing note
- Not run (documentation-only change)
