### PR TITLE
docs: fix prop-name typo in useContext docs

### DIFF
--- a/src/content/reference/react/useContext.md
+++ b/src/content/reference/react/useContext.md
@@ -1366,7 +1366,7 @@ You might have a provider without a `value` in the tree:
 
 If you forget to specify `value`, it's like passing `value={undefined}`.
 
-You may have also mistakingly used a different prop name by mistake:
+You may have also mistakenly used a different prop name by mistake:
 
 ```js {1,2}
 // 🚩 Doesn't work: prop should be called "value"


### PR DESCRIPTION
Issue: N/A (trivial docs typo fix)

Fixes a typo in the `useContext` docs by changing `mistakingly` to `mistakenly`.

Guideline alignment:
- https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md
- One focused docs change in one file.
- No behavior changes.

Validation:
- Not run (documentation-only change).
