### PR TITLE
docs: add missing "of" in render tree diagram alt text

### DIFF
--- a/src/content/learn/describing-the-ui.md
+++ b/src/content/learn/describing-the-ui.md
@@ -530,7 +530,7 @@ React uses trees to model the relationships between components and modules.
 
 A React render tree is a representation of the parent and child relationship between components.
 
-<Diagram name="generic_render_tree" height={250} width={500} alt="A tree graph with five nodes, with each node representing a component. The root node is located at the top the tree graph and is labelled 'Root Component'. It has two arrows extending down to two nodes labelled 'Component A' and 'Component C'. Each of the arrows is labelled with 'renders'. 'Component A' has a single 'renders' arrow to a node labelled 'Component B'. 'Component C' has a single 'renders' arrow to a node labelled 'Component D'.">
+<Diagram name="generic_render_tree" height={250} width={500} alt="A tree graph with five nodes, with each node representing a component. The root node is located at the top of the tree graph and is labelled 'Root Component'. It has two arrows extending down to two nodes labelled 'Component A' and 'Component C'. Each of the arrows is labelled with 'renders'. 'Component A' has a single 'renders' arrow to a node labelled 'Component B'. 'Component C' has a single 'renders' arrow to a node labelled 'Component D'.">
 
 An example React render tree.
 


### PR DESCRIPTION
## Summary

Fix a missing word in the alt text of a Diagram component on `src/content/learn/describing-the-ui.md` (L533):

> "The root node is located at the top **the** tree graph"

should read

> "The root node is located at the top **of** the tree graph"

These alt strings are read aloud by screen readers, so the missing word affects users of assistive technology.

## Test plan

- Single-word insertion in alt text — no code/JSX/heading-id changes
- `prettier:diff` skips `.md`; `eslint` on markdown only checks code fences