### PR TITLE
feat: use next/image for MDX images

### DIFF
--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -13,6 +13,7 @@ import {Children, useContext, useMemo} from 'react';
 import * as React from 'react';
 import cn from 'classnames';
 import type {HTMLAttributes} from 'react';
+import NextImage from 'next/image';
 
 import CodeBlock from './CodeBlock';
 import {CodeDiagram} from './CodeDiagram';
@@ -514,8 +515,16 @@ function YouTubeIframe(props: any) {
 }
 
 function Image(props: any) {
-  const {alt, ...rest} = props;
-  return <img alt={alt} className="max-w-[calc(min(700px,100%))]" {...rest} />;
+  const {alt, width, height, ...rest} = props;
+  return (
+    <NextImage
+      alt={alt}
+      width={width ? Number(width) : 700}
+      height={height ? Number(height) : 400}
+      className="max-w-[calc(min(700px,100%))] h-auto"
+      {...rest}
+    />
+  );
 }
 
 export const MDXComponents = {


### PR DESCRIPTION
Fixes #4382

## What changed
Replaced the plain `<img>` in the MDX `Image` component with `next/image`,
so markdown images and raw `<img>` tags now get lazy-loading, async
decoding, and image optimization.

## Changes
- Added `import NextImage from 'next/image'` in `src/components/MDX/MDXComponents.tsx`
- Updated the MDX `Image` component to render `next/image` instead of `<img>`

## Open question
Markdown images usually don't specify `width`/`height`. I used a `700×400`
fallback for dimension-less images. Is that acceptable, or is there a
preferred approach (e.g. `fill` + a sized container, or reading intrinsic
dimensions)?

That Fixes #4382 is what the template was asking for — it auto-links (and eventually auto-closes) the issue when the PR merges.