### PR TITLE
Clarify pending state description in useTransition example

### DIFF
--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -320,7 +320,7 @@ These solutions handle request ordering for you. When using Transitions to build
 
 In this example, the `updateQuantity` function also simulates a request to the server to update the item's quantity in the cart. This function is *artificially slowed down* so that it takes at least a second to complete the request.
 
-Update the quantity multiple times quickly. Notice that the pending "Total" state is shown while any requests is in progress, but the "Total" updates multiple times for each time the "quantity" was clicked:
+Update the quantity multiple times quickly. Notice that the pending "Total" state is shown until the first request completes, but the "Total" updates multiple times for each time the "quantity" was clicked:
 
 <Sandpack>
 


### PR DESCRIPTION
The original wording was incorrect both grammatically and logically. Grammatically, “any requests is” mixes a plural noun with a singular verb. Logically, the non-Action example sets `isPending` to `false` when the first request completes, even though later requests may still be in progress and continue updating the total.