### PR TITLE
fix: add leading slash to react-developer-tools link in setup guide

### DIFF
--- a/src/content/learn/setup.md
+++ b/src/content/learn/setup.md
@@ -17,7 +17,7 @@ TypeScript is a popular way to add type definitions to JavaScript codebases. [Le
 
 ## React Developer Tools {/*react-developer-tools*/}
 
-React Developer Tools is a browser extension that can inspect React components, edit props and state, and identify performance problems. Learn how to install it [here](learn/react-developer-tools).
+React Developer Tools is a browser extension that can inspect React components, edit props and state, and identify performance problems. Learn how to install it [here](/learn/react-developer-tools).
 
 ## React Compiler {/*react-compiler*/}
 


### PR DESCRIPTION
The link was missing the leading slash, making it a relative path that wouldn't resolve correctly. Changed from 'learn/...' to '/learn/...' for consistency with other links in the document.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
