### PR TITLE
Fix server functions page crash from stale code highlight

### DIFF
--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -112,7 +112,7 @@ export async function updateName(name) {
 }
 ```
 
-```js [[1, 3, "updateName"], [1, 13, "updateName"], [2, 11, "submitAction"],  [2, 23, "submitAction"]]
+```js [[1, 3, "updateName"], [1, 13, "updateName"], [2, 11, "submitAction"], [2, 25, "submitAction"]]
 "use client";
 
 import {updateName} from './actions';


### PR DESCRIPTION
## Summary
- Fixes a crash on `/reference/rsc/server-functions` where `CodeBlock` threw `Could not find: 'submitAction'` while resolving inline highlights.
- Updates the highlight meta from line 23 → 25 after a recent update wrapped post-`await` `setState` calls in a nested `startTransition`, shifting `<form action={submitAction}>` down two lines.

### Before
<img width="1469" height="786" alt="image" src="https://github.com/user-attachments/assets/20a1e07b-af89-405f-8d89-090d1fafee4b" />


### After
<img width="1467" height="776" alt="image" src="https://github.com/user-attachments/assets/e6b50093-7266-4987-bf36-5b811708b3e4" />


## Test plan
- [ ] Open http://localhost:3000/reference/rsc/server-functions or https://react-pcy5p89jo-react-foundation.vercel.app/reference/rsc/server-functions
- [ ] Confirm the page renders without the `Could not find: 'submitAction'` error
- [ ] Confirm the numbered callouts still highlight `updateName` and `submitAction` in the “Server Functions with Actions” example


Fixes: #8523


Made with [Cursor](https://cursor.com)