### PR TITLE
Remove duplicate v19.2.1 entry from versions page

### DIFF
--- a/src/content/versions.md
+++ b/src/content/versions.md
@@ -54,7 +54,6 @@ For versions older than React 15, see [15.react.dev](https://15.react.dev).
 - [React 19 Deep Dive: Coordinating HTML](https://www.youtube.com/watch?v=IBBN-s77YSI)
 
 **Releases**
-- [v19.2.1 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1922-dec-11-2025)
 - [v19.2.1 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1921-dec-3-2025)
 - [v19.2.0 (October, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1920-october-1st-2025)
 - [v19.1.3 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1913-dec-11-2025)


### PR DESCRIPTION
## What changed
- Removed a duplicated release entry for `v19.2.1` from `src/content/versions.md`.
- Keeps the canonical changelog anchor (`#1921-dec-3-2025`) and removes the extra `#1922-dec-11-2025` line that caused duplicate listings on `/versions`.

Closes #8429