### PR TITLE
fix: update use.md pitfall to make conditional calling clearer

### DIFF
--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -662,7 +662,8 @@ This cache pattern is the foundation for [re-fetching data](#re-fetching-data-in
 
 <Pitfall>
 
-Don't skip calling `use` based on whether a Promise is already settled. 
+Don't skip calling `use` based on whether a Promise is already settled.
+
 Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. 
 
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -664,7 +664,7 @@ This cache pattern is the foundation for [re-fetching data](#re-fetching-data-in
 
 Don't skip calling `use` based on whether a Promise is already settled.
 
-Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. 
+Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it.
 
 
 ```js

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -666,7 +666,6 @@ Don't skip calling `use` based on whether a Promise is already settled.
 
 Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. 
 
-Bypassing `use` this way can corrupt React's internal state tracking, and breaks React DevTools suspense data tracking:
 
 ```js
 // 🔴 Don't bypass `use` by reading promise status directly

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -678,7 +678,6 @@ const value = use(promise);
 ```js
 // ✅ Pass the promise to `use` and let React track the promise
 const value = use(promise);
-```
 
 </Pitfall>
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -663,7 +663,6 @@ This cache pattern is the foundation for [re-fetching data](#re-fetching-data-in
 <Pitfall>
 
 Don't skip calling `use` based on whether a Promise is already settled. 
-
 Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. 
 
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -662,7 +662,11 @@ This cache pattern is the foundation for [re-fetching data](#re-fetching-data-in
 
 <Pitfall>
 
-Don't skip calling `use` based on whether a Promise is already settled. Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. Bypassing `use` this way can corrupt React's internal state tracking, causing stale renders, missed updates, or incorrect Suspense behavior. This also ensures React DevTools can show that the component may suspend on data.
+Don't skip calling `use` based on whether a Promise is already settled. 
+
+Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. 
+
+Bypassing `use` this way can corrupt React's internal state tracking, and breaks React DevTools suspense data tracking:
 
 ```js
 // 🔴 Don't bypass `use` by reading promise status directly

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -678,6 +678,9 @@ const value = use(promise);
 ```js
 // ✅ Pass the promise to `use` and let React track the promise
 const value = use(promise);
+```
+
+Bypassing `use` this way can break React Suspense optimizations and Suspense features for React DevTools. You can `use(promise)` conditionally, but don't conditionally `use(promise)` based on the promise itself.
 
 </Pitfall>
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -677,7 +677,7 @@ const value = use(promise);
 ```
 
 ```js
-// ✅ Always pass the promise to `use` and let React track promise readiness
+// ✅ Pass the promise to `use` and let React track the promise
 const value = use(promise);
 ```
 

--- a/src/content/reference/react/use.md
+++ b/src/content/reference/react/use.md
@@ -662,10 +662,10 @@ This cache pattern is the foundation for [re-fetching data](#re-fetching-data-in
 
 <Pitfall>
 
-Don't conditionally call `use` based on whether a Promise is settled. Always call `use` unconditionally and let React handle reading the `status` field. This ensures React DevTools can show that the component may suspend on data.
+Don't skip calling `use` based on whether a Promise is already settled. Unlike other hooks, `use` can be called inside conditions and loops — but it must always be called for the Promise itself. Never read `promise.status` or `promise.value` directly to bypass `use`; always pass the Promise to `use` and let React handle it. Bypassing `use` this way can corrupt React's internal state tracking, causing stale renders, missed updates, or incorrect Suspense behavior. This also ensures React DevTools can show that the component may suspend on data.
 
 ```js
-// 🔴 Don't conditionally skip `use`
+// 🔴 Don't bypass `use` by reading promise status directly
 if (promise.status === 'fulfilled') {
   return promise.value;
 }
@@ -673,7 +673,7 @@ const value = use(promise);
 ```
 
 ```js
-// ✅ Always call `use` unconditionally
+// ✅ Always pass the promise to `use` and let React track promise readiness
 const value = use(promise);
 ```
 


### PR DESCRIPTION
This PR helps clarify that use should be called based on Promise readiness/status, based on what @gaearon pointed out on [bluesky](https://bsky.app/profile/danabra.mov/post/3mp2ybeswjk2k) that  "nit: this seems misleading out of context. it shouldn't say always use unconditionally. it's just promise readiness that you shouldn't check. it can be conditional on other stuff (data, props, etc)"



CC @rickhanlonii @aurorascharff 

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->