### PR TITLE
Cap height of slow list demo previews

### DIFF
--- a/src/content/reference/react/useDeferredValue.md
+++ b/src/content/reference/react/useDeferredValue.md
@@ -706,6 +706,8 @@ export default SlowList;
 ```css
 .items {
   padding: 0;
+  max-height: 300px;
+  overflow: auto;
 }
 
 .item {
@@ -783,6 +785,8 @@ export default SlowList;
 ```css
 .items {
   padding: 0;
+  max-height: 300px;
+  overflow: auto;
 }
 
 .item {

--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -736,6 +736,10 @@ export default function ContactTab() {
 button { margin-right: 10px }
 b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
+.items {
+  max-height: 300px;
+  overflow: auto;
+}
 ```
 
 </Sandpack>
@@ -891,6 +895,10 @@ export default function ContactTab() {
 button { margin-right: 10px }
 b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
+.items {
+  max-height: 300px;
+  overflow: auto;
+}
 ```
 
 </Sandpack>


### PR DESCRIPTION
# Summary
Closes issue #8486
- add a max height and scrolling to the .items container in the artificially slow useDeferredValue list demos
- add a max height and scrolling to the .items container in the artificially slow useTransition posts demos
- keep the existing item counts and slowdown behavior unchanged, while preventing the preview output from pushing the rest of the page too far down

# Testing
- pre-commit hooks passed during commit creation

Why this better:
1. Names actual change
2. Mentions both pages
3. States no behavior change
4. Matches issue intent closely
If you want closer to issue wording, use:

## Involved routes:
- /reference/react/useDeferredValue
- /reference/react/useTransition

## Example of improvement
Left: PR changes  
Right: current implementation
The current implementation can expand the list to around 12500px in height.
<img width="1700" height="1008" alt="image" src="https://github.com/user-attachments/assets/00e2b393-c68c-4596-9f15-3d0134b63580" />
