### PR TITLE
Fix lazy sandbox reload instruction

### DIFF
--- a/src/content/reference/react/lazy.md
+++ b/src/content/reference/react/lazy.md
@@ -175,7 +175,7 @@ body {
 
 </Sandpack>
 
-This demo loads with an artificial delay. The next time you untick and tick the checkbox, `Preview` will be cached, so there will be no loading state. To see the loading state again, click "Reset" on the sandbox.
+This demo loads with an artificial delay. The next time you untick and tick the checkbox, `Preview` will be cached, so there will be no loading state. To see the loading state again, click "Reload" on the sandbox.
 
 [Learn more about managing loading states with Suspense.](/reference/react/Suspense)
 


### PR DESCRIPTION
Updates the lazy documentation to reference the sandbox's current Reload control instead of the obsolete Reset label.

Validation:
- Confirmed the shared ReloadButton renders Reload and refreshes the sandbox.
- Repository-wide prose scan found no other stale sandbox control references.
- Source-to-document assertion passes.
- git diff --check passes.