### PR TITLE
Clarify ref callback cleanup behavior in common ref docs

### DIFF
--- a/src/content/reference/react-dom/components/common.md
+++ b/src/content/reference/react-dom/components/common.md
@@ -257,9 +257,9 @@ Instead of a ref object (like the one returned by [`useRef`](/reference/react/us
 
 [See an example of using the `ref` callback.](/learn/manipulating-the-dom-with-refs#how-to-manage-a-list-of-refs-using-a-ref-callback)
 
-When the `<div>` DOM node is added to the screen, React will call your `ref` callback with the DOM `node` as the argument. When that `<div>` DOM node is removed, React will call your the cleanup function returned from the callback.
+When the `<div>` DOM node is added to the screen, React will call your `ref` callback with the DOM `node` as the argument. When that `<div>` DOM node is removed, React will call the cleanup function returned from your callback.
 
-React will also call your `ref` callback whenever you pass a *different* `ref` callback. In the above example, `(node) => { ... }` is a different function on every render. When your component re-renders, the *previous* function will be called with `null` as the argument, and the *next* function will be called with the DOM node.
+React will also call your `ref` callback whenever you pass a *different* `ref` callback. In the above example, `(node) => { ... }` is a different function on every render. When your component re-renders, React calls the previous callback's cleanup function (if provided). If no cleanup function is returned, React calls the previous callback with `null`. Then React calls the next callback with the DOM node.
 
 #### Parameters {/*ref-callback-parameters*/}
 


### PR DESCRIPTION
Fixes #7811

## Summary
- Clarify the `ref` callback behavior when callbacks change between renders
- Explicitly describe the cleanup-function path as the primary behavior
- Clarify that passing `null` to the old callback is legacy fallback behavior when no cleanup is returned

## Why
Issue #7811 points out ambiguity in the current wording, especially around when React calls a previous callback with `null`. This change aligns wording with current React 19 cleanup semantics while preserving backwards-compatibility notes.

## Validation
- Ran `yarn lint`
- Ran `yarn lint-heading-ids`