### PR TITLE
Update browser support section: React 18 dropped Internet Explorer

### DIFF
--- a/src/content/reference/react-dom/client/index.md
+++ b/src/content/reference/react-dom/client/index.md
@@ -19,4 +19,4 @@ The `react-dom/client` APIs let you render React components on the client (in th
 
 ## Browser support {/*browser-support*/}
 
-React supports all popular browsers, including Internet Explorer 9 and above. Some polyfills are required for older browsers such as IE 9 and IE 10.
+React supports all popular browsers, including Chrome, Firefox, Safari, and Edge. React 18 [dropped support for Internet Explorer](/blog/2022/03/08/react-18-upgrade-guide#dropping-support-for-internet-explorer), which doesn't support the modern browser features that React relies on.


### PR DESCRIPTION
## Summary

The **Browser support** section of the `react-dom/client` reference page still states that React "supports all popular browsers, including Internet Explorer 9 and above." But this page documents the React 18 client APIs (`createRoot` / `hydrateRoot`), and React 18 [dropped support for Internet Explorer](/blog/2022/03/08/react-18-upgrade-guide#dropping-support-for-internet-explorer) — its new features rely on modern browser capabilities (such as microtasks) that can't be polyfilled in IE.

This updates the section to reflect that React no longer supports IE, with a link to the React 18 upgrade guide.

Fixes #7271
