### PR TITLE
docs: cross-reference use API on useEffect data-fetching section

### DIFF
--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -196,6 +196,8 @@ function Button({ show, children }) {
 
 ### Streaming data from the server to the client {/*streaming-data-from-server-to-client*/}
 
+When you are using Server Components, `use` can stream data from the server to the client without running `fetch` inside [an Effect](/reference/react/useEffect#fetching-data-with-effects). Because the request starts on the server, the client avoids the network waterfalls and extra render passes described in [What are good alternatives to data fetching in Effects?](/reference/react/useEffect#what-are-good-alternatives-to-data-fetching-in-effects). This pattern works only with frameworks that support React Server Components.
+
 Data can be streamed from the server to the client by passing a Promise as a prop from a <CodeStep step={1}>Server Component</CodeStep> to a <CodeStep step={2}>Client Component</CodeStep>.
 
 ```js [[1, 4, "App"], [2, 2, "Message"], [3, 7, "Suspense"], [4, 8, "messagePromise", 30], [4, 5, "messagePromise"]]

--- a/src/content/reference/react/useEffect.md
+++ b/src/content/reference/react/useEffect.md
@@ -1051,8 +1051,9 @@ This list of downsides is not specific to React. It applies to fetching data on 
 
 - **If you use a [framework](/learn/creating-a-react-app#full-stack-frameworks), use its built-in data fetching mechanism.** Modern React frameworks have integrated data fetching mechanisms that are efficient and don't suffer from the above pitfalls.
 - **Otherwise, consider using or building a client-side cache.** Popular open source solutions include [TanStack Query](https://tanstack.com/query/latest/), [useSWR](https://swr.vercel.app/), and [React Router 6.4+.](https://beta.reactrouter.com/en/main/start/overview) You can build your own solution too, in which case you would use Effects under the hood but also add logic for deduplicating requests, caching responses, and avoiding network waterfalls (by preloading data or hoisting data requirements to routes).
+- **If you are using Server Components, you can stream data to the client with the [`use`](/reference/react/use) API.** When a Server Component creates a Promise and passes it as a prop to a Client Component, the Client Component can read the resolved value with `use` inside a [`<Suspense>`](/reference/react/Suspense) boundary. This avoids running data fetching in an Effect on the client and lets the server start the request earlier. See [Streaming data from the server to the client](/reference/react/use#streaming-data-from-server-to-client) for an example.
 
-You can continue fetching data directly in Effects if neither of these approaches suit you.
+You can continue fetching data directly in Effects if none of these approaches suit you.
 
 </DeepDive>
 


### PR DESCRIPTION
Closes #8433

## Summary

Issue #8433 reports that the relationship between `useEffect` and the `use` API is unclear in the documentation:

- The `useEffect` page has a "What are good alternatives to data fetching in Effects?" section that does not mention `use`.
- The `use` page has a "Streaming data from the server to the client" section that does not mention `useEffect` or that this is an alternative to fetching in Effects.

This PR adds a minimal cross-reference between the two pages so that readers landing on either one can discover the other.

## Changes

**`src/content/reference/react/useEffect.md`** — In the "What are good alternatives to data fetching in Effects?" DeepDive, added a new bullet to the list of recommended approaches noting that the `use` API can stream data from Server Components, with a link to the relevant section on the `use` page. Also changed "neither of these approaches" to "none of these approaches" since the list now has three items instead of two.

**`src/content/reference/react/use.md`** — At the top of the "Streaming data from the server to the client" section, added a short paragraph noting that `use` is an alternative to fetching data inside an Effect when Server Components are in use, with back-links to both relevant sections of the `useEffect` page.

## Design notes

- Both additions stay short and factual, in keeping with the surrounding tone. I did not introduce new examples or new conceptual material — the existing `Suspense` example on the `use` page already demonstrates the pattern.
- I noted that this pattern works only with frameworks that support Server Components, so readers on a non-RSC stack are not misled into thinking this replaces their data-fetching layer.
- All internal anchor links were verified against the current files.
- Cross-references go both directions, so the entry point doesn't matter.

Happy to adjust scope, wording, or placement based on maintainer feedback.