### PR TITLE
Avoid duplicate sandbox base styles

### DIFF
--- a/src/components/MDX/Sandpack/SandpackRoot.tsx
+++ b/src/components/MDX/Sandpack/SandpackRoot.tsx
@@ -86,7 +86,9 @@ function SandpackRoot(props: SandpackProps) {
   }
 
   files['/src/styles.css'] = {
-    code: [sandboxStyle, files['/src/styles.css']?.code ?? ''].join('\n\n'),
+    code: files['/src/styles.css']?.code.startsWith(sandboxStyle)
+      ? files['/src/styles.css'].code
+      : [sandboxStyle, files['/src/styles.css']?.code ?? ''].join('\n\n'),
     hidden: !files['/src/styles.css']?.visible,
   };
 


### PR DESCRIPTION
## Summary

- avoid prepending the shared Sandpack base stylesheet when an example already includes it
- keep exported and forked tutorial stylesheets free of duplicate base rules

## Why

The Tic-Tac-Toe tutorial includes the same base CSS that `SandpackRoot` injects. The wrapper appended it a second time, so CodeSandbox downloads contained duplicate `*` and `body` rules even though the tutorial source defined them once.

Fixes #8535.

## Checks

- `yarn prettier:diff`
- `yarn tsc`
- `git diff --check`
