### PR TITLE
Fix typo in useEffectEvent hook usage example

### DIFF
--- a/src/content/reference/react/useEffectEvent.md
+++ b/src/content/reference/react/useEffectEvent.md
@@ -105,7 +105,7 @@ useEffect(() => {
 }, [roomId]);
 ```
 
-Since `onConnected` is an <CodeStep step={1}>Effect Event</CodeStep>, `muted` and `onConnect` are not in the Effect dependencies.
+Since `onConnected` is an <CodeStep step={1}>Effect Event</CodeStep>, `muted` and `onConnected` are not in the Effect dependencies.
 
 <Pitfall>
 


### PR DESCRIPTION
Fixes the typo on useEffectEvent's usage example.

- updates the `onConnect` to `onConnected`

Typo Reference (Before fix):

<img width="933" height="324" alt="image" src="https://github.com/user-attachments/assets/012d1295-e495-4f4f-93b3-6bfe0addb9da" />


Typo Reference (After fix):

<img width="932" height="327" alt="image" src="https://github.com/user-attachments/assets/dc2c45b6-a2aa-4c56-8aae-e33c651fc6d5" />



First ever contribution, hope to make many more in future!