### PR TITLE
docs: Add useOptimistic hook description to hooks reference page

### DIFF
--- a/src/content/reference/react/hooks.md
+++ b/src/content/reference/react/hooks.md
@@ -18,6 +18,7 @@ To add state to a component, use one of these Hooks:
 
 * [`useState`](/reference/react/useState) declares a state variable that you can update directly.
 * [`useReducer`](/reference/react/useReducer) declares a state variable with the update logic inside a [reducer function.](/learn/extracting-state-logic-into-a-reducer)
+* [`useOptimistic`](/reference/react/useOptimistic) lets you show a different state while an async action is pending.
 
 ```js
 function ImageGallery() {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
# Closes #8570 

## 📝 Description

Adds `useOptimistic` to the **State Hooks** section of the [Built-in React Hooks](https://react.dev/reference/react/hooks) overview page.

The hook was already documented at `/reference/react/useOptimistic` and listed in the left navigation menu, but was missing from the overview page, leaving it **incomplete with only 17 of the 18 hooks documented**.

`useOptimistic` is placed under **State Hooks** rather than **Performance Hooks** because its primary purpose is to manage a temporary state value during an async operation — not to optimize rendering. It works similarly to `useState`, holding a value that React will revert once the async action settles. The performance benefit of a snappier UI is a side effect, not the core intent.

## 📚 Motivation

The overview page is the main entry point for developers exploring React's built-in hooks. Having `useOptimistic` absent from this page means:

- Developers new to React may not discover it exists, since the overview page is designed to be the exhaustive reference for all built-in hooks.
- It creates an inconsistency between the sidebar navigation and the page content.
- `useOptimistic` is particularly relevant in modern React apps using Server Actions and async transitions, so its visibility on the overview page is valuable for developers adopting these patterns.

## ✅ Changes

- `src/content/reference/react/hooks.md` — added `useOptimistic` to the State Hooks section alongside `useState` and `useReducer`.

## Testing

- [x] Verified the change renders correctly at `http://localhost:3000/reference/react/hooks`
- [x] Ran `yarn check-all` with no errors

###  Before
<img width="1109" height="822" alt="Screenshot 2026-08-02 at 11 15 28" src="https://github.com/user-attachments/assets/f17f844d-4693-4bdc-8adc-4d728f32af7d" />

###  After
<img width="1108" height="843" alt="Screenshot 2026-08-02 at 11 15 58" src="https://github.com/user-attachments/assets/959c3c7c-0a4c-4851-8178-4579bb7a8b8a" />

### 🙏 Note: 
There is a stale PR [#8352](https://github.com/reactjs/react.dev/pull/8352) that proposed creating a dedicated **Async Hooks** section, which would be a more permanent home for `useOptimistic`. This fix places it under **State Hooks** as the most logical interim location, and can be revisited if that proposal or a similar one moves forward.

Let me know if this should be placed in a different order, section, or if there are any copy edits needed.
🙇‍♂️ Thanks for maintaining a great developer experience with the docs!