### PR TITLE
docs: capitalize React Actions references

### DIFF
--- a/src/content/learn/rsc-sandbox-test.md
+++ b/src/content/learn/rsc-sandbox-test.md
@@ -286,7 +286,7 @@ export default function UserCard({ userPromise, serverTime }) {
 
 ## Flight Data Types in Server Actions {/*flight-data-types-actions*/}
 
-This demo sends Map, Set, Date, and BigInt from a client component *to* a server action via `encodeReply`/`decodeReply`, then verifies the types survived the round trip.
+This demo sends Map, Set, Date, and BigInt from a client component *to* a Server Action via `encodeReply`/`decodeReply`, then verifies the types survived the round trip.
 
 <SandpackRSC>
 
@@ -310,7 +310,7 @@ export default async function App() {
           ))}
         </div>
       ) : (
-        <p>Click the button to send typed data to the server action.</p>
+        <p>Click the button to send typed data to the Server Action.</p>
       )}
     </div>
   );
@@ -390,7 +390,7 @@ export default function TestButton({ testTypes }) {
 
 ## Server Action Mutation + Re-render {/*action-mutation-rerender*/}
 
-The server action mutates server-side data and returns a confirmation string. The updated list is only visible because the framework automatically re-renders the entire server component tree after the action completes — the server component re-reads the data and streams the new UI to the client.
+The Server Action mutates server-side data and returns a confirmation string. The updated list is only visible because the framework automatically re-renders the entire server component tree after the Action completes — the server component re-reads the data and streams the new UI to the client.
 
 <SandpackRSC>
 
@@ -407,7 +407,7 @@ export default function App() {
       <p style={{ color: '#666', fontSize: 13 }}>
         This list is rendered by a server component
         reading server-side data. It only updates because
-        the server re-renders after each action.
+        the server re-renders after each Action.
       </p>
       <ul>
         {todos.map((todo, i) => (
@@ -487,7 +487,7 @@ export default function AddTodo({ createTodo }) {
 
 ## Inline Server Actions {/*inline-server-actions*/}
 
-Server actions defined inline inside a server component with `'use server'` on the function body. The action closes over module-level state and is passed as a prop — no separate `actions.js` file needed.
+Server Actions defined inline inside a server component with `'use server'` on the function body. The Action closes over module-level state and is passed as a prop — no separate `actions.js` file needed.
 
 <SandpackRSC>
 

--- a/src/content/reference/react/hooks.md
+++ b/src/content/reference/react/hooks.md
@@ -116,7 +116,7 @@ These Hooks are mostly useful to library authors and aren't commonly used in the
 - [`useDebugValue`](/reference/react/useDebugValue) lets you customize the label React DevTools displays for your custom Hook.
 - [`useId`](/reference/react/useId) lets a component associate a unique ID with itself. Typically used with accessibility APIs.
 - [`useSyncExternalStore`](/reference/react/useSyncExternalStore) lets a component subscribe to an external store.
-* [`useActionState`](/reference/react/useActionState) allows you to manage state of actions.
+* [`useActionState`](/reference/react/useActionState) allows you to manage state of Actions.
 
 ---
 

--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -60,7 +60,7 @@ function MyCart({initialState}) {
 * The `dispatchAction` function has a stable identity, so you will often see it omitted from Effect dependencies, but including it will not cause the Effect to fire. If the linter lets you omit a dependency without errors, it is safe to do. [Learn more about removing Effect dependencies.](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
 * When using the `permalink` option, ensure the same form component is rendered on the destination page (including the same `reducerAction` and `permalink`) so React knows how to pass the state through. Once the page becomes interactive, this parameter has no effect.
 * When using Server Functions, `initialState` needs to be [serializable](/reference/rsc/use-server#serializable-parameters-and-return-values) (values like plain objects, arrays, strings, and numbers).
-* If `dispatchAction` throws an error, React cancels all queued actions and shows the nearest [Error Boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary).
+* If `dispatchAction` throws an error, React cancels all queued Actions and shows the nearest [Error Boundary](/reference/react/Component#catching-rendering-errors-with-an-error-boundary).
 * If there are multiple ongoing Actions, React batches them together. This is a limitation that may be removed in a future release.
 
 <Note>
@@ -269,7 +269,7 @@ Try clicking "Add Ticket" multiple times. Every time you click, a new `addToCart
 
 We have to wait for the previous result of `addToCartAction` in order to pass the `prevCount` to the next call to `addToCartAction`. That means React has to wait for the previous Action to finish before calling the next Action.
 
-You can typically solve this by [using with useOptimistic](/reference/react/useActionState#using-with-useoptimistic) but for more complex cases you may want to consider [cancelling queued actions](#cancelling-queued-actions) or not using `useActionState`.
+You can typically solve this by [using with useOptimistic](/reference/react/useActionState#using-with-useoptimistic) but for more complex cases you may want to consider [cancelling queued Actions](#cancelling-queued-actions) or not using `useActionState`.
 
 </DeepDive>
 
@@ -1423,7 +1423,7 @@ function action(prevState, formData) {
 
 ---
 
-### My actions are being skipped {/*actions-skipped*/}
+### My Actions are being skipped {/*actions-skipped*/}
 
 If you call `dispatchAction` multiple times and some of them don't run, it may be because an earlier `dispatchAction` call threw an error.
 
@@ -1526,7 +1526,7 @@ function MyComponent() {
 }
 ```
 
-Or pass `dispatchAction` to an Action prop, is call in a Transition:
+Or pass `dispatchAction` to an Action prop, which calls it in a Transition:
 
 ```js
 function MyComponent() {

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -309,7 +309,7 @@ This is a basic example to demonstrate how Actions work, but this example does n
 
 For common use cases, React provides built-in abstractions such as:
 - [`useActionState`](/reference/react/useActionState)
-- [`<form>` actions](/reference/react-dom/components/form)
+- [`<form>` Actions](/reference/react-dom/components/form)
 - [Server Functions](/reference/rsc/server-functions)
 
 These solutions handle request ordering for you. When using Transitions to build your own custom hooks or libraries that manage async state transitions, you have greater control over the request ordering, but you must handle it yourself.
@@ -1248,7 +1248,7 @@ This is recommended for three reasons:
 
 - [Transitions are interruptible,](#perform-non-blocking-updates-with-actions) which lets the user click away without waiting for the re-render to complete.
 - [Transitions prevent unwanted loading indicators,](#preventing-unwanted-loading-indicators) which lets the user avoid jarring jumps on navigation.
-- [Transitions wait for all pending actions](#perform-non-blocking-updates-with-actions) which lets the user wait for side effects to complete before the new page is shown.
+- [Transitions wait for all pending Actions](#perform-non-blocking-updates-with-actions) which lets the user wait for side effects to complete before the new page is shown.
 
 Here is a simplified router example using Transitions for navigations.
 
@@ -1945,7 +1945,7 @@ export async function updateQuantity(newName) {
 
 When clicking multiple times, it's possible for previous requests to finish after later requests. When this happens, React currently has no way to know the intended order. This is because the updates are scheduled asynchronously, and React loses context of the order across the async boundary.
 
-This is expected, because Actions within a Transition do not guarantee execution order. For common use cases, React provides higher-level abstractions like [`useActionState`](/reference/react/useActionState) and [`<form>` actions](/reference/react-dom/components/form) that handle ordering for you. For advanced use cases, you'll need to implement your own queuing and abort logic to handle this.
+This is expected, because Actions within a Transition do not guarantee execution order. For common use cases, React provides higher-level abstractions like [`useActionState`](/reference/react/useActionState) and [`<form>` Actions](/reference/react-dom/components/form) that handle ordering for you. For advanced use cases, you'll need to implement your own queuing and abort logic to handle this.
 
 
 Example of `useActionState` handling execution order:

--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -6,7 +6,7 @@ title: Server Functions
 
 Server Functions are for use in [React Server Components](/reference/rsc/server-components).
 
-**Note:** Until September 2024, we referred to all Server Functions as "Server Actions". If a Server Function is passed to an action prop or called from inside an action then it is a Server Action, but not all Server Functions are Server Actions. The naming in this documentation has been updated to reflect that Server Functions can be used for multiple purposes.
+**Note:** Until September 2024, we referred to all Server Functions as "Server Actions". If a Server Function is passed to an action prop or called from inside an Action, then it is a Server Action, but not all Server Functions are Server Actions. The naming in this documentation has been updated to reflect that Server Functions can be used for multiple purposes.
 
 </RSC>
 
@@ -174,7 +174,7 @@ For more, see the docs for [Server Functions in Forms](/reference/rsc/use-server
 
 ### Server Functions with `useActionState` {/*server-functions-with-use-action-state*/}
 
-You can call Server Functions with `useActionState` for the common case where you just need access to the action pending state and last returned response:
+You can call Server Functions with `useActionState` for the common case where you just need access to the pending state for the Action and the last returned response:
 
 ```js [[1, 3, "updateName"], [1, 6, "updateName"], [2, 6, "submitAction"], [2, 9, "submitAction"]]
 "use client";


### PR DESCRIPTION
## Summary

Fixes #6713 — _Capitalize React concepts in docs_
Source issue: https://github.com/reactjs/react.dev/issues/6713

This PR covers the remaining `Actions` concept scope for issue `#6713` by
capitalizing React-specific references to `Actions` in docs prose and headings.

## Scope

- Updated React `Actions` concept references in:
  - `src/content/reference/react/hooks.md`
  - `src/content/reference/react/useTransition.md`
  - `src/content/reference/react/useActionState.md`
  - `src/content/reference/rsc/server-functions.md`
  - `src/content/learn/rsc-sandbox-test.md`
- Intentionally did not rename code identifiers like `action`, `formAction`, or
  `actions.js`.
- Did not touch blog or community pages.

## Verification

- Reviewed the diff manually to keep the changes limited to React-concept prose.
- Re-ran targeted searches to avoid changing code examples, prop names, or file names.

## Blockers

- `yarn install --frozen-lockfile` did not complete within this session, so full
  automated validation is still pending.
- `node scripts/headingIdLinter.js ...` currently requires repo dependencies
  (for example `github-slugger`) that were not yet installed.

## Notes

- Opening as a draft so automated lint / heading checks can be completed once
  dependency installation finishes locally.
