### PR TITLE
Fix outdated CodeSandbox console location in tic-tac-toe tutorial

### DIFF
--- a/src/content/learn/tutorial-tic-tac-toe.md
+++ b/src/content/learn/tutorial-tic-tac-toe.md
@@ -723,7 +723,7 @@ function Square({ value }) {
 }
 ```
 
-If you click on a square now, you should see a log saying `"clicked!"` in the _Console_ tab at the bottom of the _Browser_ section in CodeSandbox. Clicking the square more than once will log `"clicked!"` again. Repeated console logs with the same message will not create more lines in the console. Instead, you will see an incrementing counter next to your first `"clicked!"` log.
+If you click on a square now, you should see a log saying `"clicked!"` in the _Console_ tab in CodeSandbox. Clicking the square more than once will log `"clicked!"` again. Repeated console logs with the same message will not create more lines in the console. Instead, you will see an incrementing counter next to your first `"clicked!"` log.
 
 <Note>
 


### PR DESCRIPTION
## Summary

The "Adding behavior to the component" step of the Tic-Tac-Toe tutorial tells readers they'll see the `"clicked!"` log in the _Console_ tab **at the bottom of the _Browser_ section** in CodeSandbox. CodeSandbox's UI has since changed and the Console is no longer located there, which can confuse readers following along (reported in #8478).

This drops the now-inaccurate location detail while keeping the instruction correct — the _Console_ tab still exists in CodeSandbox.

## Note

The same "at the bottom of the _browser_ section" phrasing also appears later for the **React DevTools** tab (with an accompanying screenshot). I left that one unchanged here, since its screenshot may still reflect the current UI — happy to update it too if you'd prefer.

Fixes #8478
