### PR TITLE
fix: remove unused useState import in lifecycle-of-reactive-effects

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -1375,7 +1375,7 @@ export default function App() {
 ```
 
 ```js {expectedErrors: {'react-compiler': [8]}} src/ChatRoom.js active
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export default function ChatRoom({ roomId, createConnection }) {
   useEffect(() => {


### PR DESCRIPTION
## Summary

The `ChatRoom.js` sandpack in the "Fix a connection switch" challenge on the [Lifecycle of Reactive Effects](https://react.dev/learn/lifecycle-of-reactive-effects) page imports `useState` but the component only uses `useEffect`. The unused import can confuse learners who may wonder why it's there.

**Before:**
```js
import { useState, useEffect } from 'react';
```

**After:**
```js
import { useEffect } from 'react';
```

Fixes #8231