### PR TITLE
docs: Remove unused `onAddTask` prop and `useContext` imports from reducer + context example

### DIFF
--- a/src/content/learn/managing-state.md
+++ b/src/content/learn/managing-state.md
@@ -887,10 +887,10 @@ const initialTasks = [
 ```
 
 ```js src/AddTask.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasksDispatch } from './TasksContext.js';
 
-export default function AddTask({ onAddTask }) {
+export default function AddTask() {
   const [text, setText] = useState('');
   const dispatch = useTasksDispatch();
   return (
@@ -916,7 +916,7 @@ let nextId = 3;
 ```
 
 ```js src/TaskList.js
-import { useState, useContext } from 'react';
+import { useState } from 'react';
 import { useTasks, useTasksDispatch } from './TasksContext.js';
 
 export default function TaskList() {


### PR DESCRIPTION
AddTask no longer needs an `onAddTask` prop or `useContext` now that the component reads dispatch directly from context via `useTasksDispatch`.

  - Removes the `onAddTask` prop from `AddTask` - the component uses
    `useTasksDispatch()` directly, so no handler needs to be passed down
  - Removes the unused `useContext` import from both `AddTask.js` and
    `TaskList.js` - the custom hooks (`useTasksDispatch`, `useTasks`)
    already encapsulate the context calls

 No behavior change. This makes the example consistent with the
 surrounding explanation, which highlights that context lets child
 components skip prop-passing entirely.