### PR TITLE
fix: consistent note object type in Server Components docs

### DIFF
--- a/src/content/reference/rsc/server-components.md
+++ b/src/content/reference/rsc/server-components.md
@@ -100,7 +100,7 @@ Without Server Components, it's common to fetch dynamic data on the client in an
 ```js
 // bundle.js
 function Note({id}) {
-  const [note, setNote] = useState('');
+  const [note, setNote] = useState(null);
   // NOTE: loads *after* first render.
   useEffect(() => {
     fetch(`/api/notes/${id}`).then(data => {
@@ -108,10 +108,14 @@ function Note({id}) {
     });
   }, [id]);
 
+  if (!note) {
+    return null;
+  }
+
   return (
     <div>
       <Author id={note.authorId} />
-      <p>{note}</p>
+      <p>{note.content}</p>
     </div>
   );
 }
@@ -155,7 +159,7 @@ async function Note({id}) {
   return (
     <div>
       <Author id={note.authorId} />
-      <p>{note}</p>
+      <p>{note.content}</p>
     </div>
   );
 }
@@ -269,7 +273,7 @@ async function Page({id}) {
   const commentsPromise = db.comments.get(note.id);
   return (
     <div>
-      {note}
+      <p>{note.content}</p>
       <Suspense fallback={<p>Loading Comments...</p>}>
         <Comments commentsPromise={commentsPromise} />
       </Suspense>


### PR DESCRIPTION
## Summary

Fixes the Server Components code examples so the `note` variable is consistently treated as an object throughout all 3 examples on the page.

Closes #6933

### Changes

**Client Component example (`without Server Components`):**
- Changed `useState('')` to `useState(null)` (note is an object, not a string)
- Added null guard before accessing `note.authorId`
- Changed `{note}` to `{note.content}` in JSX

**Server Component example (`with Server Components`):**
- Changed `{note}` to `{note.content}` in JSX

**Async Server Component example:**
- Changed `{note}` to `<p>{note.content}</p>` in JSX

### Why

The `note` object has properties like `.authorId`, `.id`, and `.content`, but was being:
1. Initialized as an empty string `''`
2. Rendered directly as `{note}` which would show `[object Object]`

This is confusing for developers learning React Server Components.

cc @rickhanlonii @poteto