### PR TITLE
Add missing docs for requestFormReset API

### DIFF
--- a/src/content/reference/react-dom/index.md
+++ b/src/content/reference/react-dom/index.md
@@ -16,6 +16,7 @@ These APIs can be imported from your components. They are rarely used:
 
 * [`createPortal`](/reference/react-dom/createPortal) lets you render child components in a different part of the DOM tree.
 * [`flushSync`](/reference/react-dom/flushSync) lets you force React to flush a state update and update the DOM synchronously.
+* [`requestFormReset`](/reference/react-dom/requestFormReset) lets you request a form reset when handling submissions with custom Actions or Transitions.
 
 ## Resource Preloading APIs {/*resource-preloading-apis*/}
 

--- a/src/content/reference/react-dom/requestFormReset.md
+++ b/src/content/reference/react-dom/requestFormReset.md
@@ -1,0 +1,89 @@
+---
+title: requestFormReset
+---
+
+<Intro>
+
+`requestFormReset` lets you reset a React-managed form after an Action or Transition finishes.
+
+```js
+requestFormReset(form)
+```
+
+</Intro>
+
+<InlineToc />
+
+---
+
+## Reference {/*reference*/}
+
+### `requestFormReset(form)` {/*requestformreset*/}
+
+Call `requestFormReset` to request that a form resets after the current Action or Transition completes.
+
+```js
+import { startTransition } from 'react';
+import { requestFormReset } from 'react-dom';
+
+function handleSubmit(form) {
+  startTransition(async () => {
+    const formData = new FormData(form);
+    requestFormReset(form);
+    await save(formData);
+  });
+}
+```
+
+[See more examples below.](#usage)
+
+#### Parameters {/*parameters*/}
+
+* `form`: an [HTML form element](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement) rendered by React.
+
+#### Returns {/*returns*/}
+
+`requestFormReset` returns nothing.
+
+#### Caveats {/*caveats*/}
+
+* Pass a form element that is rendered by React. Passing a non-form element, or a form not managed by React, throws an error.
+* `requestFormReset` is intended for Actions and Transitions. If called outside an Action or Transition, React warns in development and performs a synchronous reset.
+* `requestFormReset` is useful when you implement form submission logic yourself (for example with `onSubmit` + `startTransition`) and still want React's form reset behavior.
+* This API requests a reset for uncontrolled form fields. For controlled fields, handle resets by updating state, such as in `onReset`.
+
+---
+
+## Usage {/*usage*/}
+
+### Requesting a reset in a custom form Action {/*requesting-a-reset-in-a-custom-form-action*/}
+
+React automatically resets uncontrolled fields after a successful `<form action={...}>` submission. When you implement submission manually, you can opt into the same behavior by calling `requestFormReset`.
+
+```js
+import { startTransition } from 'react';
+import { requestFormReset } from 'react-dom';
+
+function SearchForm() {
+  async function onSubmit(event) {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    startTransition(async () => {
+      requestFormReset(form);
+      await submitSearch(formData);
+    });
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <input name="query" defaultValue="react" />
+      <button type="submit">Search</button>
+    </form>
+  );
+}
+```
+
+If your submission uses the built-in `<form action={...}>` behavior, you don't need to call `requestFormReset` manually.

--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -257,6 +257,10 @@
           "path": "/reference/react-dom/flushSync"
         },
         {
+          "title": "requestFormReset",
+          "path": "/reference/react-dom/requestFormReset"
+        },
+        {
           "title": "preconnect",
           "path": "/reference/react-dom/preconnect"
         },


### PR DESCRIPTION
Fixes #8529

## Summary
- Add a new React DOM API reference page for `requestFormReset`
- Document signature, parameters, return value, caveats, and usage
- Add `requestFormReset` to the React DOM APIs index page
- Add `requestFormReset` to the reference sidebar navigation

## Why
The issue reports that `requestFormReset` is a React 19 API without a dedicated docs page. This PR adds the missing page and links it into the docs navigation so the route is discoverable.

## Validation
- Ran `yarn lint` (passes; existing unrelated warnings only)
- Ran `yarn lint-heading-ids` (passes)