### PR TITLE
fix: update table, and challenge navigation borders in dark mode

### DIFF
--- a/src/components/MDX/Challenges/Navigation.tsx
+++ b/src/components/MDX/Challenges/Navigation.tsx
@@ -115,7 +115,7 @@ export function Navigation({
           onClick={handleScrollLeft}
           aria-label="Scroll left"
           className={cn(
-            'bg-secondary-button dark:bg-secondary-button-dark h-8 px-2 rounded-l rtl:rounded-r rtl:rounded-l-none border-gray-20 border-r rtl:border-l rtl:border-r-0',
+            'bg-secondary-button dark:bg-secondary-button-dark h-8 px-2 rounded-l rtl:rounded-r rtl:rounded-l-none border-gray-20 border-r dark:border-border-dark rtl:border-l rtl:border-r-0',
             {
               'text-primary dark:text-primary-dark': canScrollLeft,
               'text-gray-30': !canScrollLeft,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -501,6 +501,13 @@
     overflow: auto;
   }
 
+  html.dark {
+    table td,
+    table th {
+      border-color: #343a46;
+    }
+  }
+
   summary::-webkit-details-marker {
     display: none;
   }


### PR DESCRIPTION
# Why

Recently spotted that tables and challenge navigation borders use the same colors in dark and light mode/theme.

# How

Update table, and challenge navigation button borders in dark mode to match other borders style and avoid reusing light mode colors.

# Preview

### Before

<img width="1413" height="631" alt="Screenshot 2026-06-25 192016" src="https://github.com/user-attachments/assets/36ec413c-d61a-420c-bdaf-b7afe61486b3" />

<img width="603" height="347" alt="Screenshot 2026-06-25 192027" src="https://github.com/user-attachments/assets/68328c18-e703-4893-a779-463e0905c9dc" />

### After

<img width="1391" height="635" alt="Screenshot 2026-06-25 191648" src="https://github.com/user-attachments/assets/b4a67d55-eb05-493c-a67c-c266a1dbe04e" />

<img width="639" height="381" alt="Screenshot 2026-06-25 191856" src="https://github.com/user-attachments/assets/177be46d-c6f1-40fc-b6e0-1cddf051aecd" />
