### PR TITLE
Add guidance on preventing form reset in React

### DIFF
--- a/src/content/reference/react-dom/components/form.md
+++ b/src/content/reference/react-dom/components/form.md
@@ -50,6 +50,34 @@ To create interactive controls for submitting information, render the [built-in 
 
 ### Handle form submission on the client {/*handle-form-submission-on-the-client*/}
 
+### Preventing unwanted form reset {/*preventing-form-reset*/}
+
+When a function is passed to the `action` prop, uncontrolled form fields are automatically reset after a successful submission.
+
+If you need to preserve the form input values, you can control the inputs using React state or use `onSubmit` with `event.preventDefault()`.
+
+```jsx
+import { useState } from "react";
+
+export default function Form() {
+  const [value, setValue] = useState("");
+
+  function handleSubmit(e) {
+    e.preventDefault();
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        name="query"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+
 Pass a function to the `action` prop of form to run the function when the form is submitted. [`formData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) will be passed to the function as an argument so you can access the data submitted by the form. This differs from the conventional [HTML action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action), which only accepts URLs. After the `action` function succeeds, all uncontrolled field elements in the form are reset.
 
 <Sandpack>


### PR DESCRIPTION
## Summary
Adds documentation explaining how to prevent automatic form reset when using the `action` prop.

## Changes
- Added a new section: "Preventing unwanted form reset"
- Explained default reset behavior of uncontrolled inputs
- Included example using controlled inputs with `onSubmit`

## Why
Forms using the `action` prop reset uncontrolled fields after submission. This behavior may be unexpected and can cause confusion. This update clarifies how developers can preserve form state.

## Notes
- No breaking changes
- Follows existing documentation style