### PR TITLE
docs: fix incorrect infinite loop claim in set-state-in-render

### DIFF
--- a/src/content/reference/eslint-plugin-react-hooks/lints/set-state-in-render.md
+++ b/src/content/reference/eslint-plugin-react-hooks/lints/set-state-in-render.md
@@ -88,7 +88,7 @@ function Counter({max}) {
 }
 ```
 
-As soon as `count` exceeds `max`, an infinite loop is triggered.
+When `count` exceeds `max`, this schedules a state update during render. This is still an anti-pattern because rendering should stay pure, and state updates should happen in an event handler or effect instead.
 
 Instead, it's often better to move this logic to the event (the place where the state is first set). For example, you can enforce the maximum at the moment you update state:
 


### PR DESCRIPTION
### Summary

This updates the explanation in the `set-state-in-render` lint documentation.

### Problem

The current documentation states that exceeding `max` will trigger an infinite loop:

> "As soon as `count` exceeds `max`, an infinite loop is triggered."

However, in this specific example, the component stabilizes after an extra render because the condition becomes false once `count` is set to `max`.

### Fix

This PR updates the wording to clarify that:
- the issue is calling `setState` during render
- this is an anti-pattern because rendering should remain pure
- state updates should instead happen in an event handler or effect

### Notes

The example code is unchanged, as it still correctly demonstrates the anti-pattern.

Closes #8411