### PR TITLE
Fix startTransition example to wrap setState after await in server-functions

### DIFF
--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -126,11 +126,13 @@ function UpdateName() {
   const submitAction = async () => {
     startTransition(async () => {
       const {error} = await updateName(name);
-      if (error) {
-        setError(error);
-      } else {
-        setName('');
-      }
+      startTransition(() => {
+        if (error) {
+          setError(error);
+        } else {
+          setName('');
+        }
+      });
     })
   }
 


### PR DESCRIPTION
Fix the server-functions example to wrap state updates after wait in another startTransition, matching the documented pattern in startTransition.md (see line 43: 'Any async calls awaited in the action will be included in the transition, but currently require wrapping any set functions after the await in an additional startTransition').

Closes #7444
