### PR TITLE
docs: clarify this binding in setState callback

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -655,7 +655,7 @@ You don't have to do this, but it's handy if you want to update state multiple t
   * If you pass an object as `nextState`, it will be shallowly merged into `this.state`.
   * If you pass a function as `nextState`, it will be treated as an _updater function_. It must be pure, should take the pending state and props as arguments, and should return the object to be shallowly merged into `this.state`. React will put your updater function in a queue and re-render your component. During the next render, React will calculate the next state by applying all of the queued updaters to the previous state.
 
-* **optional** `callback`: If specified, React will call the `callback` you've provided after the update is committed.
+* **optional** `callback`: If specified, React will call the `callback` you've provided after the update is committed. React automatically binds the `this` keyword inside the callback to the current component.
 
 #### Returns {/*setstate-returns*/}
 


### PR DESCRIPTION
Fixes #8314

**Summary**
The legacy `Component` API docs for `setState` don't mention that React automatically binds `this` for the optional callback parameter. This usually leads to developers writing unnecessary arrow functions or using manual `.bind(this)` because they (rightly) assume standard JS rules apply.

I've updated the callback description to clarify that React handles this binding internally rather than leaving it as an undocumented behaviour.

**Testing**
I verified this in a local Vite environment with a standard Class Component. I used a `function()` (not an arrow function) as the callback and confirmed that `this` correctly points to the component instance. I also verified that I could access `this.state` and `this.props` inside the callback without any manual binding.