### PR TITLE
docs: fix typo in content lifecycle-of-reactive-effects

### DIFF
--- a/src/content/learn/lifecycle-of-reactive-effects.md
+++ b/src/content/learn/lifecycle-of-reactive-effects.md
@@ -744,7 +744,7 @@ function ChatRoom() {
 
 <Pitfall>
 
-The linter is your friend, but its powers are limited. The linter only knows when the dependencies are *wrong*. It doesn't know *the best* way to solve each case. If the linter suggests a dependency, but adding it causes a loop, it doesn't mean the linter should be ignored. You need to change the code inside (or outside) the Effect so that that value isn't reactive and doesn't *need* to be a dependency.
+The linter is your friend, but its powers are limited. The linter only knows when the dependencies are *wrong*. It doesn't know *the best* way to solve each case. If the linter suggests a dependency, but adding it causes a loop, it doesn't mean the linter should be ignored. You need to change the code inside (or outside) the Effect so that value isn't reactive and doesn't *need* to be a dependency.
 
 If you have an existing codebase, you might have some Effects that suppress the linter like this:
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

When I was reading on the [react.dev](https://react.dev) site and happened to be on the topic "Escape Hatches" in the *Lifecycle of Reactive Effects* content section, I accidentally found a typo in the Pitfall section. Previously it was written like this:

> The linter is your friend, but its powers are limited. The linter only knows when the dependencies are *wrong*. It doesn't know *the best* way to solve each case. If the linter suggests a dependency, but adding it causes a loop, it doesn't mean the linter should be ignored. You need to change the code inside (or outside) the Effect **so that that value** isn't reactive and doesn't *need* to be a dependency.
> 
> If you have an existing codebase, you might have some Effects that suppress the linter like this:
> ```jsx
> useEffect(() => { 
>   // ... 
>   // 🔴 Avoid suppressing the linter like this: 
>   // eslint-ignore-next-line react-hooks/exhaustive-deps
> }, []);
> ```
> On the next page, you'll learn how to fix this code without breaking the rules. It's always worth fixing!


<img width="629" height="420" alt="typo" src="https://github.com/user-attachments/assets/85f11166-919d-44f3-bb25-efa7cf54c571" />



As you can see, the word "that" is spelled twice (**that that**). So, even though this seems trivial, I think typos like this can make readers feel uncomfortable.

Therefore, I'm trying to contribute to [react.dev](https://react.dev) through this Pull Request. This is also my first contribution to a large open source project like React. I'm very happy 😍

