### PR TITLE
docs: mention iterables from render

### DIFF
--- a/src/content/reference/react/Component.md
+++ b/src/content/reference/react/Component.md
@@ -573,11 +573,13 @@ You should write the `render` method as a pure function, meaning that it should 
 
 #### Returns {/*render-returns*/}
 
-`render` can return any valid React node. This includes React elements such as `<div />`, strings, numbers, [portals](/reference/react-dom/createPortal), empty nodes (`null`, `undefined`, `true`, and `false`), and arrays of React nodes.
+`render` can return any valid React node. This includes React elements such as `<div />`, strings, numbers, [portals](/reference/react-dom/createPortal), empty nodes (`null`, `undefined`, `true`, and `false`), arrays, and other [iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) of React nodes.
 
 #### Caveats {/*render-caveats*/}
 
 - `render` should be written as a pure function of props, state, and context. It should not have side effects.
+
+- If you return an iterable from `render`, avoid one-shot iterators that can only be enumerated once. React may enumerate the returned value more than once, so prefer arrays or iterable objects that create a fresh iterator each time.
 
 - `render` will not get called if [`shouldComponentUpdate`](#shouldcomponentupdate) is defined and returns `false`.
 


### PR DESCRIPTION
Updates the `Component.render` return value docs to mention iterables of React nodes, and adds a caveat to prefer arrays or reusable iterables over one-shot iterators because React may enumerate returned values more than once.

Closes #286

Checks run:
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn --cwd eslint-local-rules install --frozen-lockfile --ignore-scripts`
- `yarn eslint src/content/reference/react/Component.md`
- `yarn lint-heading-ids`
- `git diff --check`
