### PR TITLE
fix: correct duplicate v19.2.1 entry to v19.2.2 on Versions page

### DIFF
--- a/src/content/versions.md
+++ b/src/content/versions.md
@@ -54,7 +54,7 @@ For versions older than React 15, see [15.react.dev](https://15.react.dev).
 - [React 19 Deep Dive: Coordinating HTML](https://www.youtube.com/watch?v=IBBN-s77YSI)
 
 **Releases**
-- [v19.2.1 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1922-dec-11-2025)
+- [v19.2.2 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1922-dec-11-2025)
 - [v19.2.1 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1921-dec-3-2025)
 - [v19.2.0 (October, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1920-october-1st-2025)
 - [v19.1.3 (December, 2025)](https://github.com/facebook/react/blob/main/CHANGELOG.md#1913-dec-11-2025)


### PR DESCRIPTION
## Summary

Fixes duplicate v19.2.1 entry on the React Versions page.

Closes #8429

### Problem

The Versions page lists `v19.2.1` twice with different CHANGELOG anchors:
- Line 1: `v19.2.1` linking to `#1922-dec-11-2025`
- Line 2: `v19.2.1` linking to `#1921-dec-3-2025`

### Fix

The first entry's anchor `#1922` corresponds to **v19.2.2** (December 11, 2025), not v19.2.1. This matches the pattern across all version lines:

| Dec 11 release | Dec 3 release |
|---|---|
| v19.2.**2** | v19.2.**1** |
| v19.1.**3** | v19.1.**2** |
| v19.0.**2** | v19.0.**1** |

Changed the first entry from `v19.2.1` to `v19.2.2`.

cc @rickhanlonii