### PR TITLE
fix: normalize globby paths in deadLinkChecker for Windows compatibility

### DIFF
--- a/scripts/deadLinkChecker.js
+++ b/scripts/deadLinkChecker.js
@@ -47,7 +47,7 @@ function getMarkdownFiles() {
     path.posix.join(baseDir, '**/*.md'),
     path.posix.join(baseDir, '**/*.mdx'),
   ];
-  return globby.sync(patterns);
+  return globby.sync(patterns).map((p) => path.normalize(p));
 }
 
 function extractAnchorsFromContent(content) {


### PR DESCRIPTION
### Description

This PR fixes a cross-platform compatibility bug in the `scripts/deadLinkChecker.js` script. 

On Windows machines, running `yarn deadlinks` results in hundreds of false-positive anchor errors (e.g., `556 dead links out of 1822 total links`). This happens because `globby.sync` returns POSIX-style paths (using forward slashes `/`), while Node's native `path.join` (used during validation/lookup) returns Windows-style paths (using backslashes `\`). As a result, the lookup keys in `anchorMap` do not match, causing all anchor check lookups to fail.

### Solution

In `scripts/deadLinkChecker.js`, inside the `getMarkdownFiles()` function, we map `path.normalize(p)` onto the array returned by `globby.sync()`:

```js
return globby.sync(patterns).map((p) => path.normalize(p));
