### PR TITLE
Fix relative links missing leading slash in Learn docs

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -18,7 +18,7 @@ State is isolated between components. React keeps track of which state belongs t
 
 ## State is tied to a position in the render tree {/*state-is-tied-to-a-position-in-the-tree*/}
 
-React builds [render trees](learn/understanding-your-ui-as-a-tree#the-render-tree) for the component structure in your UI.
+React builds [render trees](/learn/understanding-your-ui-as-a-tree#the-render-tree) for the component structure in your UI.
 
 When you give a component state, you might think the state "lives" inside the component. But the state is actually held inside React. React associates each piece of state it's holding with the correct component by where that component sits in the render tree.
 

--- a/src/content/learn/react-compiler/introduction.md
+++ b/src/content/learn/react-compiler/introduction.md
@@ -144,7 +144,7 @@ However, if `expensivelyProcessAReallyLargeArrayOfObjects` is truly an expensive
 - React Compiler only memoizes React components and hooks, not every function
 - React Compiler's memoization is not shared across multiple components or hooks
 
-So if `expensivelyProcessAReallyLargeArrayOfObjects` was used in many different components, even if the same exact items were passed down, that expensive calculation would be run repeatedly. We recommend [profiling](reference/react/useMemo#how-to-tell-if-a-calculation-is-expensive) first to see if it really is that expensive before making code more complicated.
+So if `expensivelyProcessAReallyLargeArrayOfObjects` was used in many different components, even if the same exact items were passed down, that expensive calculation would be run repeatedly. We recommend [profiling](/reference/react/useMemo#how-to-tell-if-a-calculation-is-expensive) first to see if it really is that expensive before making code more complicated.
 </DeepDive>
 
 ## Should I try out the compiler? {/*should-i-try-out-the-compiler*/}

--- a/src/content/learn/setup.md
+++ b/src/content/learn/setup.md
@@ -17,7 +17,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. [Le
 
 ## React Developer Tools {/*react-developer-tools*/}
 
-React Developer Tools is a browser extension that can inspect React components, edit props and state, and identify performance problems. Learn how to install it [here](learn/react-developer-tools).
+React Developer Tools is a browser extension that can inspect React components, edit props and state, and identify performance problems. Learn how to install it [here](/learn/react-developer-tools).
 
 ## React Compiler {/*react-compiler*/}
 

--- a/src/content/learn/understanding-your-ui-as-a-tree.md
+++ b/src/content/learn/understanding-your-ui-as-a-tree.md
@@ -135,7 +135,7 @@ The root node in a React render tree is the [root component](/learn/importing-an
 
 #### Where are the HTML tags in the render tree? {/*where-are-the-html-elements-in-the-render-tree*/}
 
-You'll notice in the above render tree, there is no mention of the HTML tags that each component renders. This is because the render tree is only composed of React [components](learn/your-first-component#components-ui-building-blocks).
+You'll notice in the above render tree, there is no mention of the HTML tags that each component renders. This is because the render tree is only composed of React [components](/learn/your-first-component#components-ui-building-blocks).
 
 React, as a UI framework, is platform agnostic. On react.dev, we showcase examples that render to the web, which uses HTML markup as its UI primitives. But a React app could just as likely render to a mobile or desktop platform, which may use different UI primitives like [UIView](https://developer.apple.com/documentation/uikit/uiview) or [FrameworkElement](https://learn.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement?view=windowsdesktop-7.0).
 


### PR DESCRIPTION
## Summary

Fix 4 relative links in Learn docs that are missing the leading slash, causing them to resolve to incorrect 404 paths on the live site:

- `learn/preserving-and-resetting-state.md`: `learn/understanding-your-ui-as-a-tree#the-render-tree` → `/learn/understanding-your-ui-as-a-tree#the-render-tree`
- `learn/react-compiler/introduction.md`: `reference/react/useMemo#how-to-tell-if-a-calculation-is-expensive` → `/reference/react/useMemo#how-to-tell-if-a-calculation-is-expensive`
- `learn/setup.md`: `learn/react-developer-tools` → `/learn/react-developer-tools`
- `learn/understanding-your-ui-as-a-tree.md`: `learn/your-first-component#components-ui-building-blocks` → `/learn/your-first-component#components-ui-building-blocks`

Every other internal link in the repo uses absolute paths; these four are the only Learn docs links missing the leading slash.

## Verification

- Target pages and anchors verified to exist: `understanding-your-ui-as-a-tree#the-render-tree`, `useMemo#how-to-tell-if-a-calculation-is-expensive`, `react-developer-tools`, `your-first-component#components-ui-building-blocks`
- Link scan across all `src/content` files confirms no other Learn links are affected
