### PR TITLE
Fix incorrect links on the Versions page

### DIFF
--- a/src/content/versions.md
+++ b/src/content/versions.md
@@ -286,7 +286,7 @@ For versions older than React 15, see [15.react.dev](https://15.react.dev).
 - [React v0.4.0](https://legacy.reactjs.org/blog/2013/07/17/react-v0-4-0.html)
 - [New in React v0.4: Prop Validation and Default Values](https://legacy.reactjs.org/blog/2013/07/11/react-v0-4-prop-validation-and-default-values.html)
 - [New in React v0.4: Autobind by Default](https://legacy.reactjs.org/blog/2013/07/02/react-v0-4-autobind-by-default.html)
-- [React v0.3.3](https://legacy.reactjs.org/blog/2013/07/02/react-v0-4-autobind-by-default.html)
+- [React v0.3.3](https://legacy.reactjs.org/blog/2013/06/21/react-v0-3-3.html)
 
 **Releases**
 - [v0.10.0 (March 2014)](https://github.com/facebook/react/blob/main/CHANGELOG.md#0100-march-21-2014)
@@ -300,7 +300,7 @@ For versions older than React 15, see [15.react.dev](https://15.react.dev).
 - [v0.3.3 (June 2013)](https://github.com/facebook/react/blob/main/CHANGELOG.md#033-june-20-2013)
 - [v0.3.2 (May 2013)](https://github.com/facebook/react/blob/main/CHANGELOG.md#032-may-31-2013)
 - [v0.3.1 (May 2013)](https://github.com/facebook/react/blob/main/CHANGELOG.md#031-may-30-2013)
-- [v0.3.0 (May 2013)](https://github.com/facebook/react/blob/main/CHANGELOG.md#031-may-30-2013)
+- [v0.3.0 (May 2013)](https://github.com/facebook/react/blob/main/CHANGELOG.md#030-may-29-2013)
 
 ### Initial Commit {/*initial-commit*/}
 


### PR DESCRIPTION
## Summary

 Fix two incorrect links on the React Versions page:
 - `React v0.3.3` currently links to the v0.4 Autobind post. This updates it to the actual v0.3.3 post.
 - `v0.3.0` currently links to the `0.3.1` changelog section. This updates it to the `0.3.0` section.

## Verification

 Checked `/versions#react-10-and-below` and confirmed the target v0.3.3 post and v0.3.0 changelog section
 exist.