### PR TITLE
Fix act() event example using button before declaration

### DIFF
--- a/src/content/reference/react/act.md
+++ b/src/content/reference/react/act.md
@@ -117,26 +117,27 @@ Using `act` ensures that all updates have been applied before we make assertions
 
 To test events, wrap the event dispatch inside `act()`:
 
-```js {14,16}
+```js {16,17}
 import {act} from 'react';
 import ReactDOMClient from 'react-dom/client';
 import Counter from './Counter';
 
-it.only('can render and update a counter', async () => {
+it('can render and update a counter', async () => {
   const container = document.createElement('div');
   document.body.appendChild(container);
 
-  await act( async () => {
+  await act(async () => {
     ReactDOMClient.createRoot(container).render(<Counter />);
   });
+
+  const button = container.querySelector('button');
+  const label = container.querySelector('p');
 
   // ✅ Dispatch the event inside act().
   await act(async () => {
     button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
-  const button = container.querySelector('button');
-  const label = container.querySelector('p');
   expect(label.textContent).toBe('You clicked 1 times');
   expect(document.title).toBe('You clicked 1 times');
 });


### PR DESCRIPTION
## Summary
- The [Dispatching events in tests](https://react.dev/reference/react/act#dispatching-events-in-tests) example called `button.dispatchEvent(...)` before `const button = ...`, which would throw a `ReferenceError` (temporal dead zone).
- Move the `querySelector` calls above the click `act()`, remove leftover `it.only`, and update highlight line numbers.
- Related open PR that touches the same snippet for async style only: https://github.com/reactjs/react.dev/pull/8142

## Test plan
- [ ] Confirm the example on `/reference/react/act` renders with the highlighted lines on the dispatch `act()` block
- [ ] Mentally/run the snippet: `button` is defined before `dispatchEvent`