### PR TITLE
[Suspense] Polish activation examples

### DIFF
--- a/src/components/Layout/Toc.tsx
+++ b/src/components/Layout/Toc.tsx
@@ -11,6 +11,7 @@
 
 import cx from 'classnames';
 import {useTocHighlight} from './useTocHighlight';
+import {IsInTocContext} from '../MDX/TocContext';
 import type {Toc} from '../MDX/TocContext';
 
 export function Toc({headings}: {headings: Toc}) {
@@ -32,37 +33,39 @@ export function Toc({headings}: {headings: Toc}) {
           overscrollBehavior: 'contain',
         }}>
         <ul className="space-y-2 pb-16">
-          {headings.length > 0 &&
-            headings.map((h, i) => {
-              if (!h.url && process.env.NODE_ENV === 'development') {
-                console.error('Heading does not have URL');
-              }
-              return (
-                <li
-                  key={`heading-${h.url}-${i}`}
-                  className={cx(
-                    'text-sm px-2 rounded-s-xl',
-                    selectedIndex === i
-                      ? 'bg-highlight dark:bg-highlight-dark'
-                      : null,
-                    {
-                      'ps-4': h?.depth === 3,
-                      hidden: h.depth && h.depth > 3,
-                    }
-                  )}>
-                  <a
+          <IsInTocContext.Provider value={true}>
+            {headings.length > 0 &&
+              headings.map((h, i) => {
+                if (!h.url && process.env.NODE_ENV === 'development') {
+                  console.error('Heading does not have URL');
+                }
+                return (
+                  <li
+                    key={`heading-${h.url}-${i}`}
                     className={cx(
+                      'text-sm px-2 rounded-s-xl',
                       selectedIndex === i
-                        ? 'text-link dark:text-link-dark font-bold'
-                        : 'text-secondary dark:text-secondary-dark',
-                      'block hover:text-link dark:hover:text-link-dark leading-normal py-2'
-                    )}
-                    href={h.url}>
-                    {h.text}
-                  </a>
-                </li>
-              );
-            })}
+                        ? 'bg-highlight dark:bg-highlight-dark'
+                        : null,
+                      {
+                        'ps-4': h?.depth === 3,
+                        hidden: h.depth && h.depth > 3,
+                      }
+                    )}>
+                    <a
+                      className={cx(
+                        selectedIndex === i
+                          ? 'text-link dark:text-link-dark font-bold'
+                          : 'text-secondary dark:text-secondary-dark',
+                        'block hover:text-link dark:hover:text-link-dark leading-normal py-2'
+                      )}
+                      href={h.url}>
+                      {h.text}
+                    </a>
+                  </li>
+                );
+              })}
+          </IsInTocContext.Provider>
         </ul>
       </div>
     </nav>

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -36,7 +36,7 @@ import YouWillLearnCard from './YouWillLearnCard';
 import {Challenges, Hint, Solution} from './Challenges';
 import {IconNavArrow} from '../Icon/IconNavArrow';
 import ButtonLink from 'components/ButtonLink';
-import {TocContext} from './TocContext';
+import {TocContext, IsInTocContext} from './TocContext';
 import type {Toc, TocItem} from './TocContext';
 import {TeamMember} from './TeamMember';
 import {LanguagesContext} from './LanguagesContext';
@@ -122,33 +122,57 @@ const RSC = ({children}: {children: React.ReactNode}) => (
   <ExpandableCallout type="rsc">{children}</ExpandableCallout>
 );
 
-const CanaryBadge = ({title}: {title: string}) => (
-  <span
-    title={title}
-    className={
-      'text-base font-display px-1 py-0.5 font-bold bg-gray-10 dark:bg-gray-60 text-gray-60 dark:text-gray-10 rounded'
-    }>
-    <IconCanary
-      size="s"
-      className={'inline me-1 mb-0.5 text-sm text-gray-60 dark:text-gray-10'}
-    />
-    Canary only
-  </span>
-);
+const CanaryBadge = ({title}: {title: string}) => {
+  const isInToc = useContext(IsInTocContext);
+  if (isInToc) {
+    return (
+      <IconCanary
+        size="s"
+        title={title}
+        className="inline me-1 mb-0.5 text-gray-60 dark:text-gray-10"
+      />
+    );
+  }
+  return (
+    <span
+      title={title}
+      className={
+        'text-base font-display px-1 py-0.5 font-bold bg-gray-10 dark:bg-gray-60 text-gray-60 dark:text-gray-10 rounded'
+      }>
+      <IconCanary
+        size="s"
+        className={'inline me-1 mb-0.5 text-sm text-gray-60 dark:text-gray-10'}
+      />
+      Canary only
+    </span>
+  );
+};
 
