### PR TITLE
docs: fix Server Functions code examples with incompatible signatures

### DIFF
--- a/src/content/reference/rsc/server-functions.md
+++ b/src/content/reference/rsc/server-functions.md
@@ -109,6 +109,7 @@ export async function updateName(name) {
     return {error: 'Name is required'};
   }
   await db.users.updateName(name);
+  return {error: null};
 }
 ```
 
@@ -126,19 +127,17 @@ function UpdateName() {
   const submitAction = async () => {
     startTransition(async () => {
       const {error} = await updateName(name);
-      startTransition(() => {
-        if (error) {
-          setError(error);
-        } else {
-          setName('');
-        }
-      });
+      if (error) {
+        setError(error);
+        return;
+      }
+      setName('');
     })
   }
 
   return (
     <form action={submitAction}>
-      <input type="text" name="name" disabled={isPending}/>
+      <input type="text" name="name" value={name} onChange={(e) => setName(e.target.value)} disabled={isPending}/>
       {error && <span>Failed: {error}</span>}
     </form>
   )
@@ -156,14 +155,27 @@ Server Functions work with the new Form features in React 19.
 You can pass a Server Function to a Form to automatically submit the form to the server:
 
 
-```js [[1, 3, "updateName"], [1, 7, "updateName"]]
+```js [[1, 3, "updateNameForm"], [1, 7, "updateNameForm"]]
+"use server";
+
+export async function updateNameForm(formData) {
+  const name = formData.get('name');
+  if (!name) {
+    return {error: 'Name is required'};
+  }
+  await db.users.updateName(name);
+  return {error: null};
+}
+```
+
+```js [[1, 3, "updateNameForm"], [1, 7, "updateNameForm"]]
 "use client";
 
-import {updateName} from './actions';
+import {updateNameForm} from './actions';
 
 function UpdateName() {
   return (
-    <form action={updateName}>
+    <form action={updateNameForm}>
       <input type="text" name="name" />
     </form>
   )
@@ -178,13 +190,26 @@ For more, see the docs for [Server Functions in Forms](/reference/rsc/use-server
 
 You can call Server Functions with `useActionState` for the common case where you just need access to the action pending state and last returned response:
 
-```js [[1, 3, "updateName"], [1, 6, "updateName"], [2, 6, "submitAction"], [2, 9, "submitAction"]]
+```js [[1, 3, "updateNameAction"], [1, 6, "updateNameAction"], [2, 6, "submitAction"], [2, 9, "submitAction"]]
+"use server";
+
+export async function updateNameAction(previousState, formData) {
+  const name = formData.get('name');
+  if (!name) {
+    return {error: 'Name is required'};
+  }
+  await db.users.updateName(name);
+  return {error: null};
+}
+```
+
+```js [[1, 3, "updateNameAction"], [1, 6, "updateNameAction"], [2, 6, "submitAction"], [2, 9, "submitAction"]]
 "use client";
 
-import {updateName} from './actions';
+import {updateNameAction} from './actions';
 
 function UpdateName() {
-  const [state, submitAction, isPending] = useActionState(updateName, {error: null});
+  const [state, submitAction, isPending] = useActionState(updateNameAction, {error: null});
 
   return (
     <form action={submitAction}>


### PR DESCRIPTION
## Summary
This PR fixes broken code examples in the Server Functions documentation where function signatures don't match their usage patterns.

## Fixes
Closes #8537

## Problems Fixed

### 1. Missing return value
The updateName function returned undefined on success, but client code destructured {error} from the result.

### 2. Form action signature mismatch
When passed to <form action={updateName}>, React calls it with FormData, not a string parameter.

### 3. useActionState signature mismatch  
When used with useActionState, the function must accept (previousState, formData) and consistently return the next state.

### 4. Input not controlled
The input field didn't have value or onChange, so the name state was always empty.

## Changes Made

### Example 1: Server Functions with Actions
- Fixed updateName to return {error: null} on success
- Added value and onChange to input to make it controlled
- Simplified error handling logic

### Example 2: Server Functions with Form Actions
- Created updateNameForm function that accepts FormData
- Extracts name using formData.get('name')
- Returns proper {error: null} on success

### Example 3: Server Functions with useActionState
- Created updateNameAction with (previousState, formData) signature
- Extracts name using formData.get('name')
- Returns consistent state shape

## Impact
- Fixes #8537 - all examples now have correct function signatures
- Users can copy-paste examples and they will work
- No breaking changes to the documentation structure

## Type of Change
- Bug fix (fixes #8537)
- Documentation improvement
- Code example correction