### PR TITLE
fix(ui): make YouTube embeds responsive on mobile

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -755,3 +755,11 @@ ol.mdx-illustration-block {
 .uwu .uwu-hidden {
   display: none;
 }
+
+iframe[src^="https://www.youtube.com/embed/"]
+{
+  width: 100% !important;
+  aspect-ratio: 16 / 9 !important;
+  height: auto !important;
+  display: block !important;
+}


### PR DESCRIPTION
### Summary
Fixes #8452: Prevent horizontal overflow from fixed-width iframes. 

This is achieved by removing hardcoded sizes on iframe elements and adding a style rule for `youtube.com/embed` iframes to fill the page width while maintaining a 16/9 aspect ratio.

### Results
Before:
<img width="300" height="600" alt="Overflowing iframe image" src="https://github.com/user-attachments/assets/6d2bfe55-8eb4-404b-b385-166f4fd3476c" />


After:
<img width="300" height="600" alt="Fixed iframe image" src="https://github.com/user-attachments/assets/e44d4e62-e5c4-4565-b47e-fbf602ebb2c9" />



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->