-const ExperimentalBadge = ({title}: {title: string}) => (
-  <span
-    title={title}
-    className={
-      'text-base font-display px-1 py-0.5 font-bold bg-gray-10 dark:bg-gray-60 text-gray-60 dark:text-gray-10 rounded'
-    }>
-    <IconExperimental
-      size="s"
-      className={'inline me-1 mb-0.5 text-sm text-gray-60 dark:text-gray-10'}
-    />
-    Experimental only
-  </span>
-);
+const ExperimentalBadge = ({title}: {title: string}) => {
+  const isInToc = useContext(IsInTocContext);
+  if (isInToc) {
+    return (
+      <IconExperimental
+        size="s"
+        title={title}
+        className="inline me-1 mb-0.5 text-gray-60 dark:text-gray-10"
+      />
+    );
+  }
+  return (
+    <span
+      title={title}
+      className={
+        'text-base font-display px-1 py-0.5 font-bold bg-gray-10 dark:bg-gray-60 text-gray-60 dark:text-gray-10 rounded'
+      }>
+      <IconExperimental
+        size="s"
+        className={'inline me-1 mb-0.5 text-sm text-gray-60 dark:text-gray-10'}
+      />
+      Experimental only
+    </span>
+  );
+};
 
 const NextMajorBadge = ({title}: {title: string}) => (
   <span
@@ -422,7 +446,11 @@ function InlineToc() {
   if (root.children.length < 2) {
     return null;
   }
-  return <InlineTocItem items={root.children} />;
+  return (
+    <IsInTocContext.Provider value={true}>
+      <InlineTocItem items={root.children} />
+    </IsInTocContext.Provider>
+  );
 }
 
 function InlineTocItem({items}: {items: Array<NestedTocNode>}) {

--- a/src/components/MDX/TocContext.tsx
+++ b/src/components/MDX/TocContext.tsx
@@ -20,3 +20,6 @@ export type TocItem = {
 export type Toc = Array<TocItem>;
 
 export const TocContext = createContext<Toc>([]);
+
+// Lets badge components render compactly when inside the table of contents.
+export const IsInTocContext = createContext(false);

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -3036,7 +3036,7 @@ import { freshStylesheetUrl, freshImageUrl } from './resources.js';
 import VanillaProfileCard from './VanillaProfileCard.js';
 
 function ProfileCard({ resources }) {
-  const quote = use(fetchQuote());
+  const quote = use(resources.quotePromise);
   return (
     <>
       <link rel="stylesheet" href={resources.stylesheet} precedence="default" />
@@ -3071,6 +3071,7 @@ export default function App() {
         onClick={() => {
           startTransition(() => {
             setResources({
+              quotePromise: fetchQuote(),
               stylesheet: freshStylesheetUrl(),
               image: freshImageUrl(),
             });
@@ -3150,22 +3151,13 @@ export function freshImageUrl() {
 ```js src/data.js hidden
 // Note: the way you would do data fetching depends on
 // the framework that you use together with Suspense.
-// Normally, the caching logic would be inside a framework.
 
-let cache = null;
-
-export function fetchQuote() {
-  if (!cache) {
-    cache = new Promise((resolve) => {
-      // Add a fake delay to make waiting noticeable.
-      setTimeout(() => {
-        resolve(
-          'The best way to predict the future is to invent it.'
-        );
-      }, 2000);
-    });
-  }
-  return cache;
+export async function fetchQuote() {
+  // Add a fake delay to make waiting noticeable.
+  await new Promise((resolve) => {
+    setTimeout(resolve, 2000);
+  });
+  return 'The best way to predict the future is to invent it.';
 }
 ```
 

--- a/src/content/reference/react/Suspense.md
+++ b/src/content/reference/react/Suspense.md
@@ -2500,9 +2500,9 @@ hr {
 
 ---
 
-### Animating from Suspense content {/*animating-from-suspense-content*/}
+### <CanaryBadge /> Animating from Suspense content {/*animating-from-suspense-content*/}
 
-<CanaryBadge /> Suspense composes with [`<ViewTransition>`](/reference/react/ViewTransition) to animate the swap from the fallback to the content. Wrap the boundary in a `<ViewTransition>`, and React treats the swap as an update, cross-fading between the fallback and the content by default:
+Suspense composes with [`<ViewTransition>`](/reference/react/ViewTransition) to animate the swap from the fallback to the content. Wrap the boundary in a `<ViewTransition>`, and React treats the swap as an update, cross-fading between the fallback and the content by default:
 
 <Sandpack>
 
@@ -2738,9 +2738,9 @@ Where you place the `<ViewTransition>` relative to the boundary determines wheth
 
 ---
 
-### Waiting for a font to load {/*waiting-for-a-font-to-load*/}
+### <CanaryBadge /> Waiting for a font to load {/*waiting-for-a-font-to-load*/}
 
-<CanaryBadge /> When a [`<ViewTransition>`](/reference/react/ViewTransition) animates a Suspense boundary's reveal, React also waits for new fonts the content introduces, up to a timeout, so the text doesn't flash with a fallback font. This only happens during a `<ViewTransition>` update.
+When a [`<ViewTransition>`](/reference/react/ViewTransition) animates a Suspense boundary's reveal, React also waits for new fonts the content introduces, up to a timeout, so the text doesn't flash with a fallback font. This only happens during a `<ViewTransition>` update.
 
 In the example below, the Suspense boundary is wrapped in a `<ViewTransition>`, and the `Quote` component suspends while its data loads. Rendering the quote starts its font download. React keeps the fallback visible until the font has loaded, so the quote appears already in its font.
 
@@ -2888,11 +2888,11 @@ hr {
 
 ---
 
-### Waiting for an image to load {/*waiting-for-an-image-to-load*/}
+### <CanaryBadge /> Waiting for an image to load {/*waiting-for-an-image-to-load*/}
 
-<CanaryBadge /> Images work the same way: when a [`<ViewTransition>`](/reference/react/ViewTransition) animates a Suspense boundary's reveal, React waits for visible images to load, up to a timeout, so the animation doesn't start with a half-loaded image. This only happens during a `<ViewTransition>` update. Adding an `onLoad` handler opts a specific image out, even inside a `<ViewTransition>`.
+Images work the same way: when a [`<ViewTransition>`](/reference/react/ViewTransition) animates a Suspense boundary's reveal, React waits for visible images to load, up to a timeout, so the animation doesn't start with a half-loaded image. This only happens during a `<ViewTransition>` update. Adding an `onLoad` handler opts a specific image out, even inside a `<ViewTransition>`.
 
-In the example below, the Suspense boundary is wrapped in a `<ViewTransition>` and shows its fallback until the portrait has loaded.
+In the example below, the Suspense boundary is wrapped in a `<ViewTransition>` and shows a profile skeleton until the portrait has loaded.
 
 For comparison, the second button performs the same update with plain DOM, without React. Nothing waits for the image, so the card appears immediately and the image pops in when it loads:
 
@@ -2912,6 +2912,15 @@ function Profile({ src }) {
   );
 }
 
+function ProfilePlaceholder() {
+  return (
+    <div className="card">
+      <div className="avatar-placeholder" />
+      <p className="name-placeholder">&nbsp;</p>
+    </div>
+  );
+}
+
 export default function App() {
   const [src, setSrc] = useState(null);
   return (
@@ -2926,7 +2935,7 @@ export default function App() {
       </button>
       {src && (
         <ViewTransition>
-          <Suspense fallback={<p>⌛ Loading image...</p>}>
+          <Suspense fallback={<ProfilePlaceholder />}>
             <Profile src={src} />
           </Suspense>
         </ViewTransition>
@@ -2975,14 +2984,251 @@ export function freshImageUrl() {
   margin-top: 1em;
 }
 .card img {
+  display: block;
   border-radius: 50%;
   background: #dfe3e9;
 }
 .card p {
   font-weight: bold;
 }
+.avatar-placeholder {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: #dfe3e9;
+}
+.name-placeholder {
+  width: 90px;
+  border-radius: 4px;
+  background: #dfe3e9;
+}
 hr {
   margin: 16px 0;
+}
+```
+
+```json package.json hidden
+{
+  "dependencies": {
+    "react": "canary",
+    "react-dom": "canary",
+    "react-scripts": "latest"
+  }
+}
+```
+
+</Sandpack>
+
+---
+
+### <CanaryBadge /> Coordinating fonts, images, and stylesheets {/*coordinating-fonts-images-and-stylesheets*/}
+
+All of these waits work together. In the example below, the `ProfileCard` component suspends while its data loads, and renders a stylesheet with `precedence`, text in a new font, and a portrait. React keeps the skeleton visible while the data and the stylesheet load. The `<ViewTransition>` reveal then waits for the font and the image, so the card appears complete.
+
+For comparison, the plain DOM version loads the same data and shows every resource arriving on its own schedule:
+
+<Sandpack>
+
+```js
+import { ViewTransition, Suspense, use, useState, startTransition } from 'react';
+import { fetchQuote } from './data.js';
+import { freshStylesheetUrl, freshImageUrl } from './resources.js';
+import VanillaProfileCard from './VanillaProfileCard.js';
+
+function ProfileCard({ resources }) {
+  const quote = use(fetchQuote());
+  return (
+    <>
+      <link rel="stylesheet" href={resources.stylesheet} precedence="default" />
+      <div className="profile-card">
+        <img src={resources.image} alt="Jack Pope" width={80} height={80} />
+        <div>
+          <p className="name">Jack Pope</p>
+          <p className="bio">{quote}</p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ProfileCardPlaceholder() {
+  return (
+    <div className="profile-card">
+      <div className="avatar-placeholder" />
+      <div>
+        <p className="name name-placeholder">&nbsp;</p>
+        <p className="bio bio-placeholder">&nbsp;</p>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  const [resources, setResources] = useState(null);
+  return (
+    <>
+      <button
+        onClick={() => {
+          startTransition(() => {
+            setResources({
+              stylesheet: freshStylesheetUrl(),
+              image: freshImageUrl(),
+            });
+          });
+        }}>
+        Show profile
+      </button>
+      {resources && (
+        <ViewTransition>
+          <Suspense fallback={<ProfileCardPlaceholder />}>
+            <ProfileCard resources={resources} />
+          </Suspense>
+        </ViewTransition>
+      )}
+      <hr />
+      <VanillaProfileCard />
+    </>
+  );
+}
+```
+
+```js src/VanillaProfileCard.js
+import { useRef } from 'react';
+import { fetchQuote } from './data.js';
+import { freshStylesheetUrl, freshImageUrl } from './resources.js';
+
+export default function VanillaProfileCard() {
+  const ref = useRef(null);
+  async function show() {
+    const quote = await fetchQuote();
+    const doc = ref.current.contentWindow.document;
+    doc.open();
+    doc.write(`
+      <style>
+        body { margin: 0; font-family: sans-serif; }
+        .profile-card { display: flex; gap: 12px; align-items: center; }
+        .profile-card img { border-radius: 50%; background: #dfe3e9; }
+        .name { margin: 0 0 4px; font-family: 'Caveat', sans-serif; font-size: 22px; line-height: 28px; font-weight: bold; }
+        .bio { margin: 0; font-family: 'Caveat', sans-serif; font-size: 20px; line-height: 26px; }
+      </style>
+      <div class="profile-card">
+        <img src="${freshImageUrl()}" alt="Jack Pope" width="80" height="80" />
+        <div>
+          <p class="name">Jack Pope</p>
+          <p class="bio">${quote}</p>
+        </div>
+      </div>
+      <link rel="stylesheet" href="${freshStylesheetUrl()}">
+    `);
+    doc.close();
+  }
+  return (
+    <>
+      <button onClick={show}>Show profile (vanilla DOM)</button>
+      <iframe ref={ref} title="Vanilla profile card" className="vanilla-frame" />
+    </>
+  );
+}
+```
+
+```js src/resources.js hidden
+// Add a unique parameter so the resources aren't cached,
+// and every run shows the loading state.
+export function freshStylesheetUrl() {
+  return (
+    'https://fonts.googleapis.com/css2?family=Caveat&display=swap' +
+    '&t=' +
+    Date.now()
+  );
+}
+
+export function freshImageUrl() {
+  return 'https://react.dev/images/team/jack-pope.jpg?t=' + Date.now();
+}
+```
+
+```js src/data.js hidden
+// Note: the way you would do data fetching depends on
+// the framework that you use together with Suspense.
+// Normally, the caching logic would be inside a framework.
+
+let cache = null;
+
+export function fetchQuote() {
+  if (!cache) {
+    cache = new Promise((resolve) => {
+      // Add a fake delay to make waiting noticeable.
+      setTimeout(() => {
+        resolve(
+          'The best way to predict the future is to invent it.'
+        );
+      }, 2000);
+    });
+  }
+  return cache;
+}
+```
+
+```css
+#root {
+  min-height: 320px;
+}
+button {
+  margin-right: 8px;
+}
+hr {
+  margin: 16px 0;
+}
+.profile-card {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 1em;
+}
+.profile-card img {
+  border-radius: 50%;
+  background: #dfe3e9;
+}
+.name {
+  margin: 0 0 4px;
+  font-family: 'Caveat', sans-serif;
+  font-size: 22px;
+  line-height: 28px;
+  font-weight: bold;
+}
+.bio {
+  margin: 0;
+  font-family: 'Caveat', sans-serif;
+  font-size: 20px;
+  line-height: 26px;
+}
+.profile-card img {
+  display: block;
+}
+.avatar-placeholder {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: #dfe3e9;
+}
+.name-placeholder,
+.bio-placeholder {
+  border-radius: 4px;
+  background: #dfe3e9;
+  color: transparent;
+}
+.name-placeholder {
+  width: 90px;
+}
+.bio-placeholder {
+  width: 220px;
+}
+.vanilla-frame {
+  display: block;
+  margin-top: 1em;
+  border: none;
+  width: 100%;
+  height: 110px;
 }
 ```
 


### PR DESCRIPTION
Follow-up to #8505, based on review feedback:

- Moves the Canary badges into the section headings, and renders badges icon-only in the table of contents
- Replaces the image demo's text fallback with a profile skeleton, sized to match the revealed card
- Adds a combined example where one boundary coordinates data, a stylesheet, a font, and an image, with a plain DOM comparison