### PR TITLE
Fix note rendering in RSC docs example

### DIFF
--- a/src/content/reference/rsc/server-components.md
+++ b/src/content/reference/rsc/server-components.md
@@ -100,7 +100,7 @@ Without Server Components, it's common to fetch dynamic data on the client in an
 ```js
 // bundle.js
 function Note({id}) {
-  const [note, setNote] = useState('');
+  const [note, setNote] = useState(null);
   // NOTE: loads *after* first render.
   useEffect(() => {
     fetch(`/api/notes/${id}`).then(data => {
@@ -108,10 +108,14 @@ function Note({id}) {
     });
   }, [id]);
 
+  if (note == null) {
+    return null;
+  }
+
   return (
     <div>
       <Author id={note.authorId} />
-      <p>{note}</p>
+      <p>{note.content}</p>
     </div>
   );
 }
@@ -155,7 +159,7 @@ async function Note({id}) {
   return (
     <div>
       <Author id={note.authorId} />
-      <p>{note}</p>
+      <p>{note.content}</p>
     </div>
   );
 }


### PR DESCRIPTION
Fixes the Server Components example so the loaded note is consistently treated as an object.

The client example now waits until the note is loaded before reading authorId, and both examples render note.content instead of rendering the whole note object.

Closes #6933.

Validation:
- git diff --check -> passed