### PR TITLE
docs(react-dom): add hydrateRoot hydration mismatch debugging guide

### DIFF
--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -562,7 +562,7 @@ This renders a different value on the server and the client, so hydration fails.
 
 #### Debugging checklist {/*debugging-checklist*/}
 
-1. Open the browser console and find the first hydration warning.
+1. Open the browser console and find the hydration mismatch message or error, and its stack trace.
 2. Look for changing values in render (`Math.random()`, `Date.now()`). Move them to server data or calculate them after hydration in [`useEffect`.](/reference/react/useEffect)
 3. Keep browser-only code out of render. Read `window`, `document`, and similar APIs in [`useEffect`](/reference/react/useEffect) or an event handler.
 4. Make sure the first client render uses the same data as the server render.

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -552,7 +552,7 @@ Uncaught Error: Hydration failed because the server rendered HTML didn't match t
 
 #### Example mismatch {/*example-mismatch*/}
 
-```js
+```js {expectedErrors: {'react-compiler': [2]}}
 function App() {
   return <div>{Math.random()}</div>;
 }

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -191,6 +191,7 @@ This is important for the user experience. The user will spend some time looking
 The most common causes leading to hydration errors include:
 
 * Extra whitespace (like newlines) around the React-generated HTML inside the root node.
+* Using non-deterministic values like `Date.now()` or `Math.random()` in rendering logic.
 * Using checks like `typeof window !== 'undefined'` in your rendering logic.
 * Using browser-only APIs like [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) in your rendering logic.
 * Rendering different data on the server and the client.
@@ -531,3 +532,42 @@ root.render(App, {onUncaughtError});
 // ✅ Correct: pass options to createRoot.
 const root = hydrateRoot(container, <App />, {onUncaughtError});
 ```
+
+### Debugging hydration mismatches {/*debugging-hydration-mismatches*/}
+
+If you see an error like "Hydration failed because the server rendered HTML didn't match the client.", it means the HTML from the server is different from what React renders first in the browser.
+
+<ConsoleBlock level="error">
+
+Uncaught Error: Hydration failed because the server rendered HTML didn't match the client.
+
+</ConsoleBlock>
+
+#### Common causes {/*common-causes*/}
+
+* Values that change every time you render, like `Math.random()` or `Date.now()`.
+* Rendering that depends on browser-only globals like `window`, `document`, or `localStorage`.
+* Different data on the server and the client during the first render.
+* Data loading timing issues where server data and client data do not match.
+
+#### Example mismatch {/*example-mismatch*/}
+
+```js
+function App() {
+  return <div>{Math.random()}</div>;
+}
+```
+
+This renders a different value on the server and the client, so hydration fails.
+
+#### Debugging checklist {/*debugging-checklist*/}
+
+1. Open the browser console and find the first hydration warning.
+2. Look for changing values in render (`Math.random()`, `Date.now()`). Move them to server data or calculate them after hydration in [`useEffect`.](/reference/react/useEffect)
+3. Keep browser-only code out of render. Read `window`, `document`, and similar APIs in [`useEffect`](/reference/react/useEffect) or an event handler.
+4. Make sure the first client render uses the same data as the server render.
+5. If one mismatch is expected (for example, a timestamp), use `suppressHydrationWarning={true}` on that element.
+
+#### Isolating the component {/*isolating-the-component*/}
+
+If you still cannot find the issue, replace parts of the UI with simple static markup. Add components back one at a time until the warning comes back. The last part you added is usually where the mismatch is.

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -552,7 +552,7 @@ Uncaught Error: Hydration failed because the server rendered HTML didn't match t
 
 #### Example mismatch {/*example-mismatch*/}
 
-```js {expectedErrors: {'react-compiler': [2]}}
+```js
 function App() {
   return <div>{Math.random()}</div>;
 }
@@ -566,7 +566,7 @@ This renders a different value on the server and the client, so hydration fails.
 2. Look for changing values in render (`Math.random()`, `Date.now()`). Move them to server data or calculate them after hydration in [`useEffect`](/reference/react/useEffect).
 3. Keep browser-only code out of render. Read `window`, `document`, and similar APIs in [`useEffect`](/reference/react/useEffect) or an event handler.
 4. Make sure the first client render uses the same data as the server render.
-5. If one mismatch is expected (for example, a timestamp), use `suppressHydrationWarning={true}` on that element.
+5. If a mismatch is truly unavoidable, such as a one-off timestamp, use `suppressHydrationWarning={true}` as a last resort on the specific element. Apply it narrowly and avoid using it on large subtrees because it only silences the warning and does not fix the mismatch.
 
 #### Isolating the component {/*isolating-the-component*/}
 

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -552,11 +552,10 @@ Uncaught Error: Hydration failed because the server rendered HTML didn't match t
 
 #### Example mismatch {/*example-mismatch*/}
 
-```js
+```js {expectedErrors: {'react-compiler': [2]}}
 function App() {
   return <div>{Math.random()}</div>;
 }
-```
 
 This renders a different value on the server and the client, so hydration fails.
 

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -552,10 +552,9 @@ Uncaught Error: Hydration failed because the server rendered HTML didn't match t
 
 #### Example mismatch {/*example-mismatch*/}
 
-```jsx
+```text
 function App() {
-  const value = Math.random();
-  return <div>{value}</div>;
+  return <div>{Math.random()}</div>;
 }
 ```
 

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -552,10 +552,12 @@ Uncaught Error: Hydration failed because the server rendered HTML didn't match t
 
 #### Example mismatch {/*example-mismatch*/}
 
-```js {expectedErrors: {'react-compiler': [2]}}
+```jsx
 function App() {
-  return <div>{Math.random()}</div>;
+  const value = Math.random();
+  return <div>{value}</div>;
 }
+```
 
 This renders a different value on the server and the client, so hydration fails.
 

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -563,7 +563,7 @@ This renders a different value on the server and the client, so hydration fails.
 #### Debugging checklist {/*debugging-checklist*/}
 
 1. Open the browser console and find the hydration mismatch message or error, and its stack trace.
-2. Look for changing values in render (`Math.random()`, `Date.now()`). Move them to server data or calculate them after hydration in [`useEffect`.](/reference/react/useEffect)
+2. Look for changing values in render (`Math.random()`, `Date.now()`). Move them to server data or calculate them after hydration in [`useEffect`](/reference/react/useEffect).
 3. Keep browser-only code out of render. Read `window`, `document`, and similar APIs in [`useEffect`](/reference/react/useEffect) or an event handler.
 4. Make sure the first client render uses the same data as the server render.
 5. If one mismatch is expected (for example, a timestamp), use `suppressHydrationWarning={true}` on that element.


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

### Summary
This PR improves the hydrateRoot documentation by adding guidance for debugging hydration mismatches.

### What changed
- Added a new troubleshooting section: Debugging hydration mismatches
- Added common causes, including:
  - Changing values during render (for example, Math.random() or Date.now())
  - Browser only logic in render (window, document, localStorage)
  - Server/client data differences on first render
  - Data timing inconsistencies
- Added a minimal mismatch example using Math.random()
- Added a step by step debugging checklist
- Added an Isolating the component workflow to help identify the root cause

### Why made the section
Hydration mismatch errors are common in SSR apps and are often difficult to debug, especially for beginners and intermediate developers.  
This update gives readers a clear process to identify and fix mismatches.

### Validation
- Ran yarn lint-heading-ids successfully

### Issue
Closes [#36242](https://github.com/facebook/react/issues/36242)